### PR TITLE
Tilgjengeliggjor Bruker-objektet ved lagring av registrering

### DIFF
--- a/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/BrukerRegistreringRepository.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/BrukerRegistreringRepository.java
@@ -1,12 +1,13 @@
 package no.nav.fo.veilarbregistrering.registrering.bruker;
 
 import no.nav.fo.veilarbregistrering.bruker.AktorId;
+import no.nav.fo.veilarbregistrering.bruker.Bruker;
 
 import java.util.Optional;
 
 public interface BrukerRegistreringRepository {
 
-    OrdinaerBrukerRegistrering lagreOrdinaerBruker(OrdinaerBrukerRegistrering bruker, AktorId aktorId);
+    OrdinaerBrukerRegistrering lagreOrdinaerBruker(OrdinaerBrukerRegistrering registrering, Bruker bruker);
 
     long lagreSykmeldtBruker(SykmeldtRegistrering bruker, AktorId aktorId);
 

--- a/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/BrukerRegistreringService.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/BrukerRegistreringService.java
@@ -167,7 +167,7 @@ public class BrukerRegistreringService {
     }
 
     private OrdinaerBrukerRegistrering opprettBruker(Bruker bruker, OrdinaerBrukerRegistrering brukerRegistrering) {
-        OrdinaerBrukerRegistrering ordinaerBrukerRegistrering = brukerRegistreringRepository.lagreOrdinaerBruker(brukerRegistrering, bruker.getAktorId());
+        OrdinaerBrukerRegistrering ordinaerBrukerRegistrering = brukerRegistreringRepository.lagreOrdinaerBruker(brukerRegistrering, bruker);
 
         Profilering profilering = profilerBrukerTilInnsatsgruppe(bruker.getFoedselsnummer(), ordinaerBrukerRegistrering.getBesvarelse());
         profileringRepository.lagreProfilering(ordinaerBrukerRegistrering.getId(), profilering);

--- a/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/db/BrukerRegistreringRepositoryImpl.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/db/BrukerRegistreringRepositoryImpl.java
@@ -2,9 +2,11 @@ package no.nav.fo.veilarbregistrering.registrering.bruker.db;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import no.nav.fo.veilarbregistrering.besvarelse.Besvarelse;
+import no.nav.fo.veilarbregistrering.besvarelse.Stilling;
 import no.nav.fo.veilarbregistrering.bruker.AktorId;
+import no.nav.fo.veilarbregistrering.bruker.Bruker;
 import no.nav.fo.veilarbregistrering.registrering.bruker.*;
-import no.nav.fo.veilarbregistrering.besvarelse.*;
 import no.nav.sbl.sql.DbConstants;
 import no.nav.sbl.sql.SqlUtils;
 import no.nav.sbl.sql.order.OrderClause;
@@ -61,15 +63,15 @@ public class BrukerRegistreringRepositoryImpl implements BrukerRegistreringRepos
     }
 
     @Override
-    public OrdinaerBrukerRegistrering lagreOrdinaerBruker(OrdinaerBrukerRegistrering bruker, AktorId aktorId) {
+    public OrdinaerBrukerRegistrering lagreOrdinaerBruker(OrdinaerBrukerRegistrering registrering, Bruker bruker) {
         long id = nesteFraSekvens(BRUKER_REGISTRERING_SEQ);
-        Besvarelse besvarelse = bruker.getBesvarelse();
-        Stilling stilling = bruker.getSisteStilling();
-        String teksterForBesvarelse = tilJson(bruker.getTeksterForBesvarelse());
+        Besvarelse besvarelse = registrering.getBesvarelse();
+        Stilling stilling = registrering.getSisteStilling();
+        String teksterForBesvarelse = tilJson(registrering.getTeksterForBesvarelse());
 
         SqlUtils.insert(db, BRUKER_REGISTRERING)
                 .value(BRUKER_REGISTRERING_ID, id)
-                .value(AKTOR_ID, aktorId.asString())
+                .value(AKTOR_ID, bruker.getAktorId().asString())
                 .value(OPPRETTET_DATO, DbConstants.CURRENT_TIMESTAMP)
                 .value(TEKSTER_FOR_BESVARELSE, teksterForBesvarelse)
                 // Siste stilling

--- a/src/test/java/no/nav/fo/veilarbregistrering/oppfolging/adapter/OppfolgingClientTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/oppfolging/adapter/OppfolgingClientTest.java
@@ -123,7 +123,7 @@ class OppfolgingClientTest {
         mockIkkeUnderOppfolgingApi();
         mockServer.when(request().withMethod("POST").withPath("/oppfolging/aktiverbruker")).respond(response().withStatusCode(404));
         OrdinaerBrukerRegistrering ordinaerBrukerRegistrering = gyldigBrukerRegistrering();
-        when (brukerRegistreringRepository.lagreOrdinaerBruker(any(OrdinaerBrukerRegistrering.class), any(AktorId.class))).thenReturn(new OrdinaerBrukerRegistrering());
+        when (brukerRegistreringRepository.lagreOrdinaerBruker(any(OrdinaerBrukerRegistrering.class), any(Bruker.class))).thenReturn(new OrdinaerBrukerRegistrering());
         assertThrows(RuntimeException.class, () -> brukerRegistreringService.registrerBruker(ordinaerBrukerRegistrering, BRUKER));
     }
 

--- a/src/test/java/no/nav/fo/veilarbregistrering/registrering/bruker/BrukerRegistreringServiceTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/registrering/bruker/BrukerRegistreringServiceTest.java
@@ -86,7 +86,7 @@ public class BrukerRegistreringServiceTest {
         mockInaktivBrukerUtenReaktivering();
         mockArbeidssforholdSomOppfyllerBetingelseOmArbeidserfaring();
         OrdinaerBrukerRegistrering selvgaaendeBruker = OrdinaerBrukerRegistreringTestdataBuilder.gyldigBrukerRegistrering();
-        when(brukerRegistreringRepository.lagreOrdinaerBruker(any(OrdinaerBrukerRegistrering.class), any(AktorId.class))).thenReturn(selvgaaendeBruker);
+        when(brukerRegistreringRepository.lagreOrdinaerBruker(any(OrdinaerBrukerRegistrering.class), any(Bruker.class))).thenReturn(selvgaaendeBruker);
         registrerBruker(selvgaaendeBruker, BRUKER_INTERN);
         verify(brukerRegistreringRepository, times(1)).lagreOrdinaerBruker(any(), any());
     }
@@ -118,7 +118,7 @@ public class BrukerRegistreringServiceTest {
         mockArbeidssforholdSomOppfyllerBetingelseOmArbeidserfaring();
         mockOppfolgingMedRespons(new OppfolgingStatusData().withUnderOppfolging(false).withKanReaktiveres(false));
         OrdinaerBrukerRegistrering selvgaaendeBruker = OrdinaerBrukerRegistreringTestdataBuilder.gyldigBrukerRegistrering();
-        when(brukerRegistreringRepository.lagreOrdinaerBruker(any(OrdinaerBrukerRegistrering.class), any(AktorId.class))).thenReturn(selvgaaendeBruker);
+        when(brukerRegistreringRepository.lagreOrdinaerBruker(any(OrdinaerBrukerRegistrering.class), any(Bruker.class))).thenReturn(selvgaaendeBruker);
         registrerBruker(selvgaaendeBruker, BRUKER_INTERN);
         verify(oppfolgingClient, times(1)).aktiverBruker(any());
         verify(brukerRegistreringRepository, times(1)).lagreOrdinaerBruker(any(), any());

--- a/src/test/java/no/nav/fo/veilarbregistrering/registrering/bruker/db/BrukerRegistreringRepositoryDbIntegrationTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/registrering/bruker/db/BrukerRegistreringRepositoryDbIntegrationTest.java
@@ -4,6 +4,8 @@ import no.nav.fo.veilarbregistrering.besvarelse.AndreForholdSvar;
 import no.nav.fo.veilarbregistrering.besvarelse.BesvarelseTestdataBuilder;
 import no.nav.fo.veilarbregistrering.besvarelse.TilbakeIArbeidSvar;
 import no.nav.fo.veilarbregistrering.bruker.AktorId;
+import no.nav.fo.veilarbregistrering.bruker.Bruker;
+import no.nav.fo.veilarbregistrering.bruker.Foedselsnummer;
 import no.nav.fo.veilarbregistrering.db.DbIntegrasjonsTest;
 import no.nav.fo.veilarbregistrering.registrering.bruker.*;
 import org.junit.jupiter.api.BeforeEach;
@@ -25,7 +27,9 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class BrukerRegistreringRepositoryDbIntegrationTest extends DbIntegrasjonsTest {
 
+    private static final Foedselsnummer FOEDSELSNUMMER = Foedselsnummer.of("12345678911");
     private static final AktorId AKTOR_ID_11111 = AktorId.valueOf("11111");
+    private static final Bruker BRUKER = Bruker.of(FOEDSELSNUMMER, AKTOR_ID_11111);
 
     @Inject
     private JdbcTemplate jdbcTemplate;
@@ -41,24 +45,24 @@ public class BrukerRegistreringRepositoryDbIntegrationTest extends DbIntegrasjon
 
     @Test
     public void registrerBruker() {
-        OrdinaerBrukerRegistrering bruker = OrdinaerBrukerRegistreringTestdataBuilder.gyldigBrukerRegistrering();
-        OrdinaerBrukerRegistrering ordinaerBrukerRegistrering = brukerRegistreringRepository.lagreOrdinaerBruker(bruker, AKTOR_ID_11111);
-        assertRegistrertBruker(bruker, ordinaerBrukerRegistrering);
+        OrdinaerBrukerRegistrering registrering = OrdinaerBrukerRegistreringTestdataBuilder.gyldigBrukerRegistrering();
+        OrdinaerBrukerRegistrering ordinaerBrukerRegistrering = brukerRegistreringRepository.lagreOrdinaerBruker(registrering, BRUKER);
+        assertRegistrertBruker(registrering, ordinaerBrukerRegistrering);
     }
 
     @Test
     public void hentBrukerregistreringForAktorId() {
 
-        OrdinaerBrukerRegistrering bruker1 = OrdinaerBrukerRegistreringTestdataBuilder.gyldigBrukerRegistrering().setBesvarelse(BesvarelseTestdataBuilder.gyldigBesvarelse()
+        OrdinaerBrukerRegistrering registrering1 = OrdinaerBrukerRegistreringTestdataBuilder.gyldigBrukerRegistrering().setBesvarelse(BesvarelseTestdataBuilder.gyldigBesvarelse()
                 .setAndreForhold(AndreForholdSvar.JA));
-        OrdinaerBrukerRegistrering bruker2 = OrdinaerBrukerRegistreringTestdataBuilder.gyldigBrukerRegistrering().setBesvarelse(BesvarelseTestdataBuilder.gyldigBesvarelse()
+        OrdinaerBrukerRegistrering registrering2 = OrdinaerBrukerRegistreringTestdataBuilder.gyldigBrukerRegistrering().setBesvarelse(BesvarelseTestdataBuilder.gyldigBesvarelse()
                 .setAndreForhold(AndreForholdSvar.NEI));
 
-        brukerRegistreringRepository.lagreOrdinaerBruker(bruker1, AKTOR_ID_11111);
-        brukerRegistreringRepository.lagreOrdinaerBruker(bruker2, AKTOR_ID_11111);
+        brukerRegistreringRepository.lagreOrdinaerBruker(registrering1, BRUKER);
+        brukerRegistreringRepository.lagreOrdinaerBruker(registrering2, BRUKER);
 
         OrdinaerBrukerRegistrering registrering = brukerRegistreringRepository.hentOrdinaerBrukerregistreringForAktorId(AKTOR_ID_11111);
-        assertRegistrertBruker(bruker2, registrering);
+        assertRegistrertBruker(registrering2, registrering);
     }
 
     @Test
@@ -77,16 +81,16 @@ public class BrukerRegistreringRepositoryDbIntegrationTest extends DbIntegrasjon
 
     @Test
     public void hentOrdinaerBrukerRegistreringForAktorId(){
-        OrdinaerBrukerRegistrering bruker = OrdinaerBrukerRegistreringTestdataBuilder.gyldigBrukerRegistrering().setBesvarelse(BesvarelseTestdataBuilder.gyldigBesvarelse()
+        OrdinaerBrukerRegistrering registrering = OrdinaerBrukerRegistreringTestdataBuilder.gyldigBrukerRegistrering().setBesvarelse(BesvarelseTestdataBuilder.gyldigBesvarelse()
                 .setAndreForhold(AndreForholdSvar.JA));
 
-        OrdinaerBrukerRegistrering lagretBruker = brukerRegistreringRepository.lagreOrdinaerBruker(bruker, AKTOR_ID_11111);
-        bruker.setId(lagretBruker.getId()).setOpprettetDato(lagretBruker.getOpprettetDato());
+        OrdinaerBrukerRegistrering lagretBruker = brukerRegistreringRepository.lagreOrdinaerBruker(registrering, BRUKER);
+        registrering.setId(lagretBruker.getId()).setOpprettetDato(lagretBruker.getOpprettetDato());
 
         OrdinaerBrukerRegistrering ordinaerBrukerRegistrering = brukerRegistreringRepository
                 .hentOrdinaerBrukerregistreringForAktorId(AKTOR_ID_11111);
 
-        assertEquals(bruker, ordinaerBrukerRegistrering);
+        assertEquals(registrering, ordinaerBrukerRegistrering);
 
     }
 


### PR DESCRIPTION
For å gjøre det enkelt å kunne toggle på lagring med og uten fnr, så deler vi oppgaven i to steg.