### PR TITLE
Legger til støtte for å hente fnr tilknyttet en registrering

### DIFF
--- a/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/ArenaOverforingService.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/ArenaOverforingService.java
@@ -53,9 +53,8 @@ public class ArenaOverforingService {
 
         long brukerRegistreringId = registreringTilstand.getBrukerRegistreringId();
 
-        OrdinaerBrukerRegistrering ordinaerBrukerRegistrering = brukerRegistreringRepository.hentBrukerregistreringForId(brukerRegistreringId);
-        Foedselsnummer foedselsnummer = null; ////TODO: ordinaerBrukerRegistrering.getFoedselsnummer()
-                Profilering profilering = profileringRepository.hentProfileringForId(brukerRegistreringId);
+        Foedselsnummer foedselsnummer = brukerRegistreringRepository.hentFoedselsnummerTilknyttet(brukerRegistreringId);
+        Profilering profilering = profileringRepository.hentProfileringForId(brukerRegistreringId);
 
         Status status = overfoerRegistreringTilArena(foedselsnummer, profilering.getInnsatsgruppe());
 

--- a/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/BrukerRegistreringRepository.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/BrukerRegistreringRepository.java
@@ -2,6 +2,7 @@ package no.nav.fo.veilarbregistrering.registrering.bruker;
 
 import no.nav.fo.veilarbregistrering.bruker.AktorId;
 import no.nav.fo.veilarbregistrering.bruker.Bruker;
+import no.nav.fo.veilarbregistrering.bruker.Foedselsnummer;
 
 import java.util.Optional;
 
@@ -26,4 +27,6 @@ public interface BrukerRegistreringRepository {
     Optional<RegistreringTilstand> finnNesteRegistreringForOverforing();
 
     void oppdater(RegistreringTilstand registreringTilstand1);
+
+    Foedselsnummer hentFoedselsnummerTilknyttet(long brukerRegistreringId);
 }

--- a/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/db/RegistreringTilstandMapper.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/db/RegistreringTilstandMapper.java
@@ -2,6 +2,7 @@ package no.nav.fo.veilarbregistrering.registrering.bruker.db;
 
 import no.nav.fo.veilarbregistrering.registrering.bruker.RegistreringTilstand;
 import no.nav.fo.veilarbregistrering.registrering.bruker.Status;
+import org.springframework.jdbc.core.RowMapper;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -10,9 +11,10 @@ import java.util.UUID;
 
 import static java.util.Optional.ofNullable;
 
-class RegistreringTilstandMapper {
+class RegistreringTilstandMapper implements RowMapper<RegistreringTilstand> {
 
-    static RegistreringTilstand map(ResultSet rs) throws SQLException {
+    @Override
+    public RegistreringTilstand mapRow(ResultSet rs, int i) throws SQLException {
         return RegistreringTilstand.fromDb(
                 rs.getLong("ID"),
                 UUID.fromString(rs.getString("UUID")),

--- a/src/test/java/no/nav/fo/veilarbregistrering/registrering/bruker/db/BrukerRegistreringRepositoryDbIntegrationTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/registrering/bruker/db/BrukerRegistreringRepositoryDbIntegrationTest.java
@@ -37,7 +37,6 @@ public class BrukerRegistreringRepositoryDbIntegrationTest extends DbIntegrasjon
 
     private BrukerRegistreringRepository brukerRegistreringRepository;
 
-
     @BeforeEach
     public void setup() {
         setupInMemoryDatabaseContext();
@@ -211,5 +210,13 @@ public class BrukerRegistreringRepositoryDbIntegrationTest extends DbIntegrasjon
         Optional<RegistreringTilstand> lagretTilstand = brukerRegistreringRepository.finnNesteRegistreringForOverforing();
 
         assertThat(lagretTilstand.isPresent()).isFalse();
+    }
+
+    @Test
+    public void skal_hente_foedselsnummer_tilknyttet_ordinaerBrukerRegistrering() {
+        OrdinaerBrukerRegistrering ordinaerBrukerRegistrering = brukerRegistreringRepository.lagre(gyldigBrukerRegistrering(), BRUKER);
+
+        Foedselsnummer foedselsnummer = brukerRegistreringRepository.hentFoedselsnummerTilknyttet(ordinaerBrukerRegistrering.getId());
+        assertThat(foedselsnummer).isEqualTo(BRUKER.getFoedselsnummer());
     }
 }


### PR DESCRIPTION
For å kunne overføre en reqistrering til Arena, trenger vi fødselsnummeret til bruker. Dette er nå lagt til i bruker_registrering-tabellen. Vi kunne ha utvidet den "vanlige" spørringen for dette, men da ville fnr også blitt eksponert ut via APIet, og det ønsker vi ikke. På sikt må vi mappe om intern modell til ekstern modell, men det må komme litt senere. Har derfor valgt å gjøre det enkelt i denne omgang.

Har samtidig valgt å gå bort fra Database-overbygget fra commons-java, og heller bruke Spring JDBC direkte.