### PR TITLE
[KAIZEN-0] Fjerner unødig duplikat loggmelding.

### DIFF
--- a/src/main/java/no/nav/fo/veilarbregistrering/sykemelding/adapter/SykmeldtInfoClient.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/sykemelding/adapter/SykmeldtInfoClient.java
@@ -41,8 +41,7 @@ public class SykmeldtInfoClient extends BaseClient {
                             .header("Authorization", "Bearer " + tokenLocator.getToken(request).orElse(null))
                             .get(InfotrygdData.class));
         } catch (Exception e) {
-            log.error("Feil ved kall til tjeneste " + e);
-            throw new InternalServerErrorException();
+            throw new InternalServerErrorException("Hent maksdato fra Infotrygd feilet.", e);
         }
     }
 }


### PR DESCRIPTION
Det blir smør-på-flesk å både logge error og kaste exception. Det medfører unødvendig støy og usikkerhet når en leser loggene.
Bedre å kaste exception med en forklarende melding (husk at du skriver til en fremtidig versjon av deg selv) og full stacktrace.