### PR TITLE
[KAIZEN-0] Retter feil ifm. endepunktene

### DIFF
--- a/src/main/java/no/nav/fo/veilarbregistrering/arbeidsforhold/resources/ArbeidsforholdResource.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/arbeidsforhold/resources/ArbeidsforholdResource.java
@@ -19,7 +19,7 @@ import javax.ws.rs.Produces;
 @Component
 @Path("/")
 @Produces("application/json")
-@Api(value = "RegistreringResource", description = "Tjenester for registrering og reaktivering av arbeidssøker.")
+@Api(value = "ArbeidsforholdResource", description = "Tjenester for henting av arbeidsforhold til arbeidssøker.")
 public class ArbeidsforholdResource {
 
     private final ArbeidsforholdGateway arbeidsforholdGateway;

--- a/src/main/java/no/nav/fo/veilarbregistrering/config/ServiceBeansConfig.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/config/ServiceBeansConfig.java
@@ -61,7 +61,7 @@ public class ServiceBeansConfig {
     }
 
     @Bean
-    RegistreringResource arbeidsforholdResource(
+    RegistreringResource registreringResource(
             VeilarbAbacPepClient pepClient,
             UserService userService,
             ManuellRegistreringService manuellRegistreringService,
@@ -97,7 +97,7 @@ public class ServiceBeansConfig {
     }
 
     @Bean
-    SykemeldingResource arbeidsforholdResource(
+    SykemeldingResource sykemeldingResource(
             VeilarbAbacPepClient pepClient,
             UserService userService,
             BrukerRegistreringService brukerRegistreringService,

--- a/src/main/java/no/nav/fo/veilarbregistrering/sykemelding/resources/SykemeldingResource.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/sykemelding/resources/SykemeldingResource.java
@@ -19,7 +19,7 @@ import javax.ws.rs.Produces;
 @Component
 @Path("/")
 @Produces("application/json")
-@Api(value = "RegistreringResource", description = "Tjenester for registrering og reaktivering av arbeidssøker.")
+@Api(value = "SykemeldingResource", description = "Tjenester for uthenting av maksdato for arbeidssøker.")
 public class SykemeldingResource {
 
     private final BrukerRegistreringService brukerRegistreringService;


### PR DESCRIPTION
Ifm. oppsplitting av RegistreringResource i 3, med SykemeldingResource og ArbeidsforholdResource i tillegg til RegistreringResource, så ble metodenavnet tild e ulike Resourcene duplisert. Det medførte mest sannsynlig at bare den første ble definert, som medførte at de andre endepunktene ikke svarte.