### PR TITLE
Lager metode for å hente ut alle bruker_registreringer m/ paging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -163,6 +163,11 @@
             <artifactId>spring-jdbc</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.data</groupId>
+            <artifactId>spring-data-commons</artifactId>
+            <version>2.2.5.RELEASE</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-tx</artifactId>
         </dependency>

--- a/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/ArbeidssokerRegistrertEventDto.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/ArbeidssokerRegistrertEventDto.java
@@ -1,0 +1,46 @@
+package no.nav.fo.veilarbregistrering.registrering.bruker;
+
+import no.nav.fo.veilarbregistrering.bruker.AktorId;
+
+import java.time.LocalDateTime;
+
+public class ArbeidssokerRegistrertEventDto {
+    private final int rowNum;
+    private final long bruker_registrering_id;
+    private final AktorId aktor_id;
+    private final String begrunnelse_for_registrering;
+    private final LocalDateTime opprettet_dato;
+
+    public ArbeidssokerRegistrertEventDto(
+            int rowNum,
+            long bruker_registrering_id,
+            AktorId aktor_id,
+            String begrunnelse_for_registrering,
+            LocalDateTime opprettet_dato) {
+        this.rowNum = rowNum;
+        this.bruker_registrering_id = bruker_registrering_id;
+        this.aktor_id = aktor_id;
+        this.begrunnelse_for_registrering = begrunnelse_for_registrering;
+        this.opprettet_dato = opprettet_dato;
+    }
+
+    public int getRowNum() {
+        return rowNum;
+    }
+
+    public Long getBruker_registrering_id() {
+        return bruker_registrering_id;
+    }
+
+    public AktorId getAktor_id() {
+        return aktor_id;
+    }
+
+    public String getBegrunnelse_for_registrering() {
+        return begrunnelse_for_registrering;
+    }
+
+    public LocalDateTime getOpprettet_dato() {
+        return opprettet_dato;
+    }
+}

--- a/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/BrukerRegistreringRepository.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/BrukerRegistreringRepository.java
@@ -2,6 +2,8 @@ package no.nav.fo.veilarbregistrering.registrering.bruker;
 
 import no.nav.fo.veilarbregistrering.bruker.AktorId;
 import no.nav.fo.veilarbregistrering.bruker.Bruker;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.Optional;
 
@@ -28,4 +30,6 @@ public interface BrukerRegistreringRepository {
     void oppdater(RegistreringTilstand registreringTilstand1);
 
     Bruker hentBrukerTilknyttet(long brukerRegistreringId);
+
+    Page<ArbeidssokerRegistrertEventDto> findRegistreringByPage(Pageable pageable);
 }

--- a/src/main/java/no/nav/fo/veilarbregistrering/registrering/scheduler/PubliseringAvHistorikkTask.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/registrering/scheduler/PubliseringAvHistorikkTask.java
@@ -1,0 +1,6 @@
+package no.nav.fo.veilarbregistrering.registrering.scheduler;
+
+public class PubliseringAvHistorikkTask {
+
+
+}

--- a/src/test/java/no/nav/fo/veilarbregistrering/registrering/bruker/db/BrukerRegistreringRepositoryDbIntegrationTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/registrering/bruker/db/BrukerRegistreringRepositoryDbIntegrationTest.java
@@ -11,10 +11,11 @@ import no.nav.fo.veilarbregistrering.registrering.bruker.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.jdbc.core.JdbcTemplate;
 
 import javax.inject.Inject;
-
 import java.time.LocalDateTime;
 import java.util.Optional;
 
@@ -30,7 +31,13 @@ public class BrukerRegistreringRepositoryDbIntegrationTest extends DbIntegrasjon
 
     private static final Foedselsnummer FOEDSELSNUMMER = Foedselsnummer.of("12345678911");
     private static final AktorId AKTOR_ID_11111 = AktorId.valueOf("11111");
-    private static final Bruker BRUKER = Bruker.of(FOEDSELSNUMMER, AKTOR_ID_11111);
+    private static final Bruker BRUKER_1 = Bruker.of(FOEDSELSNUMMER, AKTOR_ID_11111);
+    private static final Foedselsnummer FOEDSELSNUMMER_2 = Foedselsnummer.of("22345678911");
+    private static final AktorId AKTOR_ID_22222 = AktorId.valueOf("22222");
+    private static final Bruker BRUKER_2 = Bruker.of(FOEDSELSNUMMER_2, AKTOR_ID_22222);
+    private static final Foedselsnummer FOEDSELSNUMMER_3 = Foedselsnummer.of("32345678911");
+    private static final AktorId AKTOR_ID_33333 = AktorId.valueOf("33333");
+    private static final Bruker BRUKER_3 = Bruker.of(FOEDSELSNUMMER_3, AKTOR_ID_33333);
 
     @Inject
     private JdbcTemplate jdbcTemplate;
