### PR TITLE
Skiller ut Sykmeldt-registrering til egen flyt

### DIFF
--- a/src/main/java/no/nav/fo/veilarbregistrering/config/ServiceBeansConfig.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/config/ServiceBeansConfig.java
@@ -55,7 +55,7 @@ public class ServiceBeansConfig {
             //FIXME: Overflødig - metodene kan være static
             StartRegistreringUtils startRegistreringUtils,
             UnleashService unleashService,
-            ArbeidssokerRegistrertProducer arbeidssokerRegistrertProducer
+            OrdinaerBrukerRegistrertProducer ordinaerBrukerRegistrertProducer
     ) {
         return new BrukerRegistreringService(
                 brukerRegistreringRepository,
@@ -67,21 +67,35 @@ public class ServiceBeansConfig {
                 manuellRegistreringService,
                 startRegistreringUtils,
                 unleashService,
-                arbeidssokerRegistrertProducer
+                ordinaerBrukerRegistrertProducer
         );
     }
 
     @Bean
     PubliseringAvHistorikkTask publiseringAvHistorikkTask (
             BrukerRegistreringRepository brukerRegistreringRepository,
-            ArbeidssokerRegistrertProducer arbeidssokerRegistrertProducer,
+            OrdinaerBrukerRegistrertProducer ordinaerBrukerRegistrertProducer,
             UnleashService unleashService
     ) {
         return new PubliseringAvHistorikkTask (
                 brukerRegistreringRepository,
-                arbeidssokerRegistrertProducer,
+                ordinaerBrukerRegistrertProducer,
                 unleashService
         );
+    }
+
+    @Bean
+    SykmeldtBrukerRegistreringService sykmeldtBrukerRegistreringService(
+            BrukerRegistreringService brukerRegistreringService,
+            BrukerRegistreringRepository brukerRegistreringRepository,
+            OppfolgingGateway oppfolgingGateway,
+            UnleashService unleashService
+    ) {
+        return new SykmeldtBrukerRegistreringService(
+                brukerRegistreringService,
+                brukerRegistreringRepository,
+                oppfolgingGateway,
+                unleashService);
     }
 
     @Bean
@@ -90,6 +104,7 @@ public class ServiceBeansConfig {
             UserService userService,
             ManuellRegistreringService manuellRegistreringService,
             BrukerRegistreringService brukerRegistreringService,
+            SykmeldtBrukerRegistreringService sykmeldtBrukerRegistreringService,
             UnleashService unleashService
     ) {
         return new RegistreringResource(
@@ -97,8 +112,8 @@ public class ServiceBeansConfig {
                 userService,
                 manuellRegistreringService,
                 brukerRegistreringService,
-                unleashService
-        );
+                unleashService,
+                sykmeldtBrukerRegistreringService);
     }
 
     @Bean
@@ -186,13 +201,13 @@ public class ServiceBeansConfig {
             ProfileringRepository profileringRepository,
             BrukerRegistreringRepository brukerRegistreringRepository,
             OppfolgingGateway oppfolgingGateway,
-            ArbeidssokerRegistrertProducer arbeidssokerRegistrertProducer) {
+            OrdinaerBrukerRegistrertProducer ordinaerBrukerRegistrertProducer) {
 
         return new ArenaOverforingService(
                 profileringRepository,
                 brukerRegistreringRepository,
                 oppfolgingGateway,
-                arbeidssokerRegistrertProducer);
+                ordinaerBrukerRegistrertProducer);
     }
 
     @Bean

