### PR TITLE
Endrer feil type

### DIFF
--- a/src/main/java/no/nav/fo/veilarbregistrering/httpclient/OppfolgingClient.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/httpclient/OppfolgingClient.java
@@ -86,6 +86,7 @@ public class OppfolgingClient {
         if (status == 204) {
             return status;
         } else if (status == 500 || status == 403) {
+            //todo: fjerne "status == 500" over når veilarboppfølging er endret til å sende 403 for kjente feil.
             log.error("Feil ved kall mot VeilArbOppfolging : {}, response : {}", url, response);
             throw new WebApplicationException(response);
         } else {


### PR DESCRIPTION
VeilArbOppfølging sender nå 403 i stedet for 500 dersom en bruker enten er utvandret, mangler arb. tillatelse osv. Dette muliggjør at vi kan skille denne typen tilstander fra andre feil.