@@ -46,7 +53,7 @@ public class BrukerRegistreringRepositoryDbIntegrationTest extends DbIntegrasjon
     @Test
     public void registrerBruker() {
         OrdinaerBrukerRegistrering registrering = gyldigBrukerRegistrering();
-        OrdinaerBrukerRegistrering ordinaerBrukerRegistrering = brukerRegistreringRepository.lagre(registrering, BRUKER);
+        OrdinaerBrukerRegistrering ordinaerBrukerRegistrering = brukerRegistreringRepository.lagre(registrering, BRUKER_1);
         assertRegistrertBruker(registrering, ordinaerBrukerRegistrering);
     }
 
@@ -58,8 +65,8 @@ public class BrukerRegistreringRepositoryDbIntegrationTest extends DbIntegrasjon
         OrdinaerBrukerRegistrering registrering2 = gyldigBrukerRegistrering().setBesvarelse(BesvarelseTestdataBuilder.gyldigBesvarelse()
                 .setAndreForhold(AndreForholdSvar.NEI));
 
-        brukerRegistreringRepository.lagre(registrering1, BRUKER);
-        brukerRegistreringRepository.lagre(registrering2, BRUKER);
+        brukerRegistreringRepository.lagre(registrering1, BRUKER_1);
+        brukerRegistreringRepository.lagre(registrering2, BRUKER_1);
 
         OrdinaerBrukerRegistrering registrering = brukerRegistreringRepository.hentOrdinaerBrukerregistreringForAktorId(AKTOR_ID_11111);
         assertRegistrertBruker(registrering2, registrering);
@@ -84,7 +91,7 @@ public class BrukerRegistreringRepositoryDbIntegrationTest extends DbIntegrasjon
         OrdinaerBrukerRegistrering registrering = gyldigBrukerRegistrering().setBesvarelse(BesvarelseTestdataBuilder.gyldigBesvarelse()
                 .setAndreForhold(AndreForholdSvar.JA));
 
-        OrdinaerBrukerRegistrering lagretBruker = brukerRegistreringRepository.lagre(registrering, BRUKER);
+        OrdinaerBrukerRegistrering lagretBruker = brukerRegistreringRepository.lagre(registrering, BRUKER_1);
         registrering.setId(lagretBruker.getId()).setOpprettetDato(lagretBruker.getOpprettetDato());
 
         OrdinaerBrukerRegistrering ordinaerBrukerRegistrering = brukerRegistreringRepository
