### PR TITLE
[KAIZEN-0] Begrenser målingene av geografiks tilknytning

### DIFF
--- a/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/BrukersTilstand.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/BrukersTilstand.java
@@ -1,0 +1,51 @@
+package no.nav.fo.veilarbregistrering.registrering.bruker;
+
+import no.nav.fo.veilarbregistrering.oppfolging.Oppfolgingsstatus;
+import no.nav.fo.veilarbregistrering.sykemelding.SykmeldtInfoData;
+
+import static no.nav.fo.veilarbregistrering.registrering.bruker.RegistreringType.*;
+
+public class BrukersTilstand {
+
+    private final SykmeldtInfoData sykmeldtInfoData;
+    private final RegistreringType registreringType;
+    private final Oppfolgingsstatus oppfolgingStatusData;
+
+    BrukersTilstand(Oppfolgingsstatus oppfolgingStatusData, SykmeldtInfoData sykmeldtInfoData, RegistreringType registreringType) {
+        this.oppfolgingStatusData = oppfolgingStatusData;
+        this.sykmeldtInfoData = sykmeldtInfoData;
+        this.registreringType = registreringType;
+    }
+
+    public boolean kanReaktiveres() {
+        return REAKTIVERING.equals(registreringType);
+    }
+
+    public boolean erOrdinaerRegistrering() {
+        return ORDINAER_REGISTRERING.equals(registreringType);
+    }
+
+    public boolean erRegistrertSomSykmeldtMedArbeidsgiver() {
+        return SYKMELDT_REGISTRERING.equals(registreringType);
+    }
+
+    public boolean isUnderOppfolging() {
+        return oppfolgingStatusData.isUnderOppfolging();
+    }
+
+    public String getFormidlingsgruppe() {
+        return oppfolgingStatusData.getFormidlingsgruppe();
+    }
+
+    public RegistreringType getRegistreringstype() {
+        return registreringType;
+    }
+
+    public String getServicegruppe() {
+        return oppfolgingStatusData.getServicegruppe();
+    }
+
+    public String getMaksDato() {
+        return sykmeldtInfoData != null ? sykmeldtInfoData.maksDato : null;
+    }
+}


### PR DESCRIPTION
startRegistrering har behov for en del data, og deriblant geografisk tilknytning. Men vi ser at `hentStartRegistreringStatus` som brukes av startRegistrering, også brukes av 3 andre konsumenter som ikke har et like omfattende behov. Det medfører at vi henter og måler geografisk tilknytning langt oftere enn vi faktisk trenger/ønsker.

Starter samtidig med en retningsdreining hvor vi henter tilstanden til bruker som igjen kan være utgangspunktet når vi senere skal registrere en bruker ned etterpå.