### PR TITLE
Sender med callId som header på KontaktBrukerOpprettetEvent

### DIFF
--- a/src/main/java/no/nav/fo/veilarbregistrering/bruker/OppholdstillatelseService.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/bruker/OppholdstillatelseService.java
@@ -1,0 +1,5 @@
+package no.nav.fo.veilarbregistrering.bruker;
+
+public interface OppholdstillatelseService {
+    void hentOgSammenlignOppholdFor(AktorId aktorid);
+}

--- a/src/main/java/no/nav/fo/veilarbregistrering/bruker/OppholdstillatelseServiceImpl.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/bruker/OppholdstillatelseServiceImpl.java
@@ -1,8 +1,5 @@
-package no.nav.fo.veilarbregistrering.registrering.bruker;
+package no.nav.fo.veilarbregistrering.bruker;
 
-import no.nav.fo.veilarbregistrering.bruker.AktorId;
-import no.nav.fo.veilarbregistrering.bruker.PdlOppslagGateway;
-import no.nav.fo.veilarbregistrering.bruker.Person;
 import no.nav.fo.veilarbregistrering.metrics.Metrics;
 import no.nav.sbl.featuretoggle.unleash.UnleashService;
 import org.slf4j.Logger;
@@ -10,14 +7,14 @@ import org.slf4j.LoggerFactory;
 
 import static no.nav.fo.veilarbregistrering.metrics.Metrics.Event.OPPHOLDSTILLATELSE_EVENT;
 
