### PR TITLE
Retter en feil i mapping av ErSykmeldtMedArbeidsgiver

### DIFF
--- a/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/BrukerRegistreringService.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/BrukerRegistreringService.java
@@ -32,8 +32,7 @@ import static no.nav.fo.veilarbregistrering.metrics.Metrics.Event.PROFILERING_EV
 import static no.nav.fo.veilarbregistrering.metrics.Metrics.Event.START_REGISTRERING_EVENT;
 import static no.nav.fo.veilarbregistrering.metrics.Metrics.reportTags;
 import static no.nav.fo.veilarbregistrering.registrering.bruker.FnrUtils.utledAlderForFnr;
-import static no.nav.fo.veilarbregistrering.registrering.bruker.RegistreringType.ORDINAER_REGISTRERING;
-import static no.nav.fo.veilarbregistrering.registrering.bruker.RegistreringType.beregnRegistreringType;
+import static no.nav.fo.veilarbregistrering.registrering.bruker.RegistreringType.*;
 import static no.nav.fo.veilarbregistrering.registrering.bruker.ValideringUtils.validerBrukerRegistrering;
 import static no.nav.fo.veilarbregistrering.registrering.resources.StartRegistreringStatusDtoMapper.map;
 
@@ -254,7 +253,7 @@ public class BrukerRegistreringService {
 
         BrukersTilstand brukersTilstand = hentBrukersTilstand(bruker.getFoedselsnummer());
 
-        if (!brukersTilstand.erRegistrertSomSykmeldtMedArbeidsgiver()) {
+        if (brukersTilstand.ikkeErSykemeldtRegistrering()) {
             throw new RuntimeException("Bruker kan ikke registreres.");
         }
 

--- a/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/BrukerRegistreringService.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/BrukerRegistreringService.java
@@ -101,7 +101,7 @@ public class BrukerRegistreringService {
             throw new RuntimeException("Bruker allerede under oppfølging.");
         }
 
-        if (!brukersTilstand.erOrdinaerRegistrering()) {
+        if (brukersTilstand.ikkeErOrdinaerRegistrering()) {
             throw new RuntimeException("Brukeren kan ikke registreres. Krever registreringtypen ordinær.");
         }
 

--- a/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/BrukersTilstand.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/BrukersTilstand.java
@@ -34,8 +34,12 @@ public class BrukersTilstand implements HasMetrics {
         return ORDINAER_REGISTRERING.equals(registreringType);
     }
 
-    public boolean erRegistrertSomSykmeldtMedArbeidsgiver() {
-        return SYKMELDT_REGISTRERING.equals(registreringType);
+    public boolean ikkeErSykemeldtRegistrering() {
+        return !this.equals(SYKMELDT_REGISTRERING);
+    }
+
+    public boolean isErSykmeldtMedArbeidsgiver() {
+        return oppfolgingStatusData.getErSykmeldtMedArbeidsgiver().orElse(false);
     }
 
     public boolean isUnderOppfolging() {

--- a/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/BrukersTilstand.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/BrukersTilstand.java
@@ -30,12 +30,12 @@ public class BrukersTilstand implements HasMetrics {
         return REAKTIVERING.equals(registreringType);
     }
 
-    public boolean erOrdinaerRegistrering() {
-        return ORDINAER_REGISTRERING.equals(registreringType);
+    public boolean ikkeErOrdinaerRegistrering() {
+        return !ORDINAER_REGISTRERING.equals(registreringType);
     }
 
     public boolean ikkeErSykemeldtRegistrering() {
-        return !this.equals(SYKMELDT_REGISTRERING);
+        return !SYKMELDT_REGISTRERING.equals(registreringType);
     }
 
     public boolean isErSykmeldtMedArbeidsgiver() {

--- a/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/RegistreringType.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/RegistreringType.java
@@ -10,14 +10,16 @@ public enum RegistreringType implements Metric {
     protected static RegistreringType beregnRegistreringType(Oppfolgingsstatus oppfolgingsstatus, SykmeldtInfoData sykeforloepMetaData) {
         if (oppfolgingsstatus.isUnderOppfolging() && !oppfolgingsstatus.getKanReaktiveres().orElse(false)) {
             return ALLEREDE_REGISTRERT;
+
         } else if (oppfolgingsstatus.getKanReaktiveres().orElse(false)) {
             return REAKTIVERING;
-        } else if (oppfolgingsstatus.getErSykmeldtMedArbeidsgiver().orElse(false)
-                && erSykmeldtMedArbeidsgiverOver39Uker(sykeforloepMetaData)) {
-            return SYKMELDT_REGISTRERING;
-        } else if (oppfolgingsstatus.getErSykmeldtMedArbeidsgiver().orElse(false)
-                && !erSykmeldtMedArbeidsgiverOver39Uker(sykeforloepMetaData)) {
-            return SPERRET;
+
+        } else if (oppfolgingsstatus.getErSykmeldtMedArbeidsgiver().orElse(false)) {
+            if (erSykmeldtMedArbeidsgiverOver39Uker(sykeforloepMetaData)) {
+                return SYKMELDT_REGISTRERING;
+            } else {
+                return SPERRET;
+            }
         } else {
             return ORDINAER_REGISTRERING;
         }

--- a/src/main/java/no/nav/fo/veilarbregistrering/registrering/resources/StartRegistreringStatusDtoMapper.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/registrering/resources/StartRegistreringStatusDtoMapper.java
@@ -18,16 +18,12 @@ public class StartRegistreringStatusDtoMapper {
         return new StartRegistreringStatusDto()
                 .setUnderOppfolging(brukersTilstand.isUnderOppfolging())
                 .setRegistreringType(brukersTilstand.getRegistreringstype())
-                .setErSykmeldtMedArbeidsgiver(brukersTilstand.erRegistrertSomSykmeldtMedArbeidsgiver())
+                .setErSykmeldtMedArbeidsgiver(brukersTilstand.isErSykmeldtMedArbeidsgiver())
                 .setMaksDato(brukersTilstand.getMaksDato())
                 .setJobbetSeksAvTolvSisteManeder(oppfyllerBetingelseOmArbeidserfaring)
-                .setFormidlingsgruppe(brukersTilstand.getFormidlingsgruppe()
-                        .orElse(Formidlingsgruppe.nullable()).stringValue())
-                .setServicegruppe(brukersTilstand.getServicegruppe()
-                        .orElse(Servicegruppe.nullable()).stringValue())
-                .setRettighetsgruppe(brukersTilstand.getRettighetsgruppe()
-                        .orElse(Rettighetsgruppe.nullable()).stringValue())
-                .setGeografiskTilknytning(muligGeografiskTilknytning.map(GeografiskTilknytning::stringValue)
-                        .orElse(null));
+                .setFormidlingsgruppe(brukersTilstand.getFormidlingsgruppe().orElse(Formidlingsgruppe.nullable()).stringValue())
+                .setServicegruppe(brukersTilstand.getServicegruppe().orElse(Servicegruppe.nullable()).stringValue())
+                .setRettighetsgruppe(brukersTilstand.getRettighetsgruppe().orElse(Rettighetsgruppe.nullable()).stringValue())
+                .setGeografiskTilknytning(muligGeografiskTilknytning.map(GeografiskTilknytning::stringValue).orElse(null));
     }
 }

--- a/src/main/java/no/nav/fo/veilarbregistrering/sykemelding/Maksdato.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/sykemelding/Maksdato.java
@@ -15,10 +15,6 @@ public class Maksdato implements Metric {
 
     private final String maksdato;
 
-    public static Maksdato nullable() {
-        return new Maksdato.NullableMaksdato();
-    }
-
     public static Maksdato of(String maksdato) {
         return new Maksdato(maksdato);
     }
@@ -28,7 +24,11 @@ public class Maksdato implements Metric {
         this.maksdato = maksdato;
     }
 
-    boolean beregnSykmeldtMellom39Og52Uker(LocalDate dagenDato) {
+    public static Maksdato nullable() {
+        return new Maksdato.NullableMaksdato();
+    }
+
+    public boolean beregnSykmeldtMellom39Og52Uker(LocalDate dagenDato) {
         LocalDate dato = LocalDate.parse(maksdato);
         long GJENSTAENDE_UKER = 13;
 
@@ -36,7 +36,7 @@ public class Maksdato implements Metric {
                 ChronoUnit.WEEKS.between(dagenDato, dato) <= GJENSTAENDE_UKER;
     }
 
-    String asString() {
+    public String asString() {
         return maksdato;
     }
 
@@ -90,12 +90,12 @@ public class Maksdato implements Metric {
         }
 
         @Override
-        boolean beregnSykmeldtMellom39Og52Uker(LocalDate dagenDato) {
+        public boolean beregnSykmeldtMellom39Og52Uker(LocalDate dagenDato) {
             return false;
         }
 
         @Override
-        String asString() {
+        public String asString() {
             return null;
         }
 

--- a/src/main/java/no/nav/fo/veilarbregistrering/sykemelding/adapter/SykmeldtInfoClient.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/sykemelding/adapter/SykmeldtInfoClient.java
@@ -31,7 +31,6 @@ public class SykmeldtInfoClient extends BaseClient {
         TokenLocator tokenLocator = new TokenLocator(AZUREADB2C_OIDC_COOKIE_NAME_SBS, null);
 
         try {
-            LOG.info("Kaller infotrygd-sykepenger på url : " + url);
             return withClient(RestUtils.RestConfig.builder().readTimeout(HTTP_READ_TIMEOUT).build(),
                     c -> c.target(url)
                             .request()

--- a/src/test/java/no/nav/fo/veilarbregistrering/registrering/bruker/RegistreringTypeTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/registrering/bruker/RegistreringTypeTest.java
@@ -1,0 +1,80 @@
+package no.nav.fo.veilarbregistrering.registrering.bruker;
+
+import no.nav.fo.veilarbregistrering.oppfolging.Formidlingsgruppe;
+import no.nav.fo.veilarbregistrering.oppfolging.Oppfolgingsstatus;
+import no.nav.fo.veilarbregistrering.oppfolging.Rettighetsgruppe;
+import no.nav.fo.veilarbregistrering.oppfolging.Servicegruppe;
+import no.nav.fo.veilarbregistrering.sykemelding.Maksdato;
+import no.nav.fo.veilarbregistrering.sykemelding.SykmeldtInfoData;
+import org.junit.Test;
+
+import java.time.LocalDate;
+
+import static no.nav.fo.veilarbregistrering.registrering.bruker.RegistreringType.SPERRET;
+import static no.nav.fo.veilarbregistrering.registrering.bruker.RegistreringType.SYKMELDT_REGISTRERING;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RegistreringTypeTest {
+
+    @Test
+    public void beregnRegistreringType_gir_SPERRET_når_bruker_er_sykemeldtMedArbeidsgiver_Og_Maksdato_Er_Null() {
+        Oppfolgingsstatus oppfolgingsstatus = new Oppfolgingsstatus(
+                false,
+                false,
+                true,
+                Formidlingsgruppe.of("IARBS"),
+                Servicegruppe.of("VURDI"),
+                Rettighetsgruppe.of("IYT"));
+
+        String maksDato = null;
+        boolean erArbeidsrettetOppfolgingSykmeldtInngangAktiv = false;
+
+        SykmeldtInfoData sykeforlop = new SykmeldtInfoData(maksDato, erArbeidsrettetOppfolgingSykmeldtInngangAktiv);
+
+        RegistreringType registreringType = RegistreringType.beregnRegistreringType(oppfolgingsstatus, sykeforlop);
+
+        assertThat(registreringType).isEqualTo(SPERRET);
+    }
+
+    @Test
+    public void beregnRegistreringType_gir_SPERRET_når_bruker_er_sykemeldtMedArbeidsgiver_Og_Maksdato_Er_Under_39_Uker() {
+        Oppfolgingsstatus oppfolgingsstatus = new Oppfolgingsstatus(
+                false,
+                false,
+                true,
+                Formidlingsgruppe.of("IARBS"),
+                Servicegruppe.of("VURDI"),
+                Rettighetsgruppe.of("IYT"));
+
+        Maksdato maksdato = Maksdato.of("2021-03-01");
+
+        SykmeldtInfoData sykeforlop = new SykmeldtInfoData(
+                maksdato.asString(),
+                maksdato.beregnSykmeldtMellom39Og52Uker(LocalDate.of(2020, 5, 1)));
+
+        RegistreringType registreringType = RegistreringType.beregnRegistreringType(oppfolgingsstatus, sykeforlop);
+
+        assertThat(registreringType).isEqualTo(SPERRET);
+    }
+
+    @Test
+    public void beregnRegistreringType_gir_SYKMELDT_REGISTRERING_når_bruker_er_sykemeldtMedArbeidsgiver_Og_Maksdato_Er_Over_39_Uker() {
+        Oppfolgingsstatus oppfolgingsstatus = new Oppfolgingsstatus(
+                false,
+                false,
+                true,
+                Formidlingsgruppe.of("IARBS"),
+                Servicegruppe.of("VURDI"),
+                Rettighetsgruppe.of("IYT"));
+
+        Maksdato maksdato = Maksdato.of("2020-06-01");
+
+        SykmeldtInfoData sykeforlop = new SykmeldtInfoData(
+                maksdato.asString(),
+                maksdato.beregnSykmeldtMellom39Og52Uker(LocalDate.of(2020, 5, 1)));
+
+        RegistreringType registreringType = RegistreringType.beregnRegistreringType(oppfolgingsstatus, sykeforlop);
+
+        assertThat(registreringType).isEqualTo(SYKMELDT_REGISTRERING);
+    }
+}

--- a/src/test/java/no/nav/fo/veilarbregistrering/registrering/resources/StartRegistreringStatusDtoMapperTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/registrering/resources/StartRegistreringStatusDtoMapperTest.java
@@ -14,6 +14,7 @@ import java.util.Optional;
 
 import static no.nav.fo.veilarbregistrering.registrering.bruker.RegistreringType.ORDINAER_REGISTRERING;
 import static no.nav.fo.veilarbregistrering.registrering.bruker.RegistreringType.SYKMELDT_REGISTRERING;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class StartRegistreringStatusDtoMapperTest {
 
@@ -77,5 +78,25 @@ public class StartRegistreringStatusDtoMapperTest {
         softAssertions.assertThat(dto.getServicegruppe()).isEqualTo("SERV");
 
         softAssertions.assertAll();
+    }
+
+    @Test
+    public void map_skal_mappe_erSykmeldtMedArbeidsgiver_Til() {
+        Oppfolgingsstatus oppfolgingsstatus = new Oppfolgingsstatus(
+                true,
+                true,
+                false,
+                Formidlingsgruppe.of("IARBS"),
+                Servicegruppe.of("SERV"),
+                Rettighetsgruppe.of("AAP"));
+        SykmeldtInfoData sykmeldtInfoData = new SykmeldtInfoData("01122019", true);
+        BrukersTilstand brukersTilstand = new BrukersTilstand(oppfolgingsstatus, sykmeldtInfoData, SYKMELDT_REGISTRERING);
+
+        StartRegistreringStatusDto dto = StartRegistreringStatusDtoMapper.map(
+                brukersTilstand,
+                Optional.of(GeografiskTilknytning.of("030109")),
+                false);
+
+        assertThat(dto.isErSykmeldtMedArbeidsgiver()).isEqualTo(false);
     }
 }


### PR DESCRIPTION
Ifm. `hentStartRegistreringStatus` ble det funnet en feil i mappingen av erSykmeldtMedArbeidsgiver i returobjektet.
Dataene som lå til grunn for utledning av `registreringType` var riktig, men verdien ble mappet feil i etterkant.
Feilen skal nå være utbedret, samt fått noen flere tester.