--- a/src/main/java/no/nav/fo/veilarbregistrering/kafka/KafkaConfig.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/kafka/KafkaConfig.java
@@ -22,9 +22,9 @@ import static java.lang.System.getenv;
 public class KafkaConfig {
 
     @Bean
-    ArbeidssokerRegistrertKafkaProducer arbeidssokerRegistrertKafkaProducer(
+    OrdinaerBrukerRegistrertKafkaProducer arbeidssokerRegistrertKafkaProducer(
             KafkaProducer kafkaProducer, UnleashService unleashService) {
-        return new ArbeidssokerRegistrertKafkaProducer(
+        return new OrdinaerBrukerRegistrertKafkaProducer(
                 kafkaProducer,
                 unleashService,
                 "aapen-arbeid-arbeidssoker-registrert" + getEnvSuffix());

--- a/src/main/java/no/nav/fo/veilarbregistrering/kafka/OrdinaerBrukerRegistrertKafkaProducer.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/kafka/OrdinaerBrukerRegistrertKafkaProducer.java
@@ -3,7 +3,7 @@ package no.nav.fo.veilarbregistrering.kafka;
 import no.nav.arbeid.soker.registrering.ArbeidssokerRegistrertEvent;
 import no.nav.fo.veilarbregistrering.besvarelse.DinSituasjonSvar;
 import no.nav.fo.veilarbregistrering.bruker.AktorId;
-import no.nav.fo.veilarbregistrering.registrering.bruker.ArbeidssokerRegistrertProducer;
+import no.nav.fo.veilarbregistrering.registrering.bruker.OrdinaerBrukerRegistrertProducer;
 import no.nav.sbl.featuretoggle.unleash.UnleashService;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
@@ -17,15 +17,15 @@ import java.util.concurrent.TimeoutException;
 
 import static no.nav.fo.veilarbregistrering.kafka.ArbeidssokerRegistrertMapper.map;
 
-public class ArbeidssokerRegistrertKafkaProducer implements ArbeidssokerRegistrertProducer {
+public class OrdinaerBrukerRegistrertKafkaProducer implements OrdinaerBrukerRegistrertProducer {
 
-    private static final Logger LOG = LoggerFactory.getLogger(ArbeidssokerRegistrertKafkaProducer.class);
+    private static final Logger LOG = LoggerFactory.getLogger(OrdinaerBrukerRegistrertKafkaProducer.class);
 
     private final KafkaProducer producer;
     private final UnleashService unleashService;
     private final String topic;
 
-    public ArbeidssokerRegistrertKafkaProducer(
+    public OrdinaerBrukerRegistrertKafkaProducer(
             KafkaProducer kafkaProducer, UnleashService unleashService, String topic) {
         this.unleashService = unleashService;
         this.producer = kafkaProducer;

--- a/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/ArenaOverforingService.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/ArenaOverforingService.java
@@ -23,13 +23,13 @@ public class ArenaOverforingService {
     private final ProfileringRepository profileringRepository;
     private final BrukerRegistreringRepository brukerRegistreringRepository;
     private final OppfolgingGateway oppfolgingGateway;
-    private final ArbeidssokerRegistrertProducer arbeidssokerRegistrertProducer;
+    private final OrdinaerBrukerRegistrertProducer ordinaerBrukerRegistrertProducer;
 
-    public ArenaOverforingService(ProfileringRepository profileringRepository, BrukerRegistreringRepository brukerRegistreringRepository, OppfolgingGateway oppfolgingGateway, ArbeidssokerRegistrertProducer arbeidssokerRegistrertProducer) {
+    public ArenaOverforingService(ProfileringRepository profileringRepository, BrukerRegistreringRepository brukerRegistreringRepository, OppfolgingGateway oppfolgingGateway, OrdinaerBrukerRegistrertProducer ordinaerBrukerRegistrertProducer) {
         this.profileringRepository = profileringRepository;
         this.brukerRegistreringRepository = brukerRegistreringRepository;
         this.oppfolgingGateway = oppfolgingGateway;
-        this.arbeidssokerRegistrertProducer = arbeidssokerRegistrertProducer;
+        this.ordinaerBrukerRegistrertProducer = ordinaerBrukerRegistrertProducer;
     }
 
     /**
@@ -66,7 +66,7 @@ public class ArenaOverforingService {
 
         OrdinaerBrukerRegistrering ordinaerBrukerRegistrering = brukerRegistreringRepository.hentBrukerregistreringForId(brukerRegistreringId);
 
-        arbeidssokerRegistrertProducer.publiserArbeidssokerRegistrert(
+        ordinaerBrukerRegistrertProducer.publiserArbeidssokerRegistrert(
                 bruker.getAktorId(),
                 ordinaerBrukerRegistrering.getBrukersSituasjon(),
                 ordinaerBrukerRegistrering.getOpprettetDato());

--- a/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/OrdinaerBrukerRegistrertProducer.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/OrdinaerBrukerRegistrertProducer.java
@@ -1,0 +1,14 @@
+package no.nav.fo.veilarbregistrering.registrering.bruker;
+
+import no.nav.fo.veilarbregistrering.besvarelse.DinSituasjonSvar;
+import no.nav.fo.veilarbregistrering.bruker.AktorId;
+
+import java.time.LocalDateTime;
+
+public interface OrdinaerBrukerRegistrertProducer {
+
+    void publiserArbeidssokerRegistrert(
+            AktorId aktorId,
+            DinSituasjonSvar brukersSituasjon,
+            LocalDateTime opprettetDato);
+}

--- a/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/PubliseringAvHistorikkTask.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/PubliseringAvHistorikkTask.java
@@ -18,17 +18,17 @@ public class PubliseringAvHistorikkTask implements Runnable {
     private static final Logger LOG = LoggerFactory.getLogger(PubliseringAvHistorikkTask.class);
 
     private final BrukerRegistreringRepository brukerRegistreringRepository;
-    private final ArbeidssokerRegistrertProducer arbeidssokerRegistrertProducer;
+    private final OrdinaerBrukerRegistrertProducer ordinaerBrukerRegistrertProducer;
     private final UnleashService unleashService;
     private static final int PAGESIZE = 100;
 
     public PubliseringAvHistorikkTask(
             BrukerRegistreringRepository brukerRegistreringRepository,
-            ArbeidssokerRegistrertProducer arbeidssokerRegistrertProducer,
+            OrdinaerBrukerRegistrertProducer ordinaerBrukerRegistrertProducer,
             UnleashService unleashService) {
 
         this.brukerRegistreringRepository = brukerRegistreringRepository;
-        this.arbeidssokerRegistrertProducer = arbeidssokerRegistrertProducer;
+        this.ordinaerBrukerRegistrertProducer = ordinaerBrukerRegistrertProducer;
         this.unleashService = unleashService;
 
         Executors.newSingleThreadScheduledExecutor()
@@ -69,7 +69,7 @@ public class PubliseringAvHistorikkTask implements Runnable {
     }
 
     private void publiserPaKafka(ArbeidssokerRegistrertEventDto dto) {
-        arbeidssokerRegistrertProducer.publiserArbeidssokerRegistrert(
+        ordinaerBrukerRegistrertProducer.publiserArbeidssokerRegistrert(
                 dto.getAktorId(),
                 //TODO: Sjekk om alle verdiene vi har i databasen er støttet
                 DinSituasjonSvar.valueOf(dto.getBegrunnelseForRegistrering()),

--- a/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/SykmeldtBrukerRegistreringService.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/SykmeldtBrukerRegistreringService.java
@@ -1,0 +1,56 @@
+package no.nav.fo.veilarbregistrering.registrering.bruker;
+
+import no.nav.fo.veilarbregistrering.amplitude.AmplitudeLogger;
+import no.nav.fo.veilarbregistrering.bruker.Bruker;
+import no.nav.fo.veilarbregistrering.oppfolging.OppfolgingGateway;
+import no.nav.sbl.featuretoggle.unleash.UnleashService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.transaction.annotation.Transactional;
+
+import static java.util.Optional.ofNullable;
+
+
+public class SykmeldtBrukerRegistreringService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SykmeldtBrukerRegistreringService.class);
+
+    private final BrukerRegistreringService brukerRegistreringService;
+    private final BrukerRegistreringRepository brukerRegistreringRepository;
+    private final UnleashService unleashService;
+    private final OppfolgingGateway oppfolgingGateway;
+
+    public SykmeldtBrukerRegistreringService(
+            BrukerRegistreringService brukerRegistreringService,
+            BrukerRegistreringRepository brukerRegistreringRepository,
+                                             OppfolgingGateway oppfolgingGateway,
+                                             UnleashService unleashService
+    ) {
+        this.brukerRegistreringService = brukerRegistreringService;
+        this.brukerRegistreringRepository = brukerRegistreringRepository;
+        this.unleashService = unleashService;
+        this.oppfolgingGateway = oppfolgingGateway;
+    }
+
+    @Transactional
+    public long registrerSykmeldt(SykmeldtRegistrering sykmeldtRegistrering, Bruker bruker) {
+        ofNullable(sykmeldtRegistrering.getBesvarelse())
+                .orElseThrow(() -> new RuntimeException("Besvarelse for sykmeldt ugyldig."));
+
+        BrukersTilstand brukersTilstand = brukerRegistreringService.hentBrukersTilstand(bruker.getFoedselsnummer());
+
+        if (brukersTilstand.ikkeErSykemeldtRegistrering()) {
+            throw new RuntimeException("Bruker kan ikke registreres.");
+        }
+
+        oppfolgingGateway.settOppfolgingSykmeldt(bruker.getFoedselsnummer(), sykmeldtRegistrering.getBesvarelse());
+        long id = brukerRegistreringRepository.lagreSykmeldtBruker(sykmeldtRegistrering, bruker.getAktorId());
+        LOG.info("Sykmeldtregistrering gjennomført med data {}", sykmeldtRegistrering);
+
+        if (unleashService.isEnabled("veilarbregistrering.amplitude.test")) {
+            AmplitudeLogger.log(bruker.getAktorId());
+        }
+
+        return id;
+    }
+}

--- a/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/SykmeldtBrukerRegistrertProducer.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/SykmeldtBrukerRegistrertProducer.java
@@ -5,7 +5,7 @@ import no.nav.fo.veilarbregistrering.bruker.AktorId;
 
 import java.time.LocalDateTime;
 
-public interface ArbeidssokerRegistrertProducer {
+public interface SykmeldtBrukerRegistrertProducer {
 
     void publiserArbeidssokerRegistrert(
             AktorId aktorId,

--- a/src/main/java/no/nav/fo/veilarbregistrering/registrering/resources/RegistreringResource.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/registrering/resources/RegistreringResource.java
@@ -6,10 +6,7 @@ import no.nav.apiapp.security.veilarbabac.VeilarbAbacPepClient;
 import no.nav.fo.veilarbregistrering.bruker.AutentiseringUtils;
 import no.nav.fo.veilarbregistrering.bruker.Bruker;
 import no.nav.fo.veilarbregistrering.bruker.UserService;
-import no.nav.fo.veilarbregistrering.registrering.bruker.BrukerRegistreringService;
-import no.nav.fo.veilarbregistrering.registrering.bruker.BrukerRegistreringWrapper;
-import no.nav.fo.veilarbregistrering.registrering.bruker.OrdinaerBrukerRegistrering;
-import no.nav.fo.veilarbregistrering.registrering.bruker.SykmeldtRegistrering;
+import no.nav.fo.veilarbregistrering.registrering.bruker.*;
 import no.nav.fo.veilarbregistrering.registrering.manuell.ManuellRegistreringService;
 import no.nav.sbl.featuretoggle.unleash.UnleashService;
 import org.slf4j.Logger;
@@ -38,6 +35,7 @@ public class RegistreringResource {
 
     private final UnleashService unleashService;
     private final BrukerRegistreringService brukerRegistreringService;
+    private final SykmeldtBrukerRegistreringService sykmeldtBrukerRegistreringService;
     private final UserService userService;
     private final ManuellRegistreringService manuellRegistreringService;
     private final VeilarbAbacPepClient pepClient;
@@ -47,13 +45,14 @@ public class RegistreringResource {
             UserService userService,
             ManuellRegistreringService manuellRegistreringService,
             BrukerRegistreringService brukerRegistreringService,
-            UnleashService unleashService
-    ) {
+            UnleashService unleashService,
+            SykmeldtBrukerRegistreringService sykmeldtBrukerRegistreringService) {
         this.pepClient = pepClient;
         this.userService = userService;
         this.manuellRegistreringService = manuellRegistreringService;
         this.brukerRegistreringService = brukerRegistreringService;
         this.unleashService = unleashService;
+        this.sykmeldtBrukerRegistreringService = sykmeldtBrukerRegistreringService;
     }
 
     @GET
@@ -165,13 +164,13 @@ public class RegistreringResource {
             final String veilederIdent = AutentiseringUtils.hentIdent()
                     .orElseThrow(() -> new RuntimeException("Fant ikke ident"));
 
-            long id = brukerRegistreringService.registrerSykmeldt(sykmeldtRegistrering, bruker);
+            long id = sykmeldtBrukerRegistreringService.registrerSykmeldt(sykmeldtRegistrering, bruker);
             manuellRegistreringService.lagreManuellRegistrering(veilederIdent, enhetId, id, SYKMELDT);
 
             reportFields(MANUELL_REGISTRERING_EVENT, SYKMELDT);
 
         } else {
-            brukerRegistreringService.registrerSykmeldt(sykmeldtRegistrering, bruker);
+            sykmeldtBrukerRegistreringService.registrerSykmeldt(sykmeldtRegistrering, bruker);
         }
 
         reportFields(SYKMELDT_BESVARELSE_EVENT,

--- a/src/test/java/no/nav/fo/veilarbregistrering/kafka/KafkaConfig.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/kafka/KafkaConfig.java
@@ -9,8 +9,8 @@ import static org.mockito.Mockito.mock;
 public class KafkaConfig {
 
     @Bean
-    ArbeidssokerRegistrertKafkaProducer arbeidssokerRegistrertKafkaProducer() {
-        return mock(ArbeidssokerRegistrertKafkaProducer.class);
+    OrdinaerBrukerRegistrertKafkaProducer arbeidssokerRegistrertKafkaProducer() {
+        return mock(OrdinaerBrukerRegistrertKafkaProducer.class);
     }
 
     @Bean

--- a/src/test/java/no/nav/fo/veilarbregistrering/oppfolging/adapter/OppfolgingClientTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/oppfolging/adapter/OppfolgingClientTest.java
@@ -11,7 +11,7 @@ import no.nav.fo.veilarbregistrering.profilering.Innsatsgruppe;
 import no.nav.fo.veilarbregistrering.profilering.Profilering;
 import no.nav.fo.veilarbregistrering.profilering.ProfileringRepository;
 import no.nav.fo.veilarbregistrering.profilering.StartRegistreringUtils;
-import no.nav.fo.veilarbregistrering.registrering.bruker.ArbeidssokerRegistrertProducer;
+import no.nav.fo.veilarbregistrering.registrering.bruker.OrdinaerBrukerRegistrertProducer;
 import no.nav.fo.veilarbregistrering.registrering.bruker.BrukerRegistreringRepository;
 import no.nav.fo.veilarbregistrering.registrering.bruker.BrukerRegistreringService;
 import no.nav.fo.veilarbregistrering.registrering.bruker.OrdinaerBrukerRegistrering;
@@ -58,7 +58,7 @@ class OppfolgingClientTest {
     private SykmeldtInfoClient sykeforloepMetadataClient;
     private ArbeidsforholdGateway arbeidsforholdGateway;
     private StartRegistreringUtils startRegistreringUtils;
-    private ArbeidssokerRegistrertProducer arbeidssokerRegistrertProducer;
+    private OrdinaerBrukerRegistrertProducer ordinaerBrukerRegistrertProducer;
     private ClientAndServer mockServer;
 
     @AfterEach
@@ -80,7 +80,7 @@ class OppfolgingClientTest {
         sykeforloepMetadataClient = mock(SykmeldtInfoClient.class);
         startRegistreringUtils = mock(StartRegistreringUtils.class);
         manuellRegistreringService = mock(ManuellRegistreringService.class);
-        arbeidssokerRegistrertProducer = (aktorId, brukersSituasjon, opprettetDato) -> {};
+        ordinaerBrukerRegistrertProducer = (aktorId, brukersSituasjon, opprettetDato) -> {};
 
         brukerRegistreringService =
                 new BrukerRegistreringService(
@@ -93,7 +93,7 @@ class OppfolgingClientTest {
                         manuellRegistreringService,
                         startRegistreringUtils,
                         unleashService,
-                        arbeidssokerRegistrertProducer);
+                        ordinaerBrukerRegistrertProducer);
 
 
         when(startRegistreringUtils.harJobbetSammenhengendeSeksAvTolvSisteManeder(any(), any())).thenReturn(true);

--- a/src/test/java/no/nav/fo/veilarbregistrering/registrering/bruker/ArenaOverforingServiceTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/registrering/bruker/ArenaOverforingServiceTest.java
@@ -20,18 +20,18 @@ public class ArenaOverforingServiceTest {
     private ProfileringRepository profileringRepository;
     private BrukerRegistreringRepository brukerRegistreringRepository;
     private OppfolgingGateway oppfolgingClient;
-    private ArbeidssokerRegistrertProducer arbeidssokerRegistrertProducer;
+    private OrdinaerBrukerRegistrertProducer ordinaerBrukerRegistrertProducer;
 
     @Before
     public void setUp() {
         profileringRepository = mock(ProfileringRepository.class);
         brukerRegistreringRepository = mock(BrukerRegistreringRepository.class);
         oppfolgingClient = mock(OppfolgingGateway.class);
-        arbeidssokerRegistrertProducer = (aktorId, brukersSituasjon, opprettetDato) -> {
+        ordinaerBrukerRegistrertProducer = (aktorId, brukersSituasjon, opprettetDato) -> {
             // uten innhold
         };
         arenaOverforingService = new ArenaOverforingService(
-                profileringRepository, brukerRegistreringRepository, oppfolgingClient, arbeidssokerRegistrertProducer);
+                profileringRepository, brukerRegistreringRepository, oppfolgingClient, ordinaerBrukerRegistrertProducer);
     }
 
     @Test

--- a/src/test/java/no/nav/fo/veilarbregistrering/registrering/bruker/SykmeldtBrukerRegistreringServiceTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/registrering/bruker/SykmeldtBrukerRegistreringServiceTest.java
@@ -1,0 +1,82 @@
+package no.nav.fo.veilarbregistrering.registrering.bruker;
+
+import no.nav.fo.veilarbregistrering.bruker.AktorId;
+import no.nav.fo.veilarbregistrering.bruker.Bruker;
+import no.nav.fo.veilarbregistrering.bruker.FnrUtilsTest;
+import no.nav.fo.veilarbregistrering.bruker.Foedselsnummer;
+import no.nav.fo.veilarbregistrering.oppfolging.adapter.OppfolgingClient;
+import no.nav.fo.veilarbregistrering.oppfolging.adapter.OppfolgingGatewayImpl;
+import no.nav.fo.veilarbregistrering.oppfolging.adapter.OppfolgingStatusData;
+import no.nav.fo.veilarbregistrering.sykemelding.adapter.InfotrygdData;
+import no.nav.fo.veilarbregistrering.sykemelding.adapter.SykmeldtInfoClient;
+import no.nav.sbl.featuretoggle.unleash.UnleashService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static java.time.LocalDate.now;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class SykmeldtBrukerRegistreringServiceTest {
+
+    private static Foedselsnummer FNR_OPPFYLLER_KRAV = Foedselsnummer.of(FnrUtilsTest.getFodselsnummerOnDateMinusYears(now(), 40));
+    private static Bruker BRUKER_INTERN = Bruker.of(FNR_OPPFYLLER_KRAV, AktorId.valueOf("AKTØRID"));
+
+    private BrukerRegistreringService brukerRegistreringService;
+    private BrukerRegistreringRepository brukerRegistreringRepository;
+    private SykmeldtInfoClient sykeforloepMetadataClient;
+    private SykmeldtBrukerRegistreringService sykmeldtBrukerRegistreringService;
+    private OppfolgingClient oppfolgingClient;
+    private UnleashService unleashService;
+
+    @BeforeEach
+    public void setup() {
+        brukerRegistreringService = mock(BrukerRegistreringService.class);
+        brukerRegistreringRepository = mock(BrukerRegistreringRepository.class);
+        unleashService = mock(UnleashService.class);
+        oppfolgingClient = mock(OppfolgingClient.class);
+        sykeforloepMetadataClient = mock(SykmeldtInfoClient.class);
+
+        sykmeldtBrukerRegistreringService =
+                new SykmeldtBrukerRegistreringService(
+                        brukerRegistreringService,
+                        brukerRegistreringRepository,
+                        new OppfolgingGatewayImpl(oppfolgingClient),
+                        unleashService);
+
+        when(unleashService.isEnabled("veilarbregistrering.lagreTilstandErAktiv")).thenReturn(true);
+        when(unleashService.isEnabled("veilarbregistrering.lagreUtenArenaOverforing")).thenReturn(false);
+    }
+
+    @Test
+    void skalIkkeRegistrereSykmeldteMedTomBesvarelse() {
+        mockSykmeldtBrukerOver39uker();
+        mockSykmeldtMedArbeidsgiver();
+        SykmeldtRegistrering sykmeldtRegistrering = new SykmeldtRegistrering().setBesvarelse(null);
+        assertThrows(RuntimeException.class, () -> sykmeldtBrukerRegistreringService.registrerSykmeldt(sykmeldtRegistrering, BRUKER_INTERN));
+    }
+
+    @Test
+    void skalIkkeRegistrereSykmeldtSomIkkeOppfyllerKrav() {
+        mockSykmeldtMedArbeidsgiver();
+        SykmeldtRegistrering sykmeldtRegistrering = SykmeldtRegistreringTestdataBuilder.gyldigSykmeldtRegistrering();
+        assertThrows(RuntimeException.class, () -> sykmeldtBrukerRegistreringService.registrerSykmeldt(sykmeldtRegistrering, BRUKER_INTERN));
+    }
+
+    private void mockSykmeldtBrukerOver39uker() {
+        String dagensDatoMinus13Uker = now().plusWeeks(13).toString();
+        when(sykeforloepMetadataClient.hentSykmeldtInfoData(any())).thenReturn(
+                new InfotrygdData()
+                        .withMaksDato(dagensDatoMinus13Uker)
+        );
+    }
+
+    private void mockSykmeldtMedArbeidsgiver() {
+        when(oppfolgingClient.hentOppfolgingsstatus(any())).thenReturn(
+                new OppfolgingStatusData().withErSykmeldtMedArbeidsgiver(true).withKanReaktiveres(false)
+        );
+    }
+
+}

--- a/src/test/java/no/nav/fo/veilarbregistrering/registrering/resources/RegistreringResourceTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/registrering/resources/RegistreringResourceTest.java
@@ -9,10 +9,7 @@ import no.nav.fo.veilarbregistrering.bruker.AktorId;
 import no.nav.fo.veilarbregistrering.bruker.Bruker;
 import no.nav.fo.veilarbregistrering.bruker.Foedselsnummer;
 import no.nav.fo.veilarbregistrering.bruker.UserService;
-import no.nav.fo.veilarbregistrering.registrering.bruker.BrukerRegistreringService;
-import no.nav.fo.veilarbregistrering.registrering.bruker.BrukerRegistreringWrapper;
-import no.nav.fo.veilarbregistrering.registrering.bruker.OrdinaerBrukerRegistrering;
-import no.nav.fo.veilarbregistrering.registrering.bruker.SykmeldtRegistrering;
+import no.nav.fo.veilarbregistrering.registrering.bruker.*;
 import no.nav.fo.veilarbregistrering.registrering.manuell.ManuellRegistreringService;
 import no.nav.sbl.featuretoggle.unleash.UnleashService;
 import org.junit.Before;
@@ -30,6 +27,7 @@ public class RegistreringResourceTest {
     private UserService userService;
     private ManuellRegistreringService manuellRegistreringService;
     private BrukerRegistreringService brukerRegistreringService;
+    private SykmeldtBrukerRegistreringService sykmeldtBrukerRegistreringService;
     private UnleashService unleashService;
 
     private static String IDENT = "10108000398"; //Aremark fiktivt fnr.";
@@ -40,6 +38,7 @@ public class RegistreringResourceTest {
         userService = mock(UserService.class);
         manuellRegistreringService = mock(ManuellRegistreringService.class);
         brukerRegistreringService = mock(BrukerRegistreringService.class);
+        sykmeldtBrukerRegistreringService = mock(SykmeldtBrukerRegistreringService.class);
         unleashService = mock(UnleashService.class);
 
         registreringResource = new RegistreringResource(
@@ -47,8 +46,8 @@ public class RegistreringResourceTest {
                 userService,
                 manuellRegistreringService,
                 brukerRegistreringService,
-                unleashService
-        );
+                unleashService,
+                sykmeldtBrukerRegistreringService);
     }
 
     @Test

--- a/src/test/java/no/nav/veilarbregistrering/integrasjonstest/BrukerRegistreringServiceIntegrationTest.java
+++ b/src/test/java/no/nav/veilarbregistrering/integrasjonstest/BrukerRegistreringServiceIntegrationTest.java
@@ -15,7 +15,7 @@ import no.nav.fo.veilarbregistrering.oppfolging.adapter.OppfolgingStatusData;
 import no.nav.fo.veilarbregistrering.profilering.ProfileringRepository;
 import no.nav.fo.veilarbregistrering.profilering.StartRegistreringUtils;
 import no.nav.fo.veilarbregistrering.profilering.db.ProfileringRepositoryImpl;
-import no.nav.fo.veilarbregistrering.registrering.bruker.ArbeidssokerRegistrertProducer;
+import no.nav.fo.veilarbregistrering.registrering.bruker.OrdinaerBrukerRegistrertProducer;
 import no.nav.fo.veilarbregistrering.registrering.bruker.BrukerRegistreringRepository;
 import no.nav.fo.veilarbregistrering.registrering.bruker.BrukerRegistreringService;
 import no.nav.fo.veilarbregistrering.registrering.bruker.OrdinaerBrukerRegistrering;
@@ -174,7 +174,7 @@ class BrukerRegistreringServiceIntegrationTest {
                 ManuellRegistreringService manuellRegistreringService,
                 StartRegistreringUtils startRegistreringUtils,
                 UnleashService unleashServicee,
-                ArbeidssokerRegistrertProducer arbeidssokerRegistrertProducer) {
+                OrdinaerBrukerRegistrertProducer ordinaerBrukerRegistrertProducer) {
 
             return new BrukerRegistreringService(
                     brukerRegistreringRepository,
@@ -186,7 +186,7 @@ class BrukerRegistreringServiceIntegrationTest {
                     manuellRegistreringService,
                     startRegistreringUtils,
                     unleashServicee,
-                    arbeidssokerRegistrertProducer
+                    ordinaerBrukerRegistrertProducer
             );
         }
 
@@ -196,7 +196,7 @@ class BrukerRegistreringServiceIntegrationTest {
         }
 
         @Bean
-        ArbeidssokerRegistrertProducer meldingsSender() {
+        OrdinaerBrukerRegistrertProducer meldingsSender() {
             return (aktorId, brukersSituasjon, opprettetDato) -> {
                 //noop
             };


### PR DESCRIPTION
Ønsker å dele opp BrukerRegistreringService i mindre deler, hvor hver del har et tydeligere ansvar, i stedet for å bare fortsette og utvide den eksisterende med hele tiden nye avhengigheter.