### PR TITLE
Sender variabler på metrikk som fields i stedet for tags

### DIFF
--- a/src/main/java/no/nav/fo/veilarbregistrering/metrics/Metrics.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/metrics/Metrics.java
@@ -34,6 +34,17 @@ public class Metrics {
         metricsEvent.report();
     }
 
+    public static void reportFields(Event event, HasMetrics hasMetrics, Metric... metric) {
+        no.nav.metrics.Event metricsEvent = MetricsFactory.createEvent(event.name);
+        hasMetrics.metrics().stream()
+                .filter(Objects::nonNull)
+                .forEach(m -> metricsEvent.addFieldToReport(m.fieldName(), m.value()));
+        Arrays.stream(metric)
+                .filter(Objects::nonNull)
+                .forEach(m -> metricsEvent.addFieldToReport(m.fieldName(), m.value()));
+        metricsEvent.report();
+    }
+
     public enum Event {
         OPPGAVE_OPPRETTET_EVENT("arbeid.registrert.oppgave"),
         START_REGISTRERING_EVENT("arbeid.registrering.start"),

--- a/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/BrukerRegistreringService.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/BrukerRegistreringService.java
@@ -27,6 +27,7 @@ import static java.time.LocalDate.now;
 import static java.util.Optional.ofNullable;
 import static no.nav.fo.veilarbregistrering.metrics.Metrics.Event.PROFILERING_EVENT;
 import static no.nav.fo.veilarbregistrering.metrics.Metrics.Event.START_REGISTRERING_EVENT;
+import static no.nav.fo.veilarbregistrering.metrics.Metrics.reportFields;
 import static no.nav.fo.veilarbregistrering.metrics.Metrics.reportTags;
 import static no.nav.fo.veilarbregistrering.registrering.bruker.RegistreringType.*;
 import static no.nav.fo.veilarbregistrering.registrering.bruker.ValideringUtils.validerBrukerRegistrering;
@@ -132,7 +133,7 @@ public class BrukerRegistreringService {
         Optional<GeografiskTilknytning> muligGeografiskTilknytning = hentGeografiskTilknytning(fnr);
 
         muligGeografiskTilknytning.ifPresent(geografiskTilknytning -> {
-            reportTags(START_REGISTRERING_EVENT, brukersTilstand, geografiskTilknytning);
+            reportFields(START_REGISTRERING_EVENT, brukersTilstand, geografiskTilknytning);
         });
 
         RegistreringType registreringType = brukersTilstand.getRegistreringstype();


### PR DESCRIPTION
Influx genererer en ny tidsserie for hver eneste variasjon av tags og dette gjør at influ-serveren til NAV sliter