### PR TITLE
[KAIZEN-0] Eksponerer geografisk tilknytning ifm. GET -> /startregist…

### DIFF
--- a/src/main/java/no/nav/fo/veilarbregistrering/bruker/adapter/VeilArbPersonClient.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/bruker/adapter/VeilArbPersonClient.java
@@ -9,10 +9,7 @@ import org.slf4j.LoggerFactory;
 import javax.inject.Provider;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.ForbiddenException;
-import javax.ws.rs.InternalServerErrorException;
 import javax.ws.rs.NotFoundException;
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.Response;
 import java.util.Optional;
 
 import static javax.ws.rs.core.HttpHeaders.COOKIE;
@@ -44,13 +41,10 @@ class VeilArbPersonClient extends BaseClient {
             return Optional.empty();
 
         } catch (ForbiddenException e) {
-            LOG.warn("Bruker har ikke tilgang på å hente ut geografisk tilknytning fra VeilArbPerson-tjenesten.", e);
-            Response response = e.getResponse();
-            throw new WebApplicationException(response);
+            throw new RuntimeException("Bruker har ikke tilgang på å hente ut geografisk tilknytning fra VeilArbPerson-tjenesten.", e);
 
         } catch (Exception e) {
-            LOG.error("Feil ved kall til VeilArbPerson-tjenesten.", e);
-            throw new InternalServerErrorException();
+            throw new RuntimeException("Feil ved kall til VeilArbPerson-tjenesten.", e);
         }
     }
 

--- a/src/main/java/no/nav/fo/veilarbregistrering/config/ServiceBeansConfig.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/config/ServiceBeansConfig.java
@@ -5,6 +5,7 @@ import no.nav.dialogarena.aktor.AktorService;
 import no.nav.fo.veilarbregistrering.arbeidsforhold.ArbeidsforholdGateway;
 import no.nav.fo.veilarbregistrering.arbeidsforhold.adapter.ArbeidsforholdGatewayImpl;
 import no.nav.fo.veilarbregistrering.arbeidsforhold.resources.ArbeidsforholdResource;
+import no.nav.fo.veilarbregistrering.bruker.PersonGateway;
 import no.nav.fo.veilarbregistrering.bruker.UserService;
 import no.nav.fo.veilarbregistrering.oppfolging.OppfolgingGateway;
 import no.nav.fo.veilarbregistrering.orgenhet.HentEnheterGateway;