@@ -124,7 +131,7 @@ public class BrukerRegistreringRepositoryDbIntegrationTest extends DbIntegrasjon
     @Test
     public void skal_lagre_og_hente_registreringTilstand() {
         OrdinaerBrukerRegistrering registrering = gyldigBrukerRegistrering();
-        OrdinaerBrukerRegistrering lagretRegistrering = brukerRegistreringRepository.lagre(registrering, BRUKER);
+        OrdinaerBrukerRegistrering lagretRegistrering = brukerRegistreringRepository.lagre(registrering, BRUKER_1);
 
         RegistreringTilstand registreringTilstand = RegistreringTilstand.ofMottattRegistrering(lagretRegistrering.getId());
 
@@ -147,9 +154,9 @@ public class BrukerRegistreringRepositoryDbIntegrationTest extends DbIntegrasjon
         OrdinaerBrukerRegistrering registrering1 = gyldigBrukerRegistrering();
         OrdinaerBrukerRegistrering registrering2 = gyldigBrukerRegistrering();
         OrdinaerBrukerRegistrering registrering3 = gyldigBrukerRegistrering();
-        OrdinaerBrukerRegistrering lagretRegistrering1 = brukerRegistreringRepository.lagre(registrering1, BRUKER);
-        OrdinaerBrukerRegistrering lagretRegistrering2 = brukerRegistreringRepository.lagre(registrering2, BRUKER);
-        OrdinaerBrukerRegistrering lagretRegistrering3 = brukerRegistreringRepository.lagre(registrering3, BRUKER);
+        OrdinaerBrukerRegistrering lagretRegistrering1 = brukerRegistreringRepository.lagre(registrering1, BRUKER_1);
+        OrdinaerBrukerRegistrering lagretRegistrering2 = brukerRegistreringRepository.lagre(registrering2, BRUKER_1);
+        OrdinaerBrukerRegistrering lagretRegistrering3 = brukerRegistreringRepository.lagre(registrering3, BRUKER_1);
 
 
         RegistreringTilstand eldsteRegistrering = registreringTilstand()
@@ -182,9 +189,9 @@ public class BrukerRegistreringRepositoryDbIntegrationTest extends DbIntegrasjon
         OrdinaerBrukerRegistrering registrering1 = gyldigBrukerRegistrering();
         OrdinaerBrukerRegistrering registrering2 = gyldigBrukerRegistrering();
         OrdinaerBrukerRegistrering registrering3 = gyldigBrukerRegistrering();
-        OrdinaerBrukerRegistrering lagretRegistrering1 = brukerRegistreringRepository.lagre(registrering1, BRUKER);
-        OrdinaerBrukerRegistrering lagretRegistrering2 = brukerRegistreringRepository.lagre(registrering2, BRUKER);
-        OrdinaerBrukerRegistrering lagretRegistrering3 = brukerRegistreringRepository.lagre(registrering3, BRUKER);
+        OrdinaerBrukerRegistrering lagretRegistrering1 = brukerRegistreringRepository.lagre(registrering1, BRUKER_1);
+        OrdinaerBrukerRegistrering lagretRegistrering2 = brukerRegistreringRepository.lagre(registrering2, BRUKER_1);
+        OrdinaerBrukerRegistrering lagretRegistrering3 = brukerRegistreringRepository.lagre(registrering3, BRUKER_1);
 
         RegistreringTilstand eldsteRegistrering = registreringTilstand()
                 .brukerRegistreringId(lagretRegistrering1.getId())
@@ -214,10 +221,34 @@ public class BrukerRegistreringRepositoryDbIntegrationTest extends DbIntegrasjon
 
     @Test
     public void skal_hente_foedselsnummer_tilknyttet_ordinaerBrukerRegistrering() {
-        OrdinaerBrukerRegistrering ordinaerBrukerRegistrering = brukerRegistreringRepository.lagre(gyldigBrukerRegistrering(), BRUKER);
+        OrdinaerBrukerRegistrering ordinaerBrukerRegistrering = brukerRegistreringRepository.lagre(gyldigBrukerRegistrering(), BRUKER_1);
 
         Bruker bruker = brukerRegistreringRepository.hentBrukerTilknyttet(ordinaerBrukerRegistrering.getId());
-        assertThat(bruker.getFoedselsnummer()).isEqualTo(BRUKER.getFoedselsnummer());
-        assertThat(bruker.getAktorId()).isEqualTo(BRUKER.getAktorId());
+        assertThat(bruker.getFoedselsnummer()).isEqualTo(BRUKER_1.getFoedselsnummer());
+        assertThat(bruker.getAktorId()).isEqualTo(BRUKER_1.getAktorId());
+    }
+
+    @Test
+    public void findRegistreringByPage_skal_returnere_eldste_registrering_pa_bakgrunn_av_id() {
+        brukerRegistreringRepository.lagre(gyldigBrukerRegistrering(), BRUKER_1);
+        brukerRegistreringRepository.lagre(gyldigBrukerRegistrering(), BRUKER_2);
+        brukerRegistreringRepository.lagre(gyldigBrukerRegistrering(), BRUKER_3);
+
+        PageRequest pageRequest = PageRequest.of(0, 2);
+        Page<ArbeidssokerRegistrertEventDto> registreringByPage = brukerRegistreringRepository.findRegistreringByPage(pageRequest);
+
+        assertThat(registreringByPage.getTotalPages()).isEqualTo(2);
+    }
+
+    @Test
+    public void findRegistreringByPage_skal_paging_for_a_levere_batcher_med_rader() {
+        brukerRegistreringRepository.lagre(gyldigBrukerRegistrering(), BRUKER_1);
+        brukerRegistreringRepository.lagre(gyldigBrukerRegistrering(), BRUKER_2);
+        brukerRegistreringRepository.lagre(gyldigBrukerRegistrering(), BRUKER_3);
+
+        PageRequest pageRequest = PageRequest.of(1, 2);
+        Page<ArbeidssokerRegistrertEventDto> registreringByPage = brukerRegistreringRepository.findRegistreringByPage(pageRequest);
+
+        assertThat(registreringByPage.getTotalPages()).isEqualTo(2);
     }
 }


### PR DESCRIPTION
For å kunne publisere alle BRUKER_REGISTRERINGER på Kafka (for å kunne tilby historikk) har vi behov for å først hente de opp. Det er snakk om over 400 000 så vi trenger å dele opp jobben i deler. Har derfor laget en metode som støttet paging, slik at vi kan justere hvor mange rader vi skal hente av gangen.

Dette er første lille steg - senere skal det lages en liten scheduler som henter og publiserer på Kafka, før vi gjør en ny hent osv til vi er ferdige.

Også viktig at vi begrenser trafikken til en node, slik at vi ikke lager duplikater.