### PR TITLE
[KAIZEN-0] Måler geografisk tilknytning sammen med tildeltenhetsnr

### DIFF
--- a/src/main/java/no/nav/fo/veilarbregistrering/config/ServiceBeansConfig.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/config/ServiceBeansConfig.java
@@ -9,6 +9,7 @@ import no.nav.fo.veilarbregistrering.bruker.PersonGateway;
 import no.nav.fo.veilarbregistrering.bruker.UserService;
 import no.nav.fo.veilarbregistrering.oppfolging.OppfolgingGateway;
 import no.nav.fo.veilarbregistrering.oppgave.OppgaveGateway;
+import no.nav.fo.veilarbregistrering.oppgave.OppgaveService;
 import no.nav.fo.veilarbregistrering.oppgave.resources.OppgaveResource;
 import no.nav.fo.veilarbregistrering.orgenhet.HentEnheterGateway;
 import no.nav.fo.veilarbregistrering.orgenhet.adapter.HentEnheterGatewayImpl;
@@ -122,13 +123,18 @@ public class ServiceBeansConfig {
     }
 
     @Bean
+    OppgaveService oppgaveService(OppgaveGateway oppgaveGateway, PersonGateway personGateway) {
+        return new OppgaveService(oppgaveGateway, personGateway);
+    }
+
+    @Bean
     OppgaveResource oppgaveResource(
             VeilarbAbacPepClient pepClient,
             UserService userService,
-            OppgaveGateway oppgaveGateway,
+            OppgaveService oppgaveService,
             AktorService aktorService
     ) {
-        return new OppgaveResource(pepClient, userService, oppgaveGateway, aktorService);
+        return new OppgaveResource(pepClient, userService, oppgaveService, aktorService);
     }
 
     @Bean

--- a/src/main/java/no/nav/fo/veilarbregistrering/oppgave/OppgaveMetrikker.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/oppgave/OppgaveMetrikker.java
@@ -1,0 +1,15 @@
+package no.nav.fo.veilarbregistrering.oppgave;
+
+import no.nav.fo.veilarbregistrering.bruker.GeografiskTilknytning;
+import no.nav.metrics.Event;
+import no.nav.metrics.MetricsFactory;
+
+class OppgaveMetrikker {
+
+    static void rapporter(GeografiskTilknytning geografiskTilknytning, String tildeltEnhetsnr) {
+        Event event = MetricsFactory.createEvent("arbeid.registrering.oppgave");
+        event.addTagToReport(geografiskTilknytning.fieldName(), geografiskTilknytning.value());
+        event.addTagToReport("tildeltEnhetsid", "".equals(tildeltEnhetsnr) ? "INGEN_VERDI" : tildeltEnhetsnr);
+        event.report();
+    }
+}

--- a/src/main/java/no/nav/fo/veilarbregistrering/oppgave/OppgaveService.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/oppgave/OppgaveService.java
@@ -1,0 +1,39 @@
+package no.nav.fo.veilarbregistrering.oppgave;
+
+import no.nav.fo.veilarbregistrering.bruker.Foedselsnummer;
+import no.nav.fo.veilarbregistrering.bruker.GeografiskTilknytning;
+import no.nav.fo.veilarbregistrering.bruker.PersonGateway;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Optional;
+
+public class OppgaveService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(OppgaveService.class);
+
+    private final OppgaveGateway oppgaveGateway;
+    private final PersonGateway personGateway;
+
+    public OppgaveService(OppgaveGateway oppgaveGateway, PersonGateway personGateway) {
+        this.oppgaveGateway = oppgaveGateway;
+        this.personGateway = personGateway;
+    }
+
+    public Oppgave opprettOppgave(String aktorId, Foedselsnummer foedselsnummer) {
+        Oppgave oppgave = oppgaveGateway.opprettOppgave(aktorId);
+
+        Optional<GeografiskTilknytning> geografiskTilknytning = Optional.empty();
+        try {
+            geografiskTilknytning = personGateway.hentGeografiskTilknytning(foedselsnummer);
+        } catch (RuntimeException e) {
+            LOG.warn("Henting av geografisk tilknytning feilet ifm. opprettelse av oppgave.", e);
+        }
+
+        geografiskTilknytning.ifPresent(gt -> {
+              OppgaveMetrikker.rapporter(gt, oppgave.getTildeltEnhetsnr());
+        });
+
+        return oppgave;
+    }
+}

--- a/src/main/java/no/nav/fo/veilarbregistrering/oppgave/resources/OppgaveResource.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/oppgave/resources/OppgaveResource.java
@@ -7,9 +7,10 @@ import no.nav.apiapp.feil.FeilType;
 import no.nav.apiapp.security.veilarbabac.Bruker;
 import no.nav.apiapp.security.veilarbabac.VeilarbAbacPepClient;
 import no.nav.dialogarena.aktor.AktorService;
+import no.nav.fo.veilarbregistrering.bruker.Foedselsnummer;
 import no.nav.fo.veilarbregistrering.bruker.UserService;
 import no.nav.fo.veilarbregistrering.oppgave.Oppgave;
-import no.nav.fo.veilarbregistrering.oppgave.OppgaveGateway;
+import no.nav.fo.veilarbregistrering.oppgave.OppgaveService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -28,7 +29,7 @@ public class OppgaveResource {
 
     private static final Logger LOG = LoggerFactory.getLogger(OppgaveResource.class);
 
-    private final OppgaveGateway oppgaveGateway;
+    private final OppgaveService oppgaveService;
     private final UserService userService;
     private final VeilarbAbacPepClient pepClient;
     private final AktorService aktorService;
@@ -36,12 +37,12 @@ public class OppgaveResource {
     public OppgaveResource(
             VeilarbAbacPepClient pepClient,
             UserService userService,
-            OppgaveGateway oppgaveGateway,
+            OppgaveService oppgaveService,
             AktorService aktorService
     ) {
         this.pepClient = pepClient;
         this.userService = userService;
-        this.oppgaveGateway = oppgaveGateway;
+        this.oppgaveService = oppgaveService;
         this.aktorService = aktorService;
     }
 
@@ -53,7 +54,9 @@ public class OppgaveResource {
 
         pepClient.sjekkSkrivetilgangTilBruker(bruker);
 
-        Oppgave oppgave = oppgaveGateway.opprettOppgave(bruker.getAktoerId());
+        Oppgave oppgave = oppgaveService.opprettOppgave(
+                bruker.getAktoerId(),
+                Foedselsnummer.of(bruker.getFoedselsnummer()));
 
         LOG.info("Oppgave {} ble opprettet og tildelt {}", oppgave.getId(), oppgave.getTildeltEnhetsnr());
 


### PR DESCRIPTION
Det er ønskelig å kunne måle match på geografisk tilknytning : tildeltEnhetsnr. De bør være 1:1, og unntak bør fanges opp.