### PR TITLE
Utforsker feilmeldingene fra Arena

### DIFF
--- a/src/main/java/no/nav/fo/veilarbregistrering/oppfolging/adapter/OppfolgingGatewayConfig.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/oppfolging/adapter/OppfolgingGatewayConfig.java
@@ -1,6 +1,7 @@
 package no.nav.fo.veilarbregistrering.oppfolging.adapter;
 
 import no.nav.fo.veilarbregistrering.oppfolging.OppfolgingGateway;
+import no.nav.sbl.featuretoggle.unleash.UnleashService;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -15,8 +16,8 @@ public class OppfolgingGatewayConfig {
     public static final String OPPFOLGING_API_PROPERTY_NAME = "VEILARBOPPFOLGINGAPI_URL";
 
     @Bean
-    OppfolgingClient oppfolgingClient(Provider<HttpServletRequest> provider) {
-        return new OppfolgingClient(getRequiredProperty(OPPFOLGING_API_PROPERTY_NAME), provider);
+    OppfolgingClient oppfolgingClient(Provider<HttpServletRequest> provider, UnleashService unleashService) {
+        return new OppfolgingClient(getRequiredProperty(OPPFOLGING_API_PROPERTY_NAME), provider, unleashService);
     }
 
     @Bean

--- a/src/test/java/no/nav/fo/veilarbregistrering/oppfolging/OppfolgingClientMock.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/oppfolging/OppfolgingClientMock.java
@@ -12,7 +12,7 @@ import javax.ws.rs.core.Response;
 public class OppfolgingClientMock extends OppfolgingClient {
 
     public OppfolgingClientMock() {
-        super(null, null);
+        super(null, null, null);
     }
 
     @Override

--- a/src/test/java/no/nav/fo/veilarbregistrering/sykemelding/adapter/SykmeldtInfoClientTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/sykemelding/adapter/SykmeldtInfoClientTest.java
@@ -104,7 +104,7 @@ class SykmeldtInfoClientTest {
     private OppfolgingClient buildOppfolgingClient() {
         Provider<HttpServletRequest> httpServletRequestProvider = new ConfigBuildClient().invoke();
         String baseUrl = "http://" + MOCKSERVER_URL + ":" + MOCKSERVER_PORT;
-        return oppfolgingClient = new OppfolgingClient(baseUrl, httpServletRequestProvider);
+        return oppfolgingClient = new OppfolgingClient(baseUrl, httpServletRequestProvider, unleashService);
     }
 
     @Test


### PR DESCRIPTION
Ifm. innføring av asynkron overføring mot Arena, trenger vi å få kontroll over de ulike feilsituasjonene fra Arena, slik at disse kan taes vare på, på en god måte. Dette er første steg for å forstå disse meldingene bedre.