### PR TITLE
FO-953: Fjerner toggle for registrering i Arena. Denne forblir i veilarboppfolging

### DIFF
--- a/src/main/java/no/nav/fo/veilarbregistrering/config/RemoteFeatureConfig.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/config/RemoteFeatureConfig.java
@@ -22,20 +22,11 @@ public class RemoteFeatureConfig {
         return new RegistreringFeature(repo);
     }
 
-    @Bean
-    public OpprettBrukerIArenaFeature registrereBrukerArenaFeature(RemoteFeatureToggleRepository repo) {
-        return new OpprettBrukerIArenaFeature(repo);
-    }
-
     public static class RegistreringFeature extends RemoteFeatureToggle {
         public RegistreringFeature(RemoteFeatureToggleRepository repository) {
-            super(repository, "veilarboppfolging.registrering", false);
+            //TODO: Toggle bør endre navn siden denne ikke lenger tilhører veilarboppfolging 
+            super(repository, "veilarboppfolging.registrering", false); 
         }
     }
-
-    public static class OpprettBrukerIArenaFeature extends RemoteFeatureToggle {
-        public OpprettBrukerIArenaFeature(RemoteFeatureToggleRepository repository) {
-            super(repository, "veilarboppfolging.opprettbrukeriarena", false);
-        }
-    }
+    
 }

