### PR TITLE
[KAIZEN-0] Tydeliggjør nullverdier med Optional

### DIFF
--- a/src/main/java/no/nav/fo/veilarbregistrering/oppfolging/Formidlingsgruppe.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/oppfolging/Formidlingsgruppe.java
@@ -1,4 +1,4 @@
-package no.nav.fo.veilarbregistrering.registrering.bruker;
+package no.nav.fo.veilarbregistrering.oppfolging;
 
 import no.nav.fo.veilarbregistrering.metrics.Metric;
 
@@ -8,14 +8,14 @@ public class Formidlingsgruppe implements Metric {
 
     private final String formidlingsgruppe;
 
-    static Formidlingsgruppe of(String formidlingsgruppe) {
-        return formidlingsgruppe != null ? new Formidlingsgruppe(formidlingsgruppe) : new NullableFormidlingsgruppe();
+    public static Formidlingsgruppe of(String formidlingsgruppe) {
+        return new Formidlingsgruppe(formidlingsgruppe);
     }
 
     private Formidlingsgruppe(String formidlingsgruppe) {
         if (formidlingsgruppe == null) {
             throw new IllegalArgumentException("Formidlingsgruppe skal ikke kunne være null. " +
-                    "Hvis null, skal NullableFormdlingsgruppe brukes i stedet.");
+                    "Hvis null, kan NullableFormdlingsgruppe brukes i stedet.");
         }
         this.formidlingsgruppe = formidlingsgruppe;
     }
@@ -42,6 +42,10 @@ public class Formidlingsgruppe implements Metric {
         return Objects.equals(formidlingsgruppe, that.formidlingsgruppe);
     }
 
+    public static NullableFormidlingsgruppe nullable() {
+        return new NullableFormidlingsgruppe();
+    }
+
     @Override
     public int hashCode() {
         return Objects.hash(formidlingsgruppe);
@@ -52,8 +56,8 @@ public class Formidlingsgruppe implements Metric {
      */
     public static class NullableFormidlingsgruppe extends Formidlingsgruppe {
 
-        NullableFormidlingsgruppe() {
-            super("UKJENT");
+        private NullableFormidlingsgruppe() {
+            super("INGEN_VERDI");
         }
 
         @Override

--- a/src/main/java/no/nav/fo/veilarbregistrering/oppfolging/Oppfolgingsstatus.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/oppfolging/Oppfolgingsstatus.java
@@ -1,16 +1,54 @@
 package no.nav.fo.veilarbregistrering.oppfolging;
 
-public interface Oppfolgingsstatus {
+import java.util.Optional;
 
-    Boolean getKanReaktiveres();
+import static java.util.Optional.ofNullable;
 
-    Boolean getErSykmeldtMedArbeidsgiver();
+public class Oppfolgingsstatus {
 
-    boolean isUnderOppfolging();
+    private boolean underOppfolging;
+    private Boolean kanReaktiveres;
+    private Boolean erSykmeldtMedArbeidsgiver;
+    private Formidlingsgruppe formidlingsgruppe;
+    private Servicegruppe servicegruppe;
+    private Rettighetsgruppe rettighetsgruppe;
 
-    String getFormidlingsgruppe();
+    public Oppfolgingsstatus(
+            boolean underOppfolging,
+            Boolean kanReaktiveres,
+            Boolean erSykmeldtMedArbeidsgiver,
+            Formidlingsgruppe formidlingsgruppe,
+            Servicegruppe servicegruppe,
+            Rettighetsgruppe rettighetsgruppe) {
+        this.underOppfolging = underOppfolging;
+        this.kanReaktiveres = kanReaktiveres;
+        this.erSykmeldtMedArbeidsgiver = erSykmeldtMedArbeidsgiver;
+        this.formidlingsgruppe = formidlingsgruppe;
+        this.servicegruppe = servicegruppe;
+        this.rettighetsgruppe = rettighetsgruppe;
+    }
 
-    String getServicegruppe();
+    public Optional<Boolean> getKanReaktiveres() {
+        return ofNullable(kanReaktiveres);
+    }
 
-    String getRettighetsgruppe();
+    public Optional<Boolean> getErSykmeldtMedArbeidsgiver() {
+        return ofNullable(erSykmeldtMedArbeidsgiver);
+    }
+
+    public boolean isUnderOppfolging() {
+        return underOppfolging;
+    }
+
+    public Optional<Formidlingsgruppe> getFormidlingsgruppe() {
+        return ofNullable(formidlingsgruppe);
+    }
+
+    public Optional<Servicegruppe> getServicegruppe() {
+        return ofNullable(servicegruppe);
+    }
+
+    public Optional<Rettighetsgruppe> getRettighetsgruppe() {
+        return ofNullable(rettighetsgruppe);
+    }
 }

--- a/src/main/java/no/nav/fo/veilarbregistrering/oppfolging/Rettighetsgruppe.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/oppfolging/Rettighetsgruppe.java
@@ -1,4 +1,4 @@
-package no.nav.fo.veilarbregistrering.registrering.bruker;
+package no.nav.fo.veilarbregistrering.oppfolging;
 
 import no.nav.fo.veilarbregistrering.metrics.Metric;
 
@@ -8,14 +8,14 @@ public class Rettighetsgruppe implements Metric {
 
     private final String rettighetsgruppe;
 
-    static Rettighetsgruppe of(String rettighetsgruppe) {
-        return rettighetsgruppe != null ? new Rettighetsgruppe(rettighetsgruppe) : new NullableRettighetsgruppe();
+    public static Rettighetsgruppe of(String rettighetsgruppe) {
+        return new Rettighetsgruppe(rettighetsgruppe);
     }
 
     private Rettighetsgruppe(String rettighetsgruppe) {
         if (rettighetsgruppe == null) {
             throw new IllegalArgumentException("Rettighetsgruppe skal ikke kunne være null. " +
-                    "Hvis null, skal NullableRettighetsgruppe brukes i stedet.");
+                    "Hvis null, kan NullableRettighetsgruppe brukes i stedet.");
         }
         this.rettighetsgruppe = rettighetsgruppe;
     }
@@ -47,13 +47,17 @@ public class Rettighetsgruppe implements Metric {
         return Objects.hash(rettighetsgruppe);
     }
 
+    public static NullableRettighetsgruppe nullable() {
+        return new NullableRettighetsgruppe();
+    }
+
     /**
      * <code>Null object</code> is an object with no referenced value or with defined neutral ("null") behavior
      */
     public static class NullableRettighetsgruppe extends Rettighetsgruppe {
 
-        NullableRettighetsgruppe() {
-            super("UKJENT");
+        private NullableRettighetsgruppe() {
+            super("INGEN_VERDI");
         }
 
         @Override

--- a/src/main/java/no/nav/fo/veilarbregistrering/oppfolging/Servicegruppe.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/oppfolging/Servicegruppe.java
@@ -1,4 +1,4 @@
-package no.nav.fo.veilarbregistrering.registrering.bruker;
+package no.nav.fo.veilarbregistrering.oppfolging;
 
 import no.nav.fo.veilarbregistrering.metrics.Metric;
 
@@ -8,14 +8,14 @@ public class Servicegruppe implements Metric {
 
     private final String servicegruppe;
 
-    static Servicegruppe of(String servicegruppe) {
-        return servicegruppe != null ? new Servicegruppe(servicegruppe) : new NullableServicegruppe();
+    public static Servicegruppe of(String servicegruppe) {
+        return new Servicegruppe(servicegruppe);
     }
 
     private Servicegruppe(String servicegruppe) {
         if (servicegruppe == null) {
             throw new IllegalArgumentException("Servicegruppe skal ikke kunne være null. " +
-                    "Hvis null, skal NullableServicegruppe brukes i stedet.");
+                    "Hvis null, kan NullableServicegruppe brukes i stedet.");
         }
         this.servicegruppe = servicegruppe;
     }
@@ -47,13 +47,17 @@ public class Servicegruppe implements Metric {
         return Objects.hash(servicegruppe);
     }
 
+    public static NullableServicegruppe nullable() {
+        return new NullableServicegruppe();
+    }
+
     /**
      * <code>Null object</code> is an object with no referenced value or with defined neutral ("null") behavior
      */
     public static class NullableServicegruppe extends Servicegruppe {
 
-        NullableServicegruppe() {
-            super("UKJENT");
+        private NullableServicegruppe() {
+            super("INGEN_VERDI");
         }
 
         @Override

--- a/src/main/java/no/nav/fo/veilarbregistrering/oppfolging/adapter/OppfolgingGatewayImpl.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/oppfolging/adapter/OppfolgingGatewayImpl.java
@@ -4,6 +4,9 @@ import no.nav.fo.veilarbregistrering.oppfolging.OppfolgingGateway;
 import no.nav.fo.veilarbregistrering.oppfolging.Oppfolgingsstatus;
 import no.nav.fo.veilarbregistrering.profilering.Innsatsgruppe;
 import no.nav.fo.veilarbregistrering.besvarelse.Besvarelse;
+import no.nav.fo.veilarbregistrering.oppfolging.Formidlingsgruppe;
+import no.nav.fo.veilarbregistrering.oppfolging.Rettighetsgruppe;
+import no.nav.fo.veilarbregistrering.oppfolging.Servicegruppe;
 
 public class OppfolgingGatewayImpl implements OppfolgingGateway {
 
@@ -15,7 +18,22 @@ public class OppfolgingGatewayImpl implements OppfolgingGateway {
 
     @Override
     public Oppfolgingsstatus hentOppfolgingsstatus(String fodselsnummer) {
-        return oppfolgingClient.hentOppfolgingsstatus(fodselsnummer);
+        OppfolgingStatusData oppfolgingStatusData = oppfolgingClient.hentOppfolgingsstatus(fodselsnummer);
+
+        return map(oppfolgingStatusData);
+    }
+
+    private static Oppfolgingsstatus map(OppfolgingStatusData oppfolgingStatusData) {
+        return new Oppfolgingsstatus(
+                oppfolgingStatusData.isUnderOppfolging(),
+                oppfolgingStatusData.getKanReaktiveres(),
+                oppfolgingStatusData.getErSykmeldtMedArbeidsgiver(),
+                oppfolgingStatusData.getFormidlingsgruppe() != null ?
+                        Formidlingsgruppe.of(oppfolgingStatusData.getFormidlingsgruppe()) : null,
+                oppfolgingStatusData.getServicegruppe() != null ?
+                        Servicegruppe.of(oppfolgingStatusData.getServicegruppe()) : null,
+                oppfolgingStatusData.getRettighetsgruppe() != null ?
+                        Rettighetsgruppe.of(oppfolgingStatusData.getRettighetsgruppe()) : null);
     }
 
     @Override

--- a/src/main/java/no/nav/fo/veilarbregistrering/oppfolging/adapter/OppfolgingStatusData.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/oppfolging/adapter/OppfolgingStatusData.java
@@ -5,14 +5,13 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.Wither;
-import no.nav.fo.veilarbregistrering.oppfolging.Oppfolgingsstatus;
 
 @Wither
 @Data
 @ToString
 @NoArgsConstructor
 @AllArgsConstructor
-public class OppfolgingStatusData implements Oppfolgingsstatus {
+public class OppfolgingStatusData {
     public boolean underOppfolging;
     public Boolean kanReaktiveres;
     public Boolean erSykmeldtMedArbeidsgiver;

--- a/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/BrukersTilstand.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/BrukersTilstand.java
@@ -2,10 +2,14 @@ package no.nav.fo.veilarbregistrering.registrering.bruker;
 
 import no.nav.fo.veilarbregistrering.metrics.HasMetrics;
 import no.nav.fo.veilarbregistrering.metrics.Metric;
+import no.nav.fo.veilarbregistrering.oppfolging.Formidlingsgruppe;
 import no.nav.fo.veilarbregistrering.oppfolging.Oppfolgingsstatus;
+import no.nav.fo.veilarbregistrering.oppfolging.Rettighetsgruppe;
+import no.nav.fo.veilarbregistrering.oppfolging.Servicegruppe;
 import no.nav.fo.veilarbregistrering.sykemelding.SykmeldtInfoData;
 
 import java.util.List;
+import java.util.Optional;
 
 import static java.util.Arrays.asList;
 import static no.nav.fo.veilarbregistrering.registrering.bruker.RegistreringType.*;
@@ -16,8 +20,8 @@ public class BrukersTilstand implements HasMetrics {
     private final RegistreringType registreringType;
     private final Oppfolgingsstatus oppfolgingStatusData;
 
-    BrukersTilstand(Oppfolgingsstatus oppfolgingStatusData, SykmeldtInfoData sykmeldtInfoData, RegistreringType registreringType) {
-        this.oppfolgingStatusData = oppfolgingStatusData;
+    public BrukersTilstand(Oppfolgingsstatus Oppfolgingsstatus, SykmeldtInfoData sykmeldtInfoData, RegistreringType registreringType) {
+        this.oppfolgingStatusData = Oppfolgingsstatus;
         this.sykmeldtInfoData = sykmeldtInfoData;
         this.registreringType = registreringType;
     }
@@ -42,16 +46,16 @@ public class BrukersTilstand implements HasMetrics {
         return registreringType;
     }
 
-    public Formidlingsgruppe getFormidlingsgruppe() {
-        return Formidlingsgruppe.of(oppfolgingStatusData.getFormidlingsgruppe());
+    public Optional<Formidlingsgruppe> getFormidlingsgruppe() {
+        return oppfolgingStatusData.getFormidlingsgruppe();
     }
 
-    public Servicegruppe getServicegruppe() {
-        return Servicegruppe.of(oppfolgingStatusData.getServicegruppe());
+    public Optional<Servicegruppe> getServicegruppe() {
+        return oppfolgingStatusData.getServicegruppe();
     }
 
-    public Rettighetsgruppe getRettighetsgruppe() {
-        return Rettighetsgruppe.of(oppfolgingStatusData.getRettighetsgruppe());
+    public Optional<Rettighetsgruppe> getRettighetsgruppe() {
+        return oppfolgingStatusData.getRettighetsgruppe();
     }
 
     public String getMaksDato() {
@@ -60,6 +64,10 @@ public class BrukersTilstand implements HasMetrics {
 
     @Override
     public List<Metric> metrics() {
-        return asList(getFormidlingsgruppe(), getRettighetsgruppe(), getServicegruppe(), registreringType);
+        return asList(
+                getFormidlingsgruppe().orElse(Formidlingsgruppe.nullable()),
+                getRettighetsgruppe().orElse(Rettighetsgruppe.nullable()),
+                getServicegruppe().orElse(Servicegruppe.nullable()),
+                registreringType);
     }
 }

--- a/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/RegistreringType.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/RegistreringType.java
@@ -4,20 +4,18 @@ import no.nav.fo.veilarbregistrering.metrics.Metric;
 import no.nav.fo.veilarbregistrering.oppfolging.Oppfolgingsstatus;
 import no.nav.fo.veilarbregistrering.sykemelding.SykmeldtInfoData;
 
-import static java.util.Optional.ofNullable;
-
 public enum RegistreringType implements Metric {
     REAKTIVERING, SPERRET, ALLEREDE_REGISTRERT, SYKMELDT_REGISTRERING, ORDINAER_REGISTRERING;
 
     protected static RegistreringType beregnRegistreringType(Oppfolgingsstatus oppfolgingsstatus, SykmeldtInfoData sykeforloepMetaData) {
-        if (oppfolgingsstatus.isUnderOppfolging() && !ofNullable(oppfolgingsstatus.getKanReaktiveres()).orElse(false)) {
+        if (oppfolgingsstatus.isUnderOppfolging() && !oppfolgingsstatus.getKanReaktiveres().orElse(false)) {
             return ALLEREDE_REGISTRERT;
-        } else if (ofNullable(oppfolgingsstatus.getKanReaktiveres()).orElse(false)) {
+        } else if (oppfolgingsstatus.getKanReaktiveres().orElse(false)) {
             return REAKTIVERING;
-        } else if (ofNullable(oppfolgingsstatus.getErSykmeldtMedArbeidsgiver()).orElse(false)
+        } else if (oppfolgingsstatus.getErSykmeldtMedArbeidsgiver().orElse(false)
                 && erSykmeldtMedArbeidsgiverOver39Uker(sykeforloepMetaData)) {
             return SYKMELDT_REGISTRERING;
-        } else if (ofNullable(oppfolgingsstatus.getErSykmeldtMedArbeidsgiver()).orElse(false)
+        } else if (oppfolgingsstatus.getErSykmeldtMedArbeidsgiver().orElse(false)
                 && !erSykmeldtMedArbeidsgiverOver39Uker(sykeforloepMetaData)) {
             return SPERRET;
         } else {

--- a/src/main/java/no/nav/fo/veilarbregistrering/registrering/resources/StartRegistreringStatusDtoMapper.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/registrering/resources/StartRegistreringStatusDtoMapper.java
@@ -1,0 +1,33 @@
+package no.nav.fo.veilarbregistrering.registrering.resources;
+
+import no.nav.fo.veilarbregistrering.bruker.GeografiskTilknytning;
+import no.nav.fo.veilarbregistrering.oppfolging.Formidlingsgruppe;
+import no.nav.fo.veilarbregistrering.oppfolging.Rettighetsgruppe;
+import no.nav.fo.veilarbregistrering.oppfolging.Servicegruppe;
+import no.nav.fo.veilarbregistrering.registrering.bruker.BrukersTilstand;
+
+import java.util.Optional;
+
+public class StartRegistreringStatusDtoMapper {
+
+    public static StartRegistreringStatusDto map(
+            BrukersTilstand brukersTilstand,
+            Optional<GeografiskTilknytning> muligGeografiskTilknytning,
+            Boolean oppfyllerBetingelseOmArbeidserfaring) {
+
+        return new StartRegistreringStatusDto()
+                .setUnderOppfolging(brukersTilstand.isUnderOppfolging())
+                .setRegistreringType(brukersTilstand.getRegistreringstype())
+                .setErSykmeldtMedArbeidsgiver(brukersTilstand.erRegistrertSomSykmeldtMedArbeidsgiver())
+                .setMaksDato(brukersTilstand.getMaksDato())
+                .setJobbetSeksAvTolvSisteManeder(oppfyllerBetingelseOmArbeidserfaring)
+                .setFormidlingsgruppe(brukersTilstand.getFormidlingsgruppe()
+                        .orElse(Formidlingsgruppe.nullable()).stringValue())
+                .setServicegruppe(brukersTilstand.getServicegruppe()
+                        .orElse(Servicegruppe.nullable()).stringValue())
+                .setRettighetsgruppe(brukersTilstand.getRettighetsgruppe()
+                        .orElse(Rettighetsgruppe.nullable()).stringValue())
+                .setGeografiskTilknytning(muligGeografiskTilknytning.map(GeografiskTilknytning::stringValue)
+                        .orElse(null));
+    }
+}

--- a/src/test/java/no/nav/fo/veilarbregistrering/registrering/bruker/FormidlingsgruppeTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/registrering/bruker/FormidlingsgruppeTest.java
@@ -1,31 +1,32 @@
 package no.nav.fo.veilarbregistrering.registrering.bruker;
 
-import org.junit.jupiter.api.Test;
+import no.nav.fo.veilarbregistrering.oppfolging.Formidlingsgruppe;
+import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class FormidlingsgruppeTest {
 
-    @Test
-    public void null_skal_gi_nullableFormidlingsgruppe() {
-        assertThat(Formidlingsgruppe.of(null)).isInstanceOf(Formidlingsgruppe.NullableFormidlingsgruppe.class);
+    @Test(expected = IllegalArgumentException.class)
+    public void null_skal_gi_illegalArgumentException() {
+        assertThat(Formidlingsgruppe.of(null));
     }
 
     @Test
     public void stringValue_for_nullableFormidlingsgruppe_skal_gi_null() {
-        Formidlingsgruppe formidlingsgruppe = Formidlingsgruppe.of(null);
+        Formidlingsgruppe formidlingsgruppe = Formidlingsgruppe.nullable();
         assertThat(formidlingsgruppe.stringValue()).isNull();
     }
 
     @Test
     public void value_for_nullableFormidlingsgruppe_skal_gi_null() {
-        Formidlingsgruppe formidlingsgruppe = Formidlingsgruppe.of(null);
+        Formidlingsgruppe formidlingsgruppe = Formidlingsgruppe.nullable();
         assertThat(formidlingsgruppe.value()).isEqualTo("INGEN_VERDI");
     }
 
     @Test
     public void formidlingsgruppe_for_nullableFormidlingsgruppe_skal_gi_null() {
-        Formidlingsgruppe formidlingsgruppe = Formidlingsgruppe.of(null);
+        Formidlingsgruppe formidlingsgruppe = Formidlingsgruppe.nullable();
         assertThat(formidlingsgruppe.fieldName()).isEqualTo("formidlingsgruppe");
     }
 }

--- a/src/test/java/no/nav/fo/veilarbregistrering/registrering/resources/StartRegistreringStatusDtoMapperTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/registrering/resources/StartRegistreringStatusDtoMapperTest.java
@@ -1,0 +1,81 @@
+package no.nav.fo.veilarbregistrering.registrering.resources;
+
+import no.nav.fo.veilarbregistrering.bruker.GeografiskTilknytning;
+import no.nav.fo.veilarbregistrering.oppfolging.Formidlingsgruppe;
+import no.nav.fo.veilarbregistrering.oppfolging.Oppfolgingsstatus;
+import no.nav.fo.veilarbregistrering.oppfolging.Rettighetsgruppe;
+import no.nav.fo.veilarbregistrering.oppfolging.Servicegruppe;
+import no.nav.fo.veilarbregistrering.registrering.bruker.BrukersTilstand;
+import no.nav.fo.veilarbregistrering.sykemelding.SykmeldtInfoData;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.Test;
+
+import java.util.Optional;
+
+import static no.nav.fo.veilarbregistrering.registrering.bruker.RegistreringType.ORDINAER_REGISTRERING;
+import static no.nav.fo.veilarbregistrering.registrering.bruker.RegistreringType.SYKMELDT_REGISTRERING;
+
+public class StartRegistreringStatusDtoMapperTest {
+
+    @Test
+    public void map_skal_håndtere_null_verdier() {
+        Oppfolgingsstatus oppfolgingsstatus = new Oppfolgingsstatus(
+                false,
+                null,
+                null,
+                null,
+                null,
+                null);
+        SykmeldtInfoData sykmeldtInfoData = new SykmeldtInfoData(null, false);
+        BrukersTilstand brukersTilstand = new BrukersTilstand(oppfolgingsstatus, sykmeldtInfoData, ORDINAER_REGISTRERING);
+
+        StartRegistreringStatusDto dto = StartRegistreringStatusDtoMapper.map(
+                brukersTilstand,
+                Optional.empty(),
+                false);
+
+        SoftAssertions softAssertions = new SoftAssertions();
+        softAssertions.assertThat(dto.getRegistreringType()).isEqualTo(ORDINAER_REGISTRERING);
+        softAssertions.assertThat(dto.getGeografiskTilknytning()).isNull();
+        softAssertions.assertThat(dto.getJobbetSeksAvTolvSisteManeder()).isFalse();
+        softAssertions.assertThat(dto.isErSykmeldtMedArbeidsgiver()).isFalse();
+        softAssertions.assertThat(dto.isUnderOppfolging()).isFalse();
+        softAssertions.assertThat(dto.getFormidlingsgruppe()).isNull();
+        softAssertions.assertThat(dto.getMaksDato()).isNull();
+        softAssertions.assertThat(dto.getRettighetsgruppe()).isNull();
+        softAssertions.assertThat(dto.getServicegruppe()).isNull();
+
+        softAssertions.assertAll();
+    }
+
+    @Test
+    public void map_skal_håndtere_verdi_i_alle_felter() {
+        Oppfolgingsstatus oppfolgingsstatus = new Oppfolgingsstatus(
+                true,
+                true,
+                true,
+                Formidlingsgruppe.of("IARBS"),
+                Servicegruppe.of("SERV"),
+                Rettighetsgruppe.of("AAP"));
+        SykmeldtInfoData sykmeldtInfoData = new SykmeldtInfoData("01122019", true);
+        BrukersTilstand brukersTilstand = new BrukersTilstand(oppfolgingsstatus, sykmeldtInfoData, SYKMELDT_REGISTRERING);
+
+        StartRegistreringStatusDto dto = StartRegistreringStatusDtoMapper.map(
+                brukersTilstand,
+                Optional.of(GeografiskTilknytning.of("030109")),
+                true);
+
+        SoftAssertions softAssertions = new SoftAssertions();
+        softAssertions.assertThat(dto.getRegistreringType()).isEqualTo(SYKMELDT_REGISTRERING);
+        softAssertions.assertThat(dto.getGeografiskTilknytning()).isEqualTo("030109");
+        softAssertions.assertThat(dto.getJobbetSeksAvTolvSisteManeder()).isTrue();
+        softAssertions.assertThat(dto.isErSykmeldtMedArbeidsgiver()).isTrue();
+        softAssertions.assertThat(dto.isUnderOppfolging()).isTrue();
+        softAssertions.assertThat(dto.getFormidlingsgruppe()).isEqualTo("IARBS");
+        softAssertions.assertThat(dto.getMaksDato()).isEqualTo("01122019");
+        softAssertions.assertThat(dto.getRettighetsgruppe()).isEqualTo("AAP");
+        softAssertions.assertThat(dto.getServicegruppe()).isEqualTo("SERV");
+
+        softAssertions.assertAll();
+    }
+}


### PR DESCRIPTION
Introduserer Optional for Oppfolgingsstatus for å tydeliggjøre nullverdier.
Rydder samtidig litt opp i tilhørende kode, og skiller ut mapping i egen klasse for lettere testing. Da kan også mapping plasseres sammen med Controller.