### PR TITLE
Forsøker å fikse feil ifm. KafkaConfig

### DIFF
--- a/src/main/java/no/nav/fo/veilarbregistrering/config/ApplicationConfig.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/config/ApplicationConfig.java
@@ -7,6 +7,7 @@ import no.nav.fo.veilarbregistrering.arbeidsforhold.adapter.AAregServiceWSConfig
 import no.nav.fo.veilarbregistrering.bruker.adapter.PersonGatewayConfig;
 import no.nav.fo.veilarbregistrering.db.DataSourceHelsesjekk;
 import no.nav.fo.veilarbregistrering.db.MigrationUtils;
+import no.nav.fo.veilarbregistrering.kafka.KafkaConfig;
 import no.nav.fo.veilarbregistrering.oppfolging.adapter.OppfolgingClientHelseSjekk;
 import no.nav.fo.veilarbregistrering.oppfolging.adapter.OppfolgingGatewayConfig;
 import no.nav.fo.veilarbregistrering.oppgave.adapter.OppgaveGatewayConfig;
@@ -26,6 +27,7 @@ import javax.servlet.ServletContext;
         ServiceBeansConfig.class,
         DatabaseConfig.class,
         DataSourceHelsesjekk.class,
+        KafkaConfig.class,
         AktorConfig.class,
         PepConfig.class,
         OrganisasjonEnhetV2Config.class,

--- a/src/main/java/no/nav/fo/veilarbregistrering/config/ServiceBeansConfig.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/config/ServiceBeansConfig.java
@@ -9,8 +9,8 @@ import no.nav.fo.veilarbregistrering.bruker.PersonGateway;
 import no.nav.fo.veilarbregistrering.bruker.UserService;
 import no.nav.fo.veilarbregistrering.kafka.KafkaProducer;
 import no.nav.fo.veilarbregistrering.oppfolging.OppfolgingGateway;
-import no.nav.fo.veilarbregistrering.oppgave.OppgaveGateway;
 import no.nav.fo.veilarbregistrering.oppgave.KontaktBrukerHenvendelseProducer;
+import no.nav.fo.veilarbregistrering.oppgave.OppgaveGateway;
 import no.nav.fo.veilarbregistrering.oppgave.OppgaveService;
 import no.nav.fo.veilarbregistrering.oppgave.resources.OppgaveResource;
 import no.nav.fo.veilarbregistrering.orgenhet.HentEnheterGateway;
@@ -38,6 +38,7 @@ import org.springframework.jdbc.core.JdbcTemplate;
 
 import javax.inject.Provider;
 import javax.servlet.http.HttpServletRequest;
+import java.util.Properties;
 
 @Configuration
 public class ServiceBeansConfig {
@@ -48,8 +49,8 @@ public class ServiceBeansConfig {
     }
 
     @Bean
-    KafkaProducer kafkaProducer(UnleashService unleashService) {
-        return new KafkaProducer(unleashService);
+    KafkaProducer kafkaProducer(Properties kafkaProperties, UnleashService unleashService) {
+        return new KafkaProducer(kafkaProperties, unleashService);
     }
 
     @Bean

--- a/src/main/java/no/nav/fo/veilarbregistrering/kafka/KafkaConfig.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/kafka/KafkaConfig.java
@@ -7,6 +7,8 @@ import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.config.SaslConfigs;
 import org.apache.kafka.common.config.SslConfigs;
 import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 
 import java.io.File;
 import java.util.Properties;
@@ -14,9 +16,11 @@ import java.util.Properties;
 import static java.lang.System.getProperty;
 import static java.lang.System.getenv;
 
-class KafkaConfig {
+@Configuration
+public class KafkaConfig {
 
-    static Properties getKafkaConfig() {
+    @Bean
+    Properties kafkaProperties() {
         Properties properties = new Properties();
         properties.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, getenv("KAFKA_SERVERS"));
         properties.put(KafkaAvroSerializerConfig.SCHEMA_REGISTRY_URL_CONFIG, getenv("KAFKA_SCHEMA"));

--- a/src/main/java/no/nav/fo/veilarbregistrering/kafka/KafkaProducer.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/kafka/KafkaProducer.java
@@ -10,6 +10,7 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Properties;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -25,10 +26,10 @@ public class KafkaProducer implements ArbeidssokerRegistrertProducer, KontaktBru
 
     private final UnleashService unleashService;
 
-    public KafkaProducer(UnleashService unleashService) {
+    public KafkaProducer(Properties kafkaProperties, UnleashService unleashService) {
         this.unleashService = unleashService;
-        this.producer = new org.apache.kafka.clients.producer.KafkaProducer(KafkaConfig.getKafkaConfig());
-        this.henvendelseProducer = new org.apache.kafka.clients.producer.KafkaProducer(KafkaConfig.getKafkaConfig());
+        this.producer = new org.apache.kafka.clients.producer.KafkaProducer(kafkaProperties);
+        this.henvendelseProducer = new org.apache.kafka.clients.producer.KafkaProducer(kafkaProperties);
     }
 
     @Override


### PR DESCRIPTION
Ser ifm. oppstart av appen, at det logges en feil knyttet til InstanceAlreadyExistsException.
Mer konkret `javax.management.InstanceAlreadyExistsException: kafka.producer:type=app-info,id=paw-veilarbregistrering`. Mistanken går i retning av at KafkaConfig ikke er en Singleton/Bean, men en static metode som kalles på nytt for hver KafkaProducer som opprettes.Forsøker nå i stedet å gjøre KafkaConfig om til en Configuration, hvor Properties blir en Bean, som så kan injectes og vi kan unngå å registrer appen flere ganger.