-public class DatakvalitetOppholdstillatelseServiceImpl implements DatakvalitetOppholdstillatelseService {
+public class OppholdstillatelseServiceImpl implements OppholdstillatelseService {
 
-    private static final Logger LOG = LoggerFactory.getLogger(DatakvalitetOppholdstillatelseServiceImpl.class);
+    private static final Logger LOG = LoggerFactory.getLogger(OppholdstillatelseServiceImpl.class);
 
     private PdlOppslagGateway pdlOppslagGateway;
     private UnleashService unleashService;
 
-    public DatakvalitetOppholdstillatelseServiceImpl(PdlOppslagGateway pdlOppslagGateway, UnleashService unleashService) {
+    public OppholdstillatelseServiceImpl(PdlOppslagGateway pdlOppslagGateway, UnleashService unleashService) {
         this.pdlOppslagGateway = pdlOppslagGateway;
         this.unleashService = unleashService;
     }

--- a/src/main/java/no/nav/fo/veilarbregistrering/config/ServiceBeansConfig.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/config/ServiceBeansConfig.java
@@ -3,10 +3,7 @@ package no.nav.fo.veilarbregistrering.config;
 import no.nav.apiapp.security.veilarbabac.VeilarbAbacPepClient;
 import no.nav.fo.veilarbregistrering.arbeidsforhold.ArbeidsforholdGateway;
 import no.nav.fo.veilarbregistrering.arbeidsforhold.resources.ArbeidsforholdResource;
-import no.nav.fo.veilarbregistrering.bruker.AktorGateway;
-import no.nav.fo.veilarbregistrering.bruker.PdlOppslagGateway;
-import no.nav.fo.veilarbregistrering.bruker.PersonGateway;
-import no.nav.fo.veilarbregistrering.bruker.UserService;
+import no.nav.fo.veilarbregistrering.bruker.*;
 import no.nav.fo.veilarbregistrering.oppfolging.OppfolgingGateway;
 import no.nav.fo.veilarbregistrering.oppgave.KontaktBrukerHenvendelseProducer;
 import no.nav.fo.veilarbregistrering.oppgave.OppgaveGateway;
@@ -205,8 +202,8 @@ public class ServiceBeansConfig {
     }
 
     @Bean
-    DatakvalitetOppholdstillatelseService datakvalitetOppholdstillatelseService(PdlOppslagGateway pdlOppslagGateway, UnleashService unleashService) {
-        return new DatakvalitetOppholdstillatelseServiceImpl(pdlOppslagGateway, unleashService);
+    OppholdstillatelseService datakvalitetOppholdstillatelseService(PdlOppslagGateway pdlOppslagGateway, UnleashService unleashService) {
+        return new OppholdstillatelseServiceImpl(pdlOppslagGateway, unleashService);
     }
 
 }

--- a/src/main/java/no/nav/fo/veilarbregistrering/kafka/KafkaConfig.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/kafka/KafkaConfig.java
@@ -4,7 +4,7 @@ import io.confluent.kafka.serializers.KafkaAvroDeserializer;
 import io.confluent.kafka.serializers.KafkaAvroDeserializerConfig;
 import io.confluent.kafka.serializers.KafkaAvroSerializer;
 import io.confluent.kafka.serializers.KafkaAvroSerializerConfig;
-import no.nav.fo.veilarbregistrering.registrering.bruker.DatakvalitetOppholdstillatelseService;
+import no.nav.fo.veilarbregistrering.bruker.OppholdstillatelseService;
 import no.nav.sbl.featuretoggle.unleash.UnleashService;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
@@ -65,13 +65,13 @@ public class KafkaConfig {
     @Bean
     KontaktBrukerOpprettetKafkaConsumer kontaktBrukerOpprettetKafkaConsumer(
             UnleashService unleashService,
-            DatakvalitetOppholdstillatelseService datakvalitetOppholdstillatelseService
+            OppholdstillatelseService oppholdstillatelseService
     ) {
         return new KontaktBrukerOpprettetKafkaConsumer(
                 kafkaConsumerProperties(),
                 unleashService,
                 "aapen-arbeid-arbeidssoker-kontaktbruker-opprettet" + getEnvSuffix(),
-                datakvalitetOppholdstillatelseService);
+                oppholdstillatelseService);
     }
 
     @Bean

--- a/src/main/java/no/nav/fo/veilarbregistrering/kafka/KontaktBrukerOpprettetKafkaConsumer.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/kafka/KontaktBrukerOpprettetKafkaConsumer.java
@@ -2,7 +2,7 @@ package no.nav.fo.veilarbregistrering.kafka;
 
 import no.nav.arbeid.soker.oppgave.KontaktBrukerOpprettetEvent;
 import no.nav.fo.veilarbregistrering.bruker.AktorId;
-import no.nav.fo.veilarbregistrering.registrering.bruker.DatakvalitetOppholdstillatelseService;
+import no.nav.fo.veilarbregistrering.bruker.OppholdstillatelseService;
 import no.nav.log.MDCConstants;
 import no.nav.sbl.featuretoggle.unleash.UnleashService;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
@@ -32,13 +32,13 @@ class KontaktBrukerOpprettetKafkaConsumer implements Runnable {
     private final Properties kafkaConsumerProperties;
     private final UnleashService unleashService;
     private final String topic;
-    private final DatakvalitetOppholdstillatelseService bruker;
+    private final OppholdstillatelseService bruker;
 
     KontaktBrukerOpprettetKafkaConsumer(
             Properties kafkaConsumerProperties,
             UnleashService unleashService,
             String topic,
-            DatakvalitetOppholdstillatelseService bruker) {
+            OppholdstillatelseService bruker) {
         this.kafkaConsumerProperties = kafkaConsumerProperties;
         this.unleashService = unleashService;
         this.topic = topic;

--- a/src/main/java/no/nav/fo/veilarbregistrering/kafka/KontaktBrukerOpprettetKafkaConsumer.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/kafka/KontaktBrukerOpprettetKafkaConsumer.java
@@ -12,6 +12,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.Properties;
@@ -60,7 +61,7 @@ class KontaktBrukerOpprettetKafkaConsumer implements Runnable {
 
                 consumerRecords.forEach(record -> {
                     Header header = record.headers().lastHeader(MDCConstants.MDC_CALL_ID);
-                    String callId = new String(header.value());
+                    String callId = new String(header.value(), StandardCharsets.UTF_8);
 
                     MDC.put(MDCConstants.MDC_CALL_ID, callId);
                     LOG.info("Behandler kontaktBrukerOpprettetEvent - callId: {}", callId);

--- a/src/main/java/no/nav/fo/veilarbregistrering/kafka/KontaktBrukerOpprettetKafkaConsumer.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/kafka/KontaktBrukerOpprettetKafkaConsumer.java
@@ -1,13 +1,13 @@
 package no.nav.fo.veilarbregistrering.kafka;
 
 import no.nav.arbeid.soker.oppgave.KontaktBrukerOpprettetEvent;
-import no.nav.common.utils.IdUtils;
 import no.nav.fo.veilarbregistrering.bruker.AktorId;
 import no.nav.fo.veilarbregistrering.registrering.bruker.DatakvalitetOppholdstillatelseService;
 import no.nav.log.MDCConstants;
 import no.nav.sbl.featuretoggle.unleash.UnleashService;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.header.Header;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
@@ -59,8 +59,11 @@ class KontaktBrukerOpprettetKafkaConsumer implements Runnable {
                 LOG.info("Leser {} events fra topic {}}", consumerRecords.count(), topic);
 
                 consumerRecords.forEach(record -> {
-                    MDC.put(MDCConstants.MDC_CALL_ID, IdUtils.generateId());
-                    LOG.info("Behandler kontaktBrukerOpprettetEvent");
+                    Header header = record.headers().lastHeader(MDCConstants.MDC_CALL_ID);
+                    String callId = new String(header.value());
+
+                    MDC.put(MDCConstants.MDC_CALL_ID, callId);
+                    LOG.info("Behandler kontaktBrukerOpprettetEvent - callId: {}", callId);
 
                     KontaktBrukerOpprettetEvent kontaktBrukerOpprettetEvent = record.value();
                     bruker.hentOgSammenlignOppholdFor(AktorId.valueOf(kontaktBrukerOpprettetEvent.getAktorid()));

--- a/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/DatakvalitetOppholdstillatelseService.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/DatakvalitetOppholdstillatelseService.java
@@ -1,7 +1,0 @@
-package no.nav.fo.veilarbregistrering.registrering.bruker;
-
-import no.nav.fo.veilarbregistrering.bruker.AktorId;
-
-public interface DatakvalitetOppholdstillatelseService {
-    void hentOgSammenlignOppholdFor(AktorId aktorid);
-}


### PR DESCRIPTION
Legger ved callId som header-info på Kafka-meldingen slik at konsument evt. kan plukke den opp og logge den/legge den til i MDC på nytt.