### PR TITLE
[KAIZEN-0] Arbeidsforhold for dto-klasser for REST

### DIFF
--- a/src/main/java/no/nav/fo/veilarbregistrering/arbeidsforhold/resources/ArbeidsforholdDto.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/arbeidsforhold/resources/ArbeidsforholdDto.java
@@ -1,0 +1,16 @@
+package no.nav.fo.veilarbregistrering.arbeidsforhold.resources;
+
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+import java.time.LocalDate;
+
+@Data
+@Accessors(chain = true)
+public class ArbeidsforholdDto {
+    private String arbeidsgiverOrgnummer;
+    private String styrk;
+    private LocalDate fom;
+    private LocalDate tom;
+
+}

--- a/src/main/java/no/nav/fo/veilarbregistrering/arbeidsforhold/resources/ArbeidsforholdMapper.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/arbeidsforhold/resources/ArbeidsforholdMapper.java
@@ -1,0 +1,19 @@
+package no.nav.fo.veilarbregistrering.arbeidsforhold.resources;
+
+import no.nav.fo.veilarbregistrering.arbeidsforhold.Arbeidsforhold;
+
+class ArbeidsforholdMapper {
+
+    private ArbeidsforholdMapper() {
+    }
+
+    static ArbeidsforholdDto map(Arbeidsforhold arbeidsforhold) {
+        ArbeidsforholdDto arbeidsforholdDto = new ArbeidsforholdDto();
+        arbeidsforholdDto.setArbeidsgiverOrgnummer(arbeidsforhold.getArbeidsgiverOrgnummer());
+        arbeidsforholdDto.setStyrk(arbeidsforhold.getStyrk());
+        arbeidsforholdDto.setFom(arbeidsforhold.getFom());
+        arbeidsforholdDto.setTom(arbeidsforhold.getTom());
+
+        return arbeidsforholdDto;
+    }
+}

--- a/src/main/java/no/nav/fo/veilarbregistrering/arbeidsforhold/resources/ArbeidsforholdResource.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/arbeidsforhold/resources/ArbeidsforholdResource.java
@@ -7,7 +7,6 @@ import no.nav.apiapp.feil.FeilType;
 import no.nav.apiapp.security.veilarbabac.Bruker;
 import no.nav.apiapp.security.veilarbabac.VeilarbAbacPepClient;
 import no.nav.dialogarena.aktor.AktorService;
-import no.nav.fo.veilarbregistrering.arbeidsforhold.Arbeidsforhold;
 import no.nav.fo.veilarbregistrering.arbeidsforhold.ArbeidsforholdGateway;
 import no.nav.fo.veilarbregistrering.arbeidsforhold.FlereArbeidsforhold;
 import no.nav.fo.veilarbregistrering.bruker.UserService;
@@ -16,6 +15,8 @@ import org.springframework.stereotype.Component;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+
+import static no.nav.fo.veilarbregistrering.arbeidsforhold.resources.ArbeidsforholdMapper.map;
 
 @Component
 @Path("/")
@@ -43,12 +44,13 @@ public class ArbeidsforholdResource {
     @GET
     @Path("/sistearbeidsforhold")
     @ApiOperation(value = "Henter informasjon om brukers siste arbeidsforhold.")
-    public Arbeidsforhold hentSisteArbeidsforhold() {
+    public ArbeidsforholdDto hentSisteArbeidsforhold() {
         final Bruker bruker = hentBruker();
 
         pepClient.sjekkLesetilgangTilBruker(bruker);
+
         FlereArbeidsforhold flereArbeidsforhold = arbeidsforholdGateway.hentArbeidsforhold(bruker.getFoedselsnummer());
-        return flereArbeidsforhold.siste();
+        return map(flereArbeidsforhold.siste());
     }
 
     private Bruker hentBruker() {

--- a/src/test/java/no/nav/fo/veilarbregistrering/arbeidsforhold/resources/ArbeidsforholdMapperTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/arbeidsforhold/resources/ArbeidsforholdMapperTest.java
@@ -1,0 +1,31 @@
+package no.nav.fo.veilarbregistrering.arbeidsforhold.resources;
+
+import no.nav.fo.veilarbregistrering.arbeidsforhold.Arbeidsforhold;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
+public class ArbeidsforholdMapperTest {
+
+    @Test
+    public void skalMappeAlleVerdier() {
+        LocalDate fom = LocalDate.of(2017,12,1);
+        LocalDate tom = LocalDate.of(2017,12,30);
+        Arbeidsforhold arbeidsforhold = new Arbeidsforhold()
+                .setFom(fom)
+                .setTom(tom)
+                .setStyrk("STK")
+                .setArbeidsgiverOrgnummer("453542352");
+
+        ArbeidsforholdDto arbeidsforholdDto = ArbeidsforholdMapper.map(arbeidsforhold);
+
+        SoftAssertions softAssertions = new SoftAssertions();
+        softAssertions.assertThat(arbeidsforholdDto.getArbeidsgiverOrgnummer()).isEqualTo("453542352");
+        softAssertions.assertThat(arbeidsforholdDto.getStyrk()).isEqualTo("STK");
+        softAssertions.assertThat(arbeidsforholdDto.getFom()).isEqualTo(fom);
+        softAssertions.assertThat(arbeidsforholdDto.getTom()).isEqualTo(tom);
+
+        softAssertions.assertAll();
+    }
+}


### PR DESCRIPTION
Arbeidsforhold eksponerte den interne datamodellen rett ut. Vi ønsker å ha et tydeligere skille mellom intern og ekstern modell. Det gjør at vi lettere og tryggere kan gjøre endringer internt, som ikke vil knekke den ytre.