### PR TITLE
[KAIZEN-0] Legger til målinger av geografisk tilknytning.

### DIFF
--- a/src/main/java/no/nav/fo/veilarbregistrering/bruker/GeografiskTilknytning.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/bruker/GeografiskTilknytning.java
@@ -114,7 +114,7 @@ public class GeografiskTilknytning implements Metrikkel {
             return Arrays.stream(BydelOslo.values())
                     .filter(bydelOslo -> bydelOslo.kode.equals(geografisktilknytning))
                     .findFirst()
-                    .orElseThrow(() -> new IllegalStateException(""));
+                    .orElseThrow(() -> new IllegalStateException(geografisktilknytning + " er ikke en kjent verdi for noen bydel i Oslo."));
         }
 
         private static boolean contains(String geografisktilknytning) {

--- a/src/main/java/no/nav/fo/veilarbregistrering/bruker/GeografiskTilknytning.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/bruker/GeografiskTilknytning.java
@@ -1,5 +1,6 @@
 package no.nav.fo.veilarbregistrering.bruker;
 
+import java.util.Arrays;
 import java.util.Objects;
 
 /**
@@ -10,7 +11,7 @@ import java.util.Objects;
  *     <li>Bydel (6 siffer)</li>
  * </ul>
  */
-public class GeografiskTilknytning {
+public class GeografiskTilknytning implements Metrikkel {
 
     private final String geografisktilknytning;
 
@@ -40,4 +41,88 @@ public class GeografiskTilknytning {
     public int hashCode() {
         return Objects.hash(geografisktilknytning);
     }
+
+    @Override
+    public String fiedldName() {
+        String fieldName = null;
+
+        if (utland()) {
+            fieldName = "utland";
+        } else if (fylke()) {
+            fieldName = "fylke";
+        } else if (bydelIkkeOslo()) {
+            fieldName = "bydel.ikke.oslo";
+        } else if (bydelOslo()) {
+            fieldName = "bydel.oslo." + BydelOslo.of(geografisktilknytning).kode;
+        } else {
+            throw new IllegalArgumentException("Geografisk tilknytning har ukjent format: " + geografisktilknytning);
+        }
+
+        return fieldName;
+    }
+
+    private boolean utland() {
+        return geografisktilknytning.length() == 3 && geografisktilknytning.matches("^[a-åA-Å]*$");
+    }
+
+    private boolean fylke() {
+        return geografisktilknytning.length() == 4 && geografisktilknytning.matches("^[0-9]*$");
+    }
+
+    private boolean bydelOslo() {
+        return geografisktilknytning.length() == 6 && BydelOslo.contains(geografisktilknytning);
+    }
+
+    private boolean bydelIkkeOslo() {
+        return geografisktilknytning.length() == 6 && !BydelOslo.contains(geografisktilknytning);
+    }
+
+    @Override
+    public int value() {
+        return 1;
+    }
+
+    private enum BydelOslo {
+
+        GamleOslo("030101", "Gamle Oslo"),
+        Grunerlokka("030102", "Grünerløkka"),
+        Sagene("030103", "Sagene"),
+        StHanshaugen("030104", "St.Hanshaugen"),
+        Frogner("030105", "Frogner"),
+        Ullern("030106", "Ullern"),
+        VestreAker("030107", "Vestre Aker"),
+        NordreAker("030108", "Nordre Aker"),
+        Bjerke("030109", "Bjerke"),
+        Grorud("030110", "Grorud"),
+        Stovner("030111", "Stovner"),
+        Alna("030112", "Alna"),
+        Ostensjo("030113", "Østensjø"),
+        Nordstrand("030114", "Nordstrand"),
+        SondreNordstrand("030115", "Søndre Nordstrand"),
+        Sentrum("030116", "Sentrum"),
+        Marka("030117", "Marka");
+
+        private final String kode;
+        private final String verdi;
+
+        BydelOslo(String kode, String verdi) {
+            this.kode = kode;
+            this.verdi = verdi;
+        };
+
+        private static BydelOslo of(String geografisktilknytning) {
+            return Arrays.stream(BydelOslo.values())
+                    .filter(bydelOslo -> bydelOslo.kode.equals(geografisktilknytning))
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalStateException(""));
+        }
+
+        private static boolean contains(String geografisktilknytning) {
+            return Arrays.stream(BydelOslo.values())
+                    .filter(bydelOslo -> bydelOslo.kode.equals(geografisktilknytning))
+                    .findAny()
+                    .isPresent();
+        }
+    }
+
 }

--- a/src/main/java/no/nav/fo/veilarbregistrering/bruker/Metrikkel.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/bruker/Metrikkel.java
@@ -1,0 +1,8 @@
+package no.nav.fo.veilarbregistrering.bruker;
+
+public interface Metrikkel {
+
+    String fiedldName();
+
+    int value();
+}

--- a/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/BrukerRegistreringService.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/BrukerRegistreringService.java
@@ -123,11 +123,11 @@ public class BrukerRegistreringService {
 
         Optional<GeografiskTilknytning> geografiskTilknytning;
         try {
-            LOG.info("Henter geografisk tilknytning for bruker.");
-
             long t1 = System.currentTimeMillis();
             geografiskTilknytning = personGateway.hentGeografiskTilknytning(Foedselsnummer.of(fnr));
             LOG.info("Henting av geografisk tilknytning tok {} ms.", System.currentTimeMillis() - t1);
+
+            geografiskTilknytning.ifPresent(g -> GeografiskTilknytningMetrikker.rapporter(g));
 
         } catch (RuntimeException e) {
             LOG.warn("Hent geografisk tilknytning feilet. Skal ikke påvirke annen bruk.", e);

--- a/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/GeografiskTilknytningMetrikker.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/GeografiskTilknytningMetrikker.java
@@ -1,0 +1,14 @@
+package no.nav.fo.veilarbregistrering.registrering.bruker;
+
+import no.nav.fo.veilarbregistrering.bruker.GeografiskTilknytning;
+import no.nav.metrics.Event;
+import no.nav.metrics.MetricsFactory;
+
+public class GeografiskTilknytningMetrikker {
+
+    static void rapporter(GeografiskTilknytning geografiskTilknytning) {
+        Event event = MetricsFactory.createEvent("registrering.bruker.registrering.geografiskTilknytning");
+        event.addFieldToReport(geografiskTilknytning.fiedldName(), geografiskTilknytning.value());
+        event.report();
+    }
+}

--- a/src/test/java/no/nav/fo/veilarbregistrering/bruker/GeografiskTilknytningTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/bruker/GeografiskTilknytningTest.java
@@ -1,0 +1,37 @@
+package no.nav.fo.veilarbregistrering.bruker;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class GeografiskTilknytningTest {
+
+    @Test
+    public void fieldName_skal_bruke_bydel_ikke_oslo_hvis_geografiskTilknytning_er_bydel_men_ikke_Oslo() {
+        assertThat(GeografiskTilknytning.of("123456").fiedldName()).isEqualTo("bydel.ikke.oslo");
+    }
+
+    @Test
+    public void fieldName_skal_bruke_bydel_oslo_med_bydelskode_hvis_geografiskTilknytning_er_bydel_i_Oslo() {
+        assertThat(GeografiskTilknytning.of("030106").fiedldName()).isEqualTo("bydel.oslo.030106");
+    }
+
+    @Test
+    public void fieldName_skal_bruke_fylke_hvis_geografiskTilknytning_består_av_fire_siffer() {
+        assertThat(GeografiskTilknytning.of("1234").fiedldName()).isEqualTo("fylke");
+    }
+
+    @Test
+    public void fieldName_skal_bruke_utland_hvis_geografiskTilknytning_består_av_tre_bokstaver() {
+        assertThat(GeografiskTilknytning.of("ABC").fiedldName()).isEqualTo("utland");
+    }
+
+    @Test
+    public void exception_skal_kastes_hvis_geografiskTilknytning_er_ukjent() {
+        try {
+            GeografiskTilknytning.of("12").fiedldName();
+        } catch (IllegalArgumentException e) {
+            assertThat(e.getMessage()).isEqualTo("Geografisk tilknytning har ukjent format: 12");
+        }
+    }
+}


### PR DESCRIPTION
Legger på metrikker for geografisk tilknytning, fordelt på utland, fylke, bydel utenom Oslo og hver enkelt bydel i Oslo.
I første omgang er dette for å kunne synliggjøre at vi har tilfeller som treffer bydel/NAV-kontor vi kan ta kontakt med.