@@ -44,6 +45,7 @@ public class ServiceBeansConfig {
             BrukerRegistreringRepository brukerRegistreringRepository,
             ProfileringRepository profileringRepository,
             OppfolgingGateway oppfolgingGateway,
+            PersonGateway personGateway,
             SykemeldingService sykemeldingService,
             ArbeidsforholdGateway arbeidsforholdGateway,
             ManuellRegistreringService manuellRegistreringService,
@@ -55,6 +57,7 @@ public class ServiceBeansConfig {
                 brukerRegistreringRepository,
                 profileringRepository,
                 oppfolgingGateway,
+                personGateway,
                 sykemeldingService,
                 arbeidsforholdGateway,
                 manuellRegistreringService,

--- a/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/StartRegistreringStatus.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/StartRegistreringStatus.java
@@ -13,4 +13,5 @@ public class StartRegistreringStatus {
     private RegistreringType registreringType;
     private String formidlingsgruppe;
     private String servicegruppe;
+    private String geografiskTilknytning;
 }

--- a/src/test/java/MainTest.java
+++ b/src/test/java/MainTest.java
@@ -1,11 +1,8 @@
 import no.nav.apiapp.ApiApp;
-import no.nav.fo.veilarbregistrering.config.ApplicationConfig;
 import no.nav.fo.veilarbregistrering.config.ApplicationTestConfig;
 import no.nav.testconfig.ApiAppTest;
 import no.nav.veilarbregistrering.TestContext;
 import no.nav.veilarbregistrering.db.DatabaseTestContext;
-
-import static java.lang.System.getProperty;
 
 public class MainTest {
     public static final String TEST_PORT = "8810";

--- a/src/test/java/no/nav/fo/veilarbregistrering/oppfolging/adapter/OppfolgingClientTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/oppfolging/adapter/OppfolgingClientTest.java
@@ -4,6 +4,7 @@ import com.google.common.net.MediaType;
 import no.nav.apiapp.security.veilarbabac.Bruker;
 import no.nav.brukerdialog.security.oidc.SystemUserTokenProvider;
 import no.nav.fo.veilarbregistrering.arbeidsforhold.ArbeidsforholdGateway;
+import no.nav.fo.veilarbregistrering.bruker.PersonGateway;
 import no.nav.fo.veilarbregistrering.config.RemoteFeatureConfig;
 import no.nav.fo.veilarbregistrering.profilering.Innsatsgruppe;
 import no.nav.fo.veilarbregistrering.profilering.Profilering;
@@ -50,6 +51,7 @@ class OppfolgingClientTest {
     private BrukerRegistreringService brukerRegistreringService;
     private ManuellRegistreringService manuellRegistreringService;
     private OppfolgingClient oppfolgingClient;
+    private PersonGateway personGateway;
     private SykmeldtInfoClient sykeforloepMetadataClient;
     private ArbeidsforholdGateway arbeidsforholdGateway;
     private StartRegistreringUtils startRegistreringUtils;
@@ -72,6 +74,8 @@ class OppfolgingClientTest {
         mockServer = ClientAndServer.startClientAndServer(MOCKSERVER_PORT);
         sykemeldtRegistreringFeature = mock(RemoteFeatureConfig.SykemeldtRegistreringFeature.class);
         oppfolgingClient = buildClient();
+        personGateway = mock(PersonGateway.class);
+
         brukerRegistreringRepository = mock(BrukerRegistreringRepository.class);
         profileringRepository = mock(ProfileringRepository.class);
         arbeidsforholdGateway = mock(ArbeidsforholdGateway.class);
@@ -85,6 +89,7 @@ class OppfolgingClientTest {
                         brukerRegistreringRepository,
                         profileringRepository,
                         new OppfolgingGatewayImpl(oppfolgingClient),
+                        personGateway,
                         new SykemeldingService(new SykemeldingGatewayImpl(sykeforloepMetadataClient)),
                         arbeidsforholdGateway,
                         manuellRegistreringService,

--- a/src/test/java/no/nav/fo/veilarbregistrering/sykemelding/adapter/SykmeldtInfoClientTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/sykemelding/adapter/SykmeldtInfoClientTest.java
@@ -4,6 +4,7 @@ import com.google.common.net.MediaType;
 import no.nav.apiapp.security.veilarbabac.Bruker;
 import no.nav.brukerdialog.security.oidc.SystemUserTokenProvider;
 import no.nav.fo.veilarbregistrering.arbeidsforhold.ArbeidsforholdGateway;
+import no.nav.fo.veilarbregistrering.bruker.PersonGateway;
 import no.nav.fo.veilarbregistrering.config.RemoteFeatureConfig;
 import no.nav.fo.veilarbregistrering.oppfolging.adapter.OppfolgingClient;
 import no.nav.fo.veilarbregistrering.oppfolging.adapter.OppfolgingGatewayImpl;
@@ -41,6 +42,7 @@ class SykmeldtInfoClientTest {
     private ProfileringRepository profileringRepository;
     private BrukerRegistreringService brukerRegistreringService;
     private OppfolgingClient oppfolgingClient;
+    private PersonGateway personGateway;
     private SykmeldtInfoClient sykeforloepMetadataClient;
     private ArbeidsforholdGateway arbeidsforholdGateway;
     private ManuellRegistreringService manuellRegistreringService;
@@ -63,6 +65,7 @@ class SykmeldtInfoClientTest {
         mockServer = ClientAndServer.startClientAndServer(MOCKSERVER_PORT);
         sykemeldtRegistreringFeature = mock(RemoteFeatureConfig.SykemeldtRegistreringFeature.class);
         oppfolgingClient = buildOppfolgingClient();
+        personGateway = mock(PersonGateway.class);
         brukerRegistreringRepository = mock(BrukerRegistreringRepository.class);
         profileringRepository = mock(ProfileringRepository.class);
         arbeidsforholdGateway = mock(ArbeidsforholdGateway.class);
@@ -76,6 +79,7 @@ class SykmeldtInfoClientTest {
                         brukerRegistreringRepository,
                         profileringRepository,
                         new OppfolgingGatewayImpl(oppfolgingClient),
+                        personGateway,
                         new SykemeldingService(new SykemeldingGatewayImpl(sykeforloepMetadataClient)),
                         arbeidsforholdGateway,
                         manuellRegistreringService,

--- a/src/test/java/no/nav/veilarbregistrering/integrasjonstest/BrukerRegistreringServiceIntegrationTest.java
+++ b/src/test/java/no/nav/veilarbregistrering/integrasjonstest/BrukerRegistreringServiceIntegrationTest.java
@@ -4,6 +4,7 @@ import io.vavr.control.Try;
 import no.nav.apiapp.security.veilarbabac.Bruker;
 import no.nav.apiapp.security.veilarbabac.VeilarbAbacPepClient;
 import no.nav.fo.veilarbregistrering.arbeidsforhold.ArbeidsforholdGateway;
+import no.nav.fo.veilarbregistrering.bruker.PersonGateway;
 import no.nav.fo.veilarbregistrering.config.DatabaseConfig;
 import no.nav.fo.veilarbregistrering.config.RemoteFeatureConfig;
 import no.nav.fo.veilarbregistrering.db.MigrationUtils;
@@ -137,6 +138,9 @@ class BrukerRegistreringServiceIntegrationTest {
         }
 
         @Bean
+        public PersonGateway personGateway() { return mock(PersonGateway.class); }
+
+        @Bean
         public SykmeldtInfoClient sykeforloepMetadataClient() {
             return mock(SykmeldtInfoClient.class);
         }
@@ -162,6 +166,7 @@ class BrukerRegistreringServiceIntegrationTest {
                 BrukerRegistreringRepository brukerRegistreringRepository,
                 ProfileringRepository profileringRepository,
                 OppfolgingClient oppfolgingClient,
+                PersonGateway personGateway,
                 SykmeldtInfoClient sykeforloepMetadataClient,
                 ArbeidsforholdGateway arbeidsforholdGateway,
                 ManuellRegistreringService manuellRegistreringService,
@@ -172,6 +177,7 @@ class BrukerRegistreringServiceIntegrationTest {
                     brukerRegistreringRepository,
                     profileringRepository,
                     new OppfolgingGatewayImpl(oppfolgingClient),
+                    personGateway,
                     new SykemeldingService(new SykemeldingGatewayImpl(sykeforloepMetadataClient)),
                     arbeidsforholdGateway,
                     manuellRegistreringService,


### PR DESCRIPTION
…rering

Henter ut geografisk tilknytning fra veilarbperson ifm. /startregistrering-endepunktet.
Hvis feil oppstår vil exception fanges, slik at annen funksjonalitet kan fungere uavhengig.
Første versjon vil eksponere data slik at vi kan teste/verifisere at integrasjon er OK, før vi i neste iterasjon tar det i bruk for å styre brukerflyt.