### PR TITLE
Endre threshold for oppskalering av podd.

### DIFF
--- a/nais/naiserator.yaml
+++ b/nais/naiserator.yaml
@@ -55,7 +55,7 @@ spec:
   replicas:
     min: 2
     max: 6
-    cpuThresholdPercentage: 50
+    cpuThresholdPercentage: 85
   resources:
     limits:
       cpu: "3"

--- a/nais/naiserator.yaml
+++ b/nais/naiserator.yaml
@@ -59,9 +59,9 @@ spec:
   resources:
     limits:
       cpu: "3"
-      memory: 2048Mi
+      memory: 3048Mi
     requests:
-      memory: 1024Mi
+      memory: 2048Mi
       cpu: "1"
   vault:
     enabled: true


### PR DESCRIPTION
Denne verdien bestemmer når kubernetes skalerer opp antall  podder. 
F.eks  Det er requested 1 CPU, dersom applikasjonen bruker mer enn 0.85 skalerer kubernetes opp antall podder  til max