### PR TITLE
[KAIZEN-0] Fullfører konfigurasjon av VeilArbPerson-integrasjonen.

### DIFF
--- a/app-config.yaml
+++ b/app-config.yaml
@@ -42,6 +42,8 @@ fasitResources:
     resourceType: webserviceendpoint
   - alias: securityTokenService
     resourceType: baseUrl
+  - alias: veilarbpersonAPI
+    resourceType: restservice
   - alias: veilArbOppfolgingAPI
     resourceType: restservice
   - alias: abac.pdp.endpoint

--- a/src/main/java/no/nav/fo/veilarbregistrering/bruker/GeografiskTilknytning.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/bruker/GeografiskTilknytning.java
@@ -1,16 +1,10 @@
 package no.nav.fo.veilarbregistrering.bruker;
 
 import java.util.Objects;
-import java.util.Optional;
 
 public class GeografiskTilknytning {
 
     private final String geografisktilknytning;
-
-    public static Optional<GeografiskTilknytning> ofNullable(String geografisktilknytning) {
-        return geografisktilknytning != null ?
-                Optional.of(new GeografiskTilknytning(geografisktilknytning)) : Optional.empty();
-    }
 
     public static GeografiskTilknytning of(String geografisktilknytning) {
         return new GeografiskTilknytning(geografisktilknytning);

--- a/src/main/java/no/nav/fo/veilarbregistrering/bruker/adapter/PersonGatewayConfig.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/bruker/adapter/PersonGatewayConfig.java
@@ -1,0 +1,27 @@
+package no.nav.fo.veilarbregistrering.bruker.adapter;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.inject.Provider;
+import javax.servlet.http.HttpServletRequest;
+
+@Configuration
+public class PersonGatewayConfig {
+
+    public static final String PERSON_API_PROPERTY_NAME = "VEILARBPERSONGAPI_URL";
+
+    @Value("VEILARBPERSONGAPI_URL")
+    private String baseUrl;
+
+    @Bean
+    VeilArbPersonClient veilArbPersonClient(Provider<HttpServletRequest> provider) {
+        return new VeilArbPersonClient(baseUrl, provider);
+    }
+
+    @Bean
+    PersonGatewayImpl personGateway(VeilArbPersonClient client) {
+        return new PersonGatewayImpl(client);
+    }
+}

--- a/src/main/java/no/nav/fo/veilarbregistrering/bruker/adapter/PersonGatewayImpl.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/bruker/adapter/PersonGatewayImpl.java
@@ -6,16 +6,16 @@ import no.nav.fo.veilarbregistrering.bruker.PersonGateway;
 
 import java.util.Optional;
 
-public class PersonGatewayImpl implements PersonGateway {
+class PersonGatewayImpl implements PersonGateway {
 
     private final VeilArbPersonClient client;
 
-    public PersonGatewayImpl(VeilArbPersonClient client) {
+    PersonGatewayImpl(VeilArbPersonClient client) {
         this.client = client;
     }
 
     @Override
     public Optional<GeografiskTilknytning> hentGeografiskTilknytning(Foedselsnummer foedselsnummer) {
-        return GeografiskTilknytning.ofNullable(client.geografisktilknytning(foedselsnummer));
+        return client.geografisktilknytning(foedselsnummer).map(t -> GeografiskTilknytning.of(t));
     }
 }

--- a/src/main/java/no/nav/fo/veilarbregistrering/config/ApplicationConfig.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/config/ApplicationConfig.java
@@ -4,6 +4,7 @@ import no.nav.apiapp.ApiApplication;
 import no.nav.apiapp.config.ApiAppConfigurator;
 import no.nav.dialogarena.aktor.AktorConfig;
 import no.nav.fo.veilarbregistrering.arbeidsforhold.adapter.AAregServiceWSConfig;
+import no.nav.fo.veilarbregistrering.bruker.adapter.PersonGatewayConfig;
 import no.nav.fo.veilarbregistrering.db.DataSourceHelsesjekk;
 import no.nav.fo.veilarbregistrering.db.MigrationUtils;
 import no.nav.fo.veilarbregistrering.oppfolging.adapter.OppfolgingClientHelseSjekk;
@@ -29,7 +30,8 @@ import javax.servlet.ServletContext;
         AAregServiceWSConfig.class,
         OppfolgingClientHelseSjekk.class,
         SykmeldtInfoClientHelseSjekk.class,
-        RemoteFeatureConfig.class
+        RemoteFeatureConfig.class,
+        PersonGatewayConfig.class
 })
 public class ApplicationConfig implements ApiApplication {
 

--- a/src/test/java/no/nav/veilarbregistrering/TestContext.java
+++ b/src/test/java/no/nav/veilarbregistrering/TestContext.java
@@ -13,14 +13,13 @@ import static no.nav.brukerdialog.security.oidc.provider.AzureADB2CConfig.EXTERN
 import static no.nav.brukerdialog.security.oidc.provider.AzureADB2CConfig.EXTERNAL_USERS_AZUREAD_B2C_EXPECTED_AUDIENCE;
 import static no.nav.dialogarena.aktor.AktorConfig.AKTOER_ENDPOINT_URL;
 import static no.nav.fasit.FasitUtils.Zone.FSS;
-import static no.nav.fasit.FasitUtils.getDefaultEnvironment;
-import static no.nav.fasit.FasitUtils.getRestService;
-import static no.nav.fasit.FasitUtils.getServiceUser;
+import static no.nav.fasit.FasitUtils.*;
 import static no.nav.fo.veilarbregistrering.arbeidsforhold.adapter.AAregServiceWSConfig.AAREG_ENDPOINT_URL;
+import static no.nav.fo.veilarbregistrering.bruker.adapter.PersonGatewayConfig.PERSON_API_PROPERTY_NAME;
 import static no.nav.fo.veilarbregistrering.config.ApplicationConfig.APPLICATION_NAME;
-import static no.nav.fo.veilarbregistrering.orgenhet.adapter.OrganisasjonEnhetV2Config.NORG2_ORGANISASJONENHET_V2_URL;
 import static no.nav.fo.veilarbregistrering.config.RemoteFeatureConfig.UNLEASH_API_URL_PROPERTY;
 import static no.nav.fo.veilarbregistrering.oppfolging.adapter.OppfolgingClient.OPPFOLGING_API_PROPERTY_NAME;
+import static no.nav.fo.veilarbregistrering.orgenhet.adapter.OrganisasjonEnhetV2Config.NORG2_ORGANISASJONENHET_V2_URL;
 import static no.nav.sbl.dialogarena.common.abac.pep.service.AbacServiceConfig.ABAC_ENDPOINT_URL_PROPERTY_NAME;
 
 
@@ -47,6 +46,8 @@ public class TestContext {
         setProperty(AAREG_ENDPOINT_URL, "https://modapp-" + getDefaultEnvironment() + ".adeo.no/aareg-core/ArbeidsforholdService/v3");
 
         setProperty(OPPFOLGING_API_PROPERTY_NAME, "https://localhost.nav.no:8443/veilarboppfolging/api");
+
+        setProperty(PERSON_API_PROPERTY_NAME, "https://localhost.nav.no:8443/veilarbperson/api");
 
         setProperty(UNLEASH_API_URL_PROPERTY, "https://unleash.nais.adeo.no/api/");
 


### PR DESCRIPTION
Oppretter egen Config-klasse for alt under adapter-pakken for VeilArbPerson-integrasjonen.
Forsøker samtidig å begrense synlighet for alle pakker under her til et minimum. Det er ikke meningen at dette skal brukes uten å gå via PersonGateway-interfacet.