### PR TITLE
Første iterasjon av innføring av shedlock

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,14 @@
             <version>5.0.2</version>
         </dependency>
         <dependency>
+            <groupId>net.javacrumbs.shedlock</groupId>
+            <artifactId>shedlock-spring</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>net.javacrumbs.shedlock</groupId>
+            <artifactId>shedlock-provider-jdbc</artifactId>
+        </dependency>
+        <dependency>
             <groupId>no.nav.common</groupId>
             <artifactId>oidc-security</artifactId>
         </dependency>

--- a/src/main/resources/db/migration/veilarbregistreringDB/V1_35__add_shedlock.sql
+++ b/src/main/resources/db/migration/veilarbregistreringDB/V1_35__add_shedlock.sql
@@ -1,0 +1,7 @@
+CREATE TABLE SHEDLOCK (
+  name       VARCHAR(64),
+  lock_until TIMESTAMP(3),
+  locked_at  TIMESTAMP(3),
+  locked_by  VARCHAR(255),
+  PRIMARY KEY (name)
+);


### PR DESCRIPTION
Tar i bruk Shedlock for å sikre at ikke flere enn en tråd utfører en jobb av gangen, for å kunne begrense trafikk mot Arena.