### PR TITLE
[KAIZEN-0] Flytter ClientConfig til Adapter-pakken.

### DIFF
--- a/src/main/java/no/nav/fo/veilarbregistrering/bruker/adapter/PersonGatewayConfig.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/bruker/adapter/PersonGatewayConfig.java
@@ -12,12 +12,12 @@ public class PersonGatewayConfig {
 
     public static final String PERSON_API_PROPERTY_NAME = "VEILARBPERSONGAPI_URL";
 
-    @Value("VEILARBPERSONGAPI_URL")
-    private String baseUrl;
+    @Value(PERSON_API_PROPERTY_NAME)
+    private String baseUrlVeilArbPersonApi;
 
     @Bean
     VeilArbPersonClient veilArbPersonClient(Provider<HttpServletRequest> provider) {
-        return new VeilArbPersonClient(baseUrl, provider);
+        return new VeilArbPersonClient(baseUrlVeilArbPersonApi, provider);
     }
 
     @Bean

--- a/src/main/java/no/nav/fo/veilarbregistrering/config/ApplicationConfig.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/config/ApplicationConfig.java
@@ -8,6 +8,8 @@ import no.nav.fo.veilarbregistrering.bruker.adapter.PersonGatewayConfig;
 import no.nav.fo.veilarbregistrering.db.DataSourceHelsesjekk;
 import no.nav.fo.veilarbregistrering.db.MigrationUtils;
 import no.nav.fo.veilarbregistrering.oppfolging.adapter.OppfolgingClientHelseSjekk;
+import no.nav.fo.veilarbregistrering.oppfolging.adapter.OppfolgingGatewayConfig;
+import no.nav.fo.veilarbregistrering.sykemelding.adapter.SykemeldingGatewayConfig;
 import no.nav.fo.veilarbregistrering.sykemelding.adapter.SykmeldtInfoClientHelseSjekk;
 import no.nav.fo.veilarbregistrering.orgenhet.adapter.OrganisasjonEnhetV2Config;
 import org.springframework.context.annotation.Configuration;
@@ -31,7 +33,9 @@ import javax.servlet.ServletContext;
         OppfolgingClientHelseSjekk.class,
         SykmeldtInfoClientHelseSjekk.class,
         RemoteFeatureConfig.class,
-        PersonGatewayConfig.class
+        PersonGatewayConfig.class,
+        OppfolgingGatewayConfig.class,
+        SykemeldingGatewayConfig.class
 })
 public class ApplicationConfig implements ApiApplication {
 

--- a/src/main/java/no/nav/fo/veilarbregistrering/config/ServiceBeansConfig.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/config/ServiceBeansConfig.java
@@ -7,15 +7,13 @@ import no.nav.fo.veilarbregistrering.arbeidsforhold.adapter.ArbeidsforholdGatewa
 import no.nav.fo.veilarbregistrering.arbeidsforhold.resources.ArbeidsforholdResource;
 import no.nav.fo.veilarbregistrering.bruker.UserService;
 import no.nav.fo.veilarbregistrering.oppfolging.OppfolgingGateway;
-import no.nav.fo.veilarbregistrering.oppfolging.adapter.OppfolgingClient;
-import no.nav.fo.veilarbregistrering.oppfolging.adapter.OppfolgngGatewayImpl;
 import no.nav.fo.veilarbregistrering.orgenhet.HentEnheterGateway;
 import no.nav.fo.veilarbregistrering.orgenhet.adapter.HentEnheterGatewayImpl;
 import no.nav.fo.veilarbregistrering.profilering.ProfileringRepository;
+import no.nav.fo.veilarbregistrering.profilering.StartRegistreringUtils;
 import no.nav.fo.veilarbregistrering.profilering.db.ProfileringRepositoryImpl;
 import no.nav.fo.veilarbregistrering.registrering.bruker.BrukerRegistreringRepository;
 import no.nav.fo.veilarbregistrering.registrering.bruker.BrukerRegistreringService;
-import no.nav.fo.veilarbregistrering.profilering.StartRegistreringUtils;
 import no.nav.fo.veilarbregistrering.registrering.bruker.db.BrukerRegistreringRepositoryImpl;
 import no.nav.fo.veilarbregistrering.registrering.manuell.ManuellRegistreringRepository;
 import no.nav.fo.veilarbregistrering.registrering.manuell.ManuellRegistreringService;
@@ -23,8 +21,6 @@ import no.nav.fo.veilarbregistrering.registrering.manuell.db.ManuellRegistrering
 import no.nav.fo.veilarbregistrering.registrering.resources.RegistreringResource;
 import no.nav.fo.veilarbregistrering.sykemelding.SykemeldingGateway;
 import no.nav.fo.veilarbregistrering.sykemelding.SykemeldingService;
-import no.nav.fo.veilarbregistrering.sykemelding.adapter.SykemeldingGatewayImpl;
-import no.nav.fo.veilarbregistrering.sykemelding.adapter.SykmeldtInfoClient;
 import no.nav.fo.veilarbregistrering.sykemelding.resources.SykemeldingResource;
 import no.nav.tjeneste.virksomhet.arbeidsforhold.v3.binding.ArbeidsforholdV3;
 import no.nav.tjeneste.virksomhet.organisasjonenhet.v2.binding.OrganisasjonEnhetV2;
@@ -41,16 +37,6 @@ public class ServiceBeansConfig {
     @Bean
     SykemeldingService sykemeldingService(SykemeldingGateway sykemeldingGateway) {
         return new SykemeldingService(sykemeldingGateway);
-    }
-
-    @Bean
-    SykemeldingGateway sykemeldingGateway(SykmeldtInfoClient sykeforloepMetadataClient) {
-        return new SykemeldingGatewayImpl(sykeforloepMetadataClient);
-    }
-
-    @Bean
-    OppfolgingGateway oppfolgingGateway(OppfolgingClient oppfolgingClient) {
-        return new OppfolgngGatewayImpl(oppfolgingClient);
     }
 
     @Bean
@@ -154,16 +140,6 @@ public class ServiceBeansConfig {
     @Bean
     ArbeidsforholdGateway arbeidsforholdGateway(ArbeidsforholdV3 arbeidsforholdV3) {
         return new ArbeidsforholdGatewayImpl(arbeidsforholdV3);
-    }
-
-    @Bean
-    OppfolgingClient oppfolgingClient(Provider<HttpServletRequest> provider) {
-        return new OppfolgingClient(provider);
-    }
-
-    @Bean
-    SykmeldtInfoClient sykeforloepMetadataClient(Provider<HttpServletRequest> provider) {
-        return new SykmeldtInfoClient(provider);
     }
 
     @Bean

--- a/src/main/java/no/nav/fo/veilarbregistrering/oppfolging/adapter/OppfolgingClientHelseSjekk.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/oppfolging/adapter/OppfolgingClientHelseSjekk.java
@@ -3,7 +3,7 @@ package no.nav.fo.veilarbregistrering.oppfolging.adapter;
 import no.nav.apiapp.selftest.Helsesjekk;
 import no.nav.apiapp.selftest.HelsesjekkMetadata;
 
-import static no.nav.fo.veilarbregistrering.oppfolging.adapter.OppfolgingClient.OPPFOLGING_API_PROPERTY_NAME;
+import static no.nav.fo.veilarbregistrering.oppfolging.adapter.OppfolgingGatewayConfig.OPPFOLGING_API_PROPERTY_NAME;
 import static no.nav.sbl.rest.RestUtils.withClient;
 import static no.nav.sbl.util.EnvironmentUtils.getRequiredProperty;
 

--- a/src/main/java/no/nav/fo/veilarbregistrering/oppfolging/adapter/OppfolgingGatewayConfig.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/oppfolging/adapter/OppfolgingGatewayConfig.java
@@ -1,0 +1,28 @@
+package no.nav.fo.veilarbregistrering.oppfolging.adapter;
+
+import no.nav.fo.veilarbregistrering.oppfolging.OppfolgingGateway;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.inject.Provider;
+import javax.servlet.http.HttpServletRequest;
+
+@Configuration
+public class OppfolgingGatewayConfig {
+
+    public static final String OPPFOLGING_API_PROPERTY_NAME = "VEILARBOPPFOLGINGAPI_URL";
+
+    @Value(OPPFOLGING_API_PROPERTY_NAME)
+    private String baseUrlVeilArbOppfolgingApi;
+
+    @Bean
+    OppfolgingClient oppfolgingClient(Provider<HttpServletRequest> provider) {
+        return new OppfolgingClient(baseUrlVeilArbOppfolgingApi, provider);
+    }
+
+    @Bean
+    OppfolgingGateway oppfolgingGateway(OppfolgingClient oppfolgingClient) {
+        return new OppfolgingGatewayImpl(oppfolgingClient);
+    }
+}

--- a/src/main/java/no/nav/fo/veilarbregistrering/oppfolging/adapter/OppfolgingGatewayImpl.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/oppfolging/adapter/OppfolgingGatewayImpl.java
@@ -5,11 +5,11 @@ import no.nav.fo.veilarbregistrering.oppfolging.Oppfolgingsstatus;
 import no.nav.fo.veilarbregistrering.profilering.Innsatsgruppe;
 import no.nav.fo.veilarbregistrering.besvarelse.Besvarelse;
 
-public class OppfolgngGatewayImpl implements OppfolgingGateway {
+public class OppfolgingGatewayImpl implements OppfolgingGateway {
 
     private final OppfolgingClient oppfolgingClient;
 
-    public OppfolgngGatewayImpl(OppfolgingClient oppfolgingClient) {
+    public OppfolgingGatewayImpl(OppfolgingClient oppfolgingClient) {
         this.oppfolgingClient = oppfolgingClient;
     }
 

--- a/src/main/java/no/nav/fo/veilarbregistrering/sykemelding/adapter/SykemeldingGatewayConfig.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/sykemelding/adapter/SykemeldingGatewayConfig.java
@@ -1,0 +1,28 @@
+package no.nav.fo.veilarbregistrering.sykemelding.adapter;
+
+import no.nav.fo.veilarbregistrering.sykemelding.SykemeldingGateway;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.inject.Provider;
+import javax.servlet.http.HttpServletRequest;
+
+@Configuration
+public class SykemeldingGatewayConfig {
+
+    public static final String INFOTRYGDAPI_URL_PROPERTY_NAME = "http://infotrygd-fo.default.svc.nais.local";
+
+    @Value(INFOTRYGDAPI_URL_PROPERTY_NAME)
+    private String baseUrlInfotrygdApi;
+
+    @Bean
+    SykmeldtInfoClient sykeforloepMetadataClient(Provider<HttpServletRequest> provider) {
+        return new SykmeldtInfoClient(baseUrlInfotrygdApi, provider);
+    }
+
+    @Bean
+    SykemeldingGateway sykemeldingGateway(SykmeldtInfoClient sykeforloepMetadataClient) {
+        return new SykemeldingGatewayImpl(sykeforloepMetadataClient);
+    }
+}

--- a/src/main/java/no/nav/fo/veilarbregistrering/sykemelding/adapter/SykmeldtInfoClient.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/sykemelding/adapter/SykmeldtInfoClient.java
@@ -1,11 +1,11 @@
 package no.nav.fo.veilarbregistrering.sykemelding.adapter;
 
-import lombok.extern.slf4j.Slf4j;
 import no.nav.brukerdialog.security.jaspic.TokenLocator;
 import no.nav.fo.veilarbregistrering.httpclient.BaseClient;
 import no.nav.sbl.rest.RestUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import javax.inject.Inject;
 import javax.inject.Provider;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.InternalServerErrorException;
@@ -14,14 +14,12 @@ import static javax.ws.rs.core.HttpHeaders.COOKIE;
 import static no.nav.brukerdialog.security.Constants.AZUREADB2C_OIDC_COOKIE_NAME_SBS;
 import static no.nav.sbl.rest.RestUtils.withClient;
 
-@Slf4j
 public class SykmeldtInfoClient extends BaseClient {
 
-    public static final String INFOTRYGDAPI_URL_PROPERTY_NAME = "http://infotrygd-fo.default.svc.nais.local";
+    private static final Logger LOG = LoggerFactory.getLogger(SykmeldtInfoClient.class);
 
-    @Inject
-    public SykmeldtInfoClient(Provider<HttpServletRequest> httpServletRequestProvider) {
-        super(INFOTRYGDAPI_URL_PROPERTY_NAME, httpServletRequestProvider);
+    public SykmeldtInfoClient(String baseUrl, Provider<HttpServletRequest> httpServletRequestProvider) {
+        super(baseUrl, httpServletRequestProvider);
     }
 
     public InfotrygdData hentSykmeldtInfoData(String fnr) {
@@ -33,7 +31,7 @@ public class SykmeldtInfoClient extends BaseClient {
         TokenLocator tokenLocator = new TokenLocator(AZUREADB2C_OIDC_COOKIE_NAME_SBS, null);
 
         try {
-            log.info("Kaller infotrygd-sykepenger på url : " + url);
+            LOG.info("Kaller infotrygd-sykepenger på url : " + url);
             return withClient(RestUtils.RestConfig.builder().readTimeout(HTTP_READ_TIMEOUT).build(),
                     c -> c.target(url)
                             .request()

--- a/src/main/java/no/nav/fo/veilarbregistrering/sykemelding/adapter/SykmeldtInfoClientHelseSjekk.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/sykemelding/adapter/SykmeldtInfoClientHelseSjekk.java
@@ -3,7 +3,7 @@ package no.nav.fo.veilarbregistrering.sykemelding.adapter;
 import no.nav.apiapp.selftest.Helsesjekk;
 import no.nav.apiapp.selftest.HelsesjekkMetadata;
 
-import static no.nav.fo.veilarbregistrering.sykemelding.adapter.SykmeldtInfoClient.INFOTRYGDAPI_URL_PROPERTY_NAME;
+import static no.nav.fo.veilarbregistrering.sykemelding.adapter.SykemeldingGatewayConfig.INFOTRYGDAPI_URL_PROPERTY_NAME;
 import static no.nav.sbl.rest.RestUtils.withClient;
 
 public class SykmeldtInfoClientHelseSjekk implements Helsesjekk {

--- a/src/test/java/no/nav/fo/veilarbregistrering/mock/OppfolgingClientMock.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/mock/OppfolgingClientMock.java
@@ -11,7 +11,7 @@ import javax.ws.rs.core.Response;
 public class OppfolgingClientMock extends OppfolgingClient {
 
     public OppfolgingClientMock() {
-        super(null);
+        super(null, null);
     }
 
     @Override

--- a/src/test/java/no/nav/fo/veilarbregistrering/mock/SykmeldtInfoClientMock.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/mock/SykmeldtInfoClientMock.java
@@ -6,7 +6,7 @@ import no.nav.fo.veilarbregistrering.sykemelding.adapter.SykmeldtInfoClient;
 public class SykmeldtInfoClientMock extends SykmeldtInfoClient {
 
     public SykmeldtInfoClientMock() {
-        super(null);
+        super(null, null);
     }
 
     @Override

--- a/src/test/java/no/nav/fo/veilarbregistrering/oppfolging/adapter/OppfolgingClientTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/oppfolging/adapter/OppfolgingClientTest.java
@@ -32,6 +32,7 @@ import javax.ws.rs.WebApplicationException;
 import static java.lang.System.setProperty;
 import static no.nav.fo.veilarbregistrering.profilering.ProfileringTestdataBuilder.lagProfilering;
 import static no.nav.fo.veilarbregistrering.registrering.bruker.OrdinaerBrukerRegistreringTestdataBuilder.gyldigBrukerRegistrering;
+import static no.nav.sbl.util.EnvironmentUtils.getRequiredProperty;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -85,7 +86,7 @@ class OppfolgingClientTest {
                 new BrukerRegistreringService(
                         brukerRegistreringRepository,
                         profileringRepository,
-                        new OppfolgngGatewayImpl(oppfolgingClient),
+                        new OppfolgingGatewayImpl(oppfolgingClient),
                         new SykemeldingService(new SykemeldingGatewayImpl(sykeforloepMetadataClient)),
                         arbeidsforholdGateway,
                         manuellRegistreringService,
@@ -110,7 +111,8 @@ class OppfolgingClientTest {
         when(httpServletRequest.getHeader(any())).thenReturn("");
         when(systemUserTokenProvider.getToken()).thenReturn("testToken");
         setProperty("VEILARBOPPFOLGINGAPI_URL", "http://" + MOCKSERVER_URL + ":" + MOCKSERVER_PORT);
-        OppfolgingClient oppfolgingClient = this.oppfolgingClient = new OppfolgingClient(httpServletRequestProvider);
+        OppfolgingClient oppfolgingClient = this.oppfolgingClient = new OppfolgingClient(
+                getRequiredProperty(OppfolgingGatewayConfig.OPPFOLGING_API_PROPERTY_NAME), httpServletRequestProvider);
         oppfolgingClient.settSystemUserTokenProvider(systemUserTokenProvider);
         return oppfolgingClient;
     }

--- a/src/test/java/no/nav/fo/veilarbregistrering/oppfolging/adapter/OppfolgingClientTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/oppfolging/adapter/OppfolgingClientTest.java
@@ -29,10 +29,8 @@ import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.InternalServerErrorException;
 import javax.ws.rs.WebApplicationException;
 
-import static java.lang.System.setProperty;
 import static no.nav.fo.veilarbregistrering.profilering.ProfileringTestdataBuilder.lagProfilering;
 import static no.nav.fo.veilarbregistrering.registrering.bruker.OrdinaerBrukerRegistreringTestdataBuilder.gyldigBrukerRegistrering;
-import static no.nav.sbl.util.EnvironmentUtils.getRequiredProperty;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -110,9 +108,8 @@ class OppfolgingClientTest {
         when(httpServletRequestProvider.get()).thenReturn(httpServletRequest);
         when(httpServletRequest.getHeader(any())).thenReturn("");
         when(systemUserTokenProvider.getToken()).thenReturn("testToken");
-        setProperty("VEILARBOPPFOLGINGAPI_URL", "http://" + MOCKSERVER_URL + ":" + MOCKSERVER_PORT);
-        OppfolgingClient oppfolgingClient = this.oppfolgingClient = new OppfolgingClient(
-                getRequiredProperty(OppfolgingGatewayConfig.OPPFOLGING_API_PROPERTY_NAME), httpServletRequestProvider);
+        String baseUrl = "http://" + MOCKSERVER_URL + ":" + MOCKSERVER_PORT;
+        OppfolgingClient oppfolgingClient = this.oppfolgingClient = new OppfolgingClient(baseUrl, httpServletRequestProvider);
         oppfolgingClient.settSystemUserTokenProvider(systemUserTokenProvider);
         return oppfolgingClient;
     }

--- a/src/test/java/no/nav/fo/veilarbregistrering/registrering/bruker/BrukerRegistreringServiceTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/registrering/bruker/BrukerRegistreringServiceTest.java
@@ -7,7 +7,7 @@ import no.nav.fo.veilarbregistrering.arbeidsforhold.ArbeidsforholdGateway;
 import no.nav.fo.veilarbregistrering.config.RemoteFeatureConfig;
 import no.nav.fo.veilarbregistrering.oppfolging.adapter.OppfolgingClient;
 import no.nav.fo.veilarbregistrering.oppfolging.adapter.OppfolgingStatusData;
-import no.nav.fo.veilarbregistrering.oppfolging.adapter.OppfolgngGatewayImpl;
+import no.nav.fo.veilarbregistrering.oppfolging.adapter.OppfolgingGatewayImpl;
 import no.nav.fo.veilarbregistrering.profilering.ProfileringRepository;
 import no.nav.fo.veilarbregistrering.profilering.StartRegistreringUtils;
 import no.nav.fo.veilarbregistrering.registrering.manuell.ManuellRegistreringService;
@@ -58,7 +58,7 @@ public class BrukerRegistreringServiceTest {
                 new BrukerRegistreringService(
                         brukerRegistreringRepository,
                         profileringRepository,
-                        new OppfolgngGatewayImpl(oppfolgingClient),
+                        new OppfolgingGatewayImpl(oppfolgingClient),
                         new SykemeldingService(new SykemeldingGatewayImpl(sykeforloepMetadataClient)),
                         arbeidsforholdGateway,
                         manuellRegistreringService,

--- a/src/test/java/no/nav/fo/veilarbregistrering/sykemelding/adapter/SykmeldtInfoClientTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/sykemelding/adapter/SykmeldtInfoClientTest.java
@@ -6,10 +6,13 @@ import no.nav.brukerdialog.security.oidc.SystemUserTokenProvider;
 import no.nav.fo.veilarbregistrering.arbeidsforhold.ArbeidsforholdGateway;
 import no.nav.fo.veilarbregistrering.config.RemoteFeatureConfig;
 import no.nav.fo.veilarbregistrering.oppfolging.adapter.OppfolgingClient;
-import no.nav.fo.veilarbregistrering.oppfolging.adapter.OppfolgngGatewayImpl;
+import no.nav.fo.veilarbregistrering.oppfolging.adapter.OppfolgingGatewayImpl;
 import no.nav.fo.veilarbregistrering.profilering.ProfileringRepository;
 import no.nav.fo.veilarbregistrering.profilering.StartRegistreringUtils;
-import no.nav.fo.veilarbregistrering.registrering.bruker.*;
+import no.nav.fo.veilarbregistrering.registrering.bruker.BrukerRegistreringRepository;
+import no.nav.fo.veilarbregistrering.registrering.bruker.BrukerRegistreringService;
+import no.nav.fo.veilarbregistrering.registrering.bruker.StartRegistreringStatus;
+import no.nav.fo.veilarbregistrering.registrering.bruker.SykmeldtRegistrering;
 import no.nav.fo.veilarbregistrering.registrering.manuell.ManuellRegistreringService;
 import no.nav.fo.veilarbregistrering.sykemelding.SykemeldingService;
 import no.nav.veilarbregistrering.TestContext;
@@ -19,7 +22,6 @@ import org.mockserver.integration.ClientAndServer;
 import javax.inject.Provider;
 import javax.servlet.http.HttpServletRequest;
 
-import static java.lang.System.setProperty;
 import static no.nav.fo.veilarbregistrering.registrering.bruker.RegistreringType.SYKMELDT_REGISTRERING;
 import static no.nav.fo.veilarbregistrering.registrering.bruker.SykmeldtRegistreringTestdataBuilder.gyldigSykmeldtRegistrering;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -73,7 +75,7 @@ class SykmeldtInfoClientTest {
                 new BrukerRegistreringService(
                         brukerRegistreringRepository,
                         profileringRepository,
-                        new OppfolgngGatewayImpl(oppfolgingClient),
+                        new OppfolgingGatewayImpl(oppfolgingClient),
                         new SykemeldingService(new SykemeldingGatewayImpl(sykeforloepMetadataClient)),
                         arbeidsforholdGateway,
                         manuellRegistreringService,
@@ -87,14 +89,14 @@ class SykmeldtInfoClientTest {
 
     private SykmeldtInfoClient buildSykeForloepClient() {
         Provider<HttpServletRequest> httpServletRequestProvider = new ConfigBuildClient().invoke();
-        setProperty("SYKEFRAVAERAPI_URL", "http://" + MOCKSERVER_URL + ":" + MOCKSERVER_PORT + "/");
-        return sykeforloepMetadataClient = new SykmeldtInfoClient(httpServletRequestProvider);
+        String baseUrl = "http://" + MOCKSERVER_URL + ":" + MOCKSERVER_PORT + "/";
+        return sykeforloepMetadataClient = new SykmeldtInfoClient(baseUrl, httpServletRequestProvider);
     }
 
     private OppfolgingClient buildOppfolgingClient() {
         Provider<HttpServletRequest> httpServletRequestProvider = new ConfigBuildClient().invoke();
-        setProperty("VEILARBOPPFOLGINGAPI_URL", "http://" + MOCKSERVER_URL + ":" + MOCKSERVER_PORT);
-        return oppfolgingClient = new OppfolgingClient(httpServletRequestProvider);
+        String baseUrl = "http://" + MOCKSERVER_URL + ":" + MOCKSERVER_PORT;
+        return oppfolgingClient = new OppfolgingClient(baseUrl, httpServletRequestProvider);
     }
 
     @Test

--- a/src/test/java/no/nav/veilarbregistrering/TestContext.java
+++ b/src/test/java/no/nav/veilarbregistrering/TestContext.java
@@ -18,7 +18,7 @@ import static no.nav.fo.veilarbregistrering.arbeidsforhold.adapter.AAregServiceW
 import static no.nav.fo.veilarbregistrering.bruker.adapter.PersonGatewayConfig.PERSON_API_PROPERTY_NAME;
 import static no.nav.fo.veilarbregistrering.config.ApplicationConfig.APPLICATION_NAME;
 import static no.nav.fo.veilarbregistrering.config.RemoteFeatureConfig.UNLEASH_API_URL_PROPERTY;
-import static no.nav.fo.veilarbregistrering.oppfolging.adapter.OppfolgingClient.OPPFOLGING_API_PROPERTY_NAME;
+import static no.nav.fo.veilarbregistrering.oppfolging.adapter.OppfolgingGatewayConfig.OPPFOLGING_API_PROPERTY_NAME;
 import static no.nav.fo.veilarbregistrering.orgenhet.adapter.OrganisasjonEnhetV2Config.NORG2_ORGANISASJONENHET_V2_URL;
 import static no.nav.sbl.dialogarena.common.abac.pep.service.AbacServiceConfig.ABAC_ENDPOINT_URL_PROPERTY_NAME;
 

--- a/src/test/java/no/nav/veilarbregistrering/integrasjonstest/BrukerRegistreringServiceIntegrationTest.java
+++ b/src/test/java/no/nav/veilarbregistrering/integrasjonstest/BrukerRegistreringServiceIntegrationTest.java
@@ -9,7 +9,7 @@ import no.nav.fo.veilarbregistrering.config.RemoteFeatureConfig;
 import no.nav.fo.veilarbregistrering.db.MigrationUtils;
 import no.nav.fo.veilarbregistrering.oppfolging.adapter.OppfolgingClient;
 import no.nav.fo.veilarbregistrering.oppfolging.adapter.OppfolgingStatusData;
-import no.nav.fo.veilarbregistrering.oppfolging.adapter.OppfolgngGatewayImpl;
+import no.nav.fo.veilarbregistrering.oppfolging.adapter.OppfolgingGatewayImpl;
 import no.nav.fo.veilarbregistrering.profilering.ProfileringRepository;
 import no.nav.fo.veilarbregistrering.profilering.db.ProfileringRepositoryImpl;
 import no.nav.fo.veilarbregistrering.registrering.bruker.BrukerRegistreringRepository;
@@ -171,7 +171,7 @@ class BrukerRegistreringServiceIntegrationTest {
             return new BrukerRegistreringService(
                     brukerRegistreringRepository,
                     profileringRepository,
-                    new OppfolgngGatewayImpl(oppfolgingClient),
+                    new OppfolgingGatewayImpl(oppfolgingClient),
                     new SykemeldingService(new SykemeldingGatewayImpl(sykeforloepMetadataClient)),
                     arbeidsforholdGateway,
                     manuellRegistreringService,


### PR DESCRIPTION
Ønsker å isolere konfigurasjonen til der den hører hjemme. Det gjør igjen at vi potensielt kan begrense innsyn for klassene under adapter-pakken.
Har gjennomført endringen for Sykemelding og Oppfolging i tillegg til Person.