--- a/src/main/java/no/nav/fo/veilarbregistrering/config/ServiceBeansConfig.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/config/ServiceBeansConfig.java
@@ -19,7 +19,6 @@ public class ServiceBeansConfig {
     BrukerRegistreringService registrerBrukerService(
             ArbeidssokerregistreringRepository arbeidssokerregistreringRepository,
             AktorService aktorService,
-            RemoteFeatureConfig.OpprettBrukerIArenaFeature sjekkRegistrereBrukerArenaFeature,
             RemoteFeatureConfig.RegistreringFeature skalRegistrereBrukerGenerellFeature,
             OppfolgingClient oppfolgingClient,
             ArbeidsforholdService arbeidsforholdService,
@@ -28,7 +27,6 @@ public class ServiceBeansConfig {
         return new BrukerRegistreringService(
                 arbeidssokerregistreringRepository,
                 aktorService,
-                sjekkRegistrereBrukerArenaFeature,
                 skalRegistrereBrukerGenerellFeature,
                 oppfolgingClient,
                 arbeidsforholdService,

--- a/src/main/java/no/nav/fo/veilarbregistrering/service/BrukerRegistreringService.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/service/BrukerRegistreringService.java
@@ -1,7 +1,6 @@
 package no.nav.fo.veilarbregistrering.service;
 
 import no.nav.dialogarena.aktor.AktorService;
-import no.nav.fo.veilarbregistrering.config.RemoteFeatureConfig.OpprettBrukerIArenaFeature;
 import no.nav.fo.veilarbregistrering.config.RemoteFeatureConfig.RegistreringFeature;
 import no.nav.fo.veilarbregistrering.db.ArbeidssokerregistreringRepository;
 import no.nav.fo.veilarbregistrering.domain.*;
@@ -18,7 +17,6 @@ public class BrukerRegistreringService {
 
     private final ArbeidssokerregistreringRepository arbeidssokerregistreringRepository;
     private final AktorService aktorService;
-    private final OpprettBrukerIArenaFeature opprettBrukerIArenaFeature;
     private final RegistreringFeature registreringFeature;
     private OppfolgingClient oppfolgingClient;
     private ArbeidsforholdService arbeidsforholdService;
@@ -26,7 +24,6 @@ public class BrukerRegistreringService {
 
     public BrukerRegistreringService(ArbeidssokerregistreringRepository arbeidssokerregistreringRepository,
                                      AktorService aktorService,
-                                     OpprettBrukerIArenaFeature opprettBrukerIArenaFeature,
                                      RegistreringFeature registreringFeature,
                                      OppfolgingClient oppfolgingClient,
                                      ArbeidsforholdService arbeidsforholdService,
@@ -35,7 +32,6 @@ public class BrukerRegistreringService {
     ) {
         this.arbeidssokerregistreringRepository = arbeidssokerregistreringRepository;
         this.aktorService = aktorService;
-        this.opprettBrukerIArenaFeature = opprettBrukerIArenaFeature;
         this.registreringFeature = registreringFeature;
         this.oppfolgingClient = oppfolgingClient;
         this.arbeidsforholdService = arbeidsforholdService;
@@ -85,9 +81,7 @@ public class BrukerRegistreringService {
     private BrukerRegistrering opprettBruker(String fnr, BrukerRegistrering bruker, AktorId aktorId) {
         BrukerRegistrering brukerRegistrering = arbeidssokerregistreringRepository.lagreBruker(bruker, aktorId);
 
-        if (opprettBrukerIArenaFeature.erAktiv()) {
-            oppfolgingClient.aktiverBruker(new AktiverBrukerData(new Fnr(fnr), "IKVAL"));
-        }
+        oppfolgingClient.aktiverBruker(new AktiverBrukerData(new Fnr(fnr), "IKVAL"));
         return brukerRegistrering;
     }
 }

--- a/src/test/java/no/nav/fo/veilarbregistrering/service/BrukerRegistreringServiceTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/service/BrukerRegistreringServiceTest.java
@@ -36,14 +36,12 @@ public class BrukerRegistreringServiceTest {
     private BrukerRegistreringService brukerRegistreringService;
     private OppfolgingClient oppfolgingClient;
     private ArbeidsforholdService arbeidsforholdService;
-    private RemoteFeatureConfig.OpprettBrukerIArenaFeature opprettBrukerIArenaFeature;
     private RemoteFeatureConfig.RegistreringFeature registreringFeature;
     private StartRegistreringUtilsService startRegistreringUtilsService;
 
 
     @BeforeEach
     public void setup() {
-        opprettBrukerIArenaFeature = mock(RemoteFeatureConfig.OpprettBrukerIArenaFeature.class);
         registreringFeature = mock(RemoteFeatureConfig.RegistreringFeature.class);
         aktorService = mock(AktorService.class);
         arbeidssokerregistreringRepository = mock(ArbeidssokerregistreringRepository.class);
@@ -58,14 +56,12 @@ public class BrukerRegistreringServiceTest {
                 new BrukerRegistreringService(
                         arbeidssokerregistreringRepository,
                         aktorService,
-                        opprettBrukerIArenaFeature,
                         registreringFeature,
                         oppfolgingClient,
                         arbeidsforholdService,
                         startRegistreringUtilsService);
 
         when(aktorService.getAktorId(any())).thenReturn(of("AKTORID"));
-        when(opprettBrukerIArenaFeature.erAktiv()).thenReturn(true);
         when(registreringFeature.erAktiv()).thenReturn(true);
     }
 
@@ -82,21 +78,12 @@ public class BrukerRegistreringServiceTest {
     }
 
     @Test
-    void skalRegistrereSelvgaaendeBrukerIDatabasenSelvOmArenaErToggletBort()  {
-        when(opprettBrukerIArenaFeature.erAktiv()).thenReturn(false);
+    void skalRegistrereSelvgaaendeBrukerIDatabasen()  {
         mockArbeidssforholdSomOppfyllerKravForSelvgaaendeBruker();
         BrukerRegistrering selvgaaendeBruker = getBrukerRegistreringSelvgaaende();
         registrerBruker(selvgaaendeBruker, FNR_OPPFYLLER_KRAV);
-        verify(oppfolgingClient, times(0)).aktiverBruker(any());
-        verify(arbeidssokerregistreringRepository, times(1)).lagreBruker(any(), any());
-    }
-
-    @Test
-    void skalRegistrereIArenaNaarArenaToggleErPaa()  {
-        when(opprettBrukerIArenaFeature.erAktiv()).thenReturn(true);
-        mockArbeidssforholdSomOppfyllerKravForSelvgaaendeBruker();
-        registrerBruker(getBrukerRegistreringSelvgaaende(), FNR_OPPFYLLER_KRAV);
         verify(oppfolgingClient, times(1)).aktiverBruker(any());
+        verify(arbeidssokerregistreringRepository, times(1)).lagreBruker(any(), any());
     }
 
     @Test

--- a/src/test/java/no/nav/fo/veilarbregistrering/service/OppfolgingClientTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/service/OppfolgingClientTest.java
@@ -37,7 +37,6 @@ class OppfolgingClientTest {
     private BrukerRegistreringService brukerRegistreringService;
     private OppfolgingClient oppfolgingClient;
     private ArbeidsforholdService arbeidsforholdService;
-    private RemoteFeatureConfig.OpprettBrukerIArenaFeature opprettBrukerIArenaFeature;
     private RemoteFeatureConfig.RegistreringFeature registreringFeature;
     private StartRegistreringUtilsService startRegistreringUtilsService;
     private ClientAndServer mockServer;
@@ -51,7 +50,6 @@ class OppfolgingClientTest {
     @BeforeEach
     public void setup() {
         mockServer = ClientAndServer.startClientAndServer(MOCKSERVER_PORT);
-        opprettBrukerIArenaFeature = mock(RemoteFeatureConfig.OpprettBrukerIArenaFeature.class);
         registreringFeature = mock(RemoteFeatureConfig.RegistreringFeature.class);
         aktorService = mock(AktorService.class);
         oppfolgingClient = buildClient();
@@ -64,7 +62,6 @@ class OppfolgingClientTest {
                 new BrukerRegistreringService(
                         arbeidssokerregistreringRepository,
                         aktorService,
-                        opprettBrukerIArenaFeature,
                         registreringFeature,
                         oppfolgingClient,
                         arbeidsforholdService,
@@ -76,7 +73,6 @@ class OppfolgingClientTest {
 
         when(startRegistreringUtilsService.oppfyllerKravOmAutomatiskRegistrering(any(), any(), any(), any())).thenReturn(true);
         when(aktorService.getAktorId(any())).thenReturn(Optional.of("AKTORID"));
-        when(opprettBrukerIArenaFeature.erAktiv()).thenReturn(true);
         when(registreringFeature.erAktiv()).thenReturn(true);
     }
 

--- a/src/test/java/no/nav/veilarbregistrering/integrasjonstest/BrukerRegistreringServiceIntegrationTest.java
+++ b/src/test/java/no/nav/veilarbregistrering/integrasjonstest/BrukerRegistreringServiceIntegrationTest.java
@@ -4,7 +4,6 @@ import io.vavr.control.Try;
 import no.nav.apiapp.security.PepClient;
 import no.nav.dialogarena.aktor.AktorService;
 import no.nav.fo.veilarbregistrering.config.DatabaseConfig;
-import no.nav.fo.veilarbregistrering.config.RemoteFeatureConfig.OpprettBrukerIArenaFeature;
 import no.nav.fo.veilarbregistrering.config.RemoteFeatureConfig.RegistreringFeature;
 import no.nav.fo.veilarbregistrering.db.ArbeidssokerregistreringRepository;
 import no.nav.fo.veilarbregistrering.db.MigrationUtils;
@@ -37,7 +36,6 @@ class BrukerRegistreringServiceIntegrationTest {
 
     private static BrukerRegistreringService brukerRegistreringService;
     private static AktorService aktorService;
-    private static OpprettBrukerIArenaFeature opprettBrukerIArenaFeature;
     private static RegistreringFeature registreringFeature;
     private static OppfolgingClient oppfolgingClient;
     private static ArbeidssokerregistreringRepository arbeidssokerregistreringRepository;
@@ -63,7 +61,6 @@ class BrukerRegistreringServiceIntegrationTest {
         brukerRegistreringService = context.getBean(BrukerRegistreringService.class);
         oppfolgingClient = context.getBean(OppfolgingClient.class);
         aktorService = context.getBean(AktorService.class);
-        opprettBrukerIArenaFeature = context.getBean(OpprettBrukerIArenaFeature.class);
         registreringFeature = context.getBean(RegistreringFeature.class);
         startRegistreringUtilsService = context.getBean(StartRegistreringUtilsService.class);
     }
@@ -99,7 +96,6 @@ class BrukerRegistreringServiceIntegrationTest {
 
     private void cofigureMocks() {
         when(registreringFeature.erAktiv()).thenReturn(true);
-        when(opprettBrukerIArenaFeature.erAktiv()).thenReturn(true);
         when(aktorService.getAktorId(any())).thenAnswer((invocation -> Optional.of(invocation.getArgument(0))));
         when(startRegistreringUtilsService.oppfyllerKravOmAutomatiskRegistrering(any(), any(), any(), any())).thenReturn(true);
     }
@@ -118,11 +114,6 @@ class BrukerRegistreringServiceIntegrationTest {
         @Bean
         public AktorService aktoerService() {
             return mock(AktorService.class);
-        }
-
-        @Bean
-        public OpprettBrukerIArenaFeature opprettBrukerIArenaFeature() {
-            return mock(OpprettBrukerIArenaFeature.class);
         }
 
         @Bean
@@ -155,7 +146,6 @@ class BrukerRegistreringServiceIntegrationTest {
         BrukerRegistreringService registrerBrukerService(
                 ArbeidssokerregistreringRepository arbeidssokerregistreringRepository,
                 AktorService aktorService,
-                OpprettBrukerIArenaFeature sjekkRegistrereBrukerArenaFeature,
                 RegistreringFeature skalRegistrereBrukerGenerellFeature,
                 OppfolgingClient oppfolgingClient,
                 ArbeidsforholdService arbeidsforholdService,
@@ -164,7 +154,6 @@ class BrukerRegistreringServiceIntegrationTest {
             return new BrukerRegistreringService(
                     arbeidssokerregistreringRepository,
                     aktorService,
-                    sjekkRegistrereBrukerArenaFeature,
                     skalRegistrereBrukerGenerellFeature,
                     oppfolgingClient,
                     arbeidsforholdService,


### PR DESCRIPTION
Det er vel ok å droppe denne togglen her? Det er vel naturlig at registrering alltid gjør kall mot veilarboppfolging (så lenge registrering i seg selv er slått på), og så kan veilarboppfolging beholde toggle mot Arena?