### PR TITLE
Tar i bruk Nullable-pattern for Opphold

### DIFF
--- a/src/main/java/no/nav/fo/veilarbregistrering/bruker/Opphold.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/bruker/Opphold.java
@@ -1,0 +1,66 @@
+package no.nav.fo.veilarbregistrering.bruker;
+
+import no.nav.fo.veilarbregistrering.metrics.Metric;
+
+public class Opphold implements Metric {
+
+    private final Oppholdstype type;
+    private final Periode periode;
+
+    public static Opphold of(Oppholdstype type, Periode periode) {
+        return new Opphold(type, periode);
+    }
+
+    public static Opphold.NullableOpphold nullable() {
+        return new Opphold.NullableOpphold();
+    }
+
+    private Opphold(Oppholdstype type, Periode periode) {
+        this.type = type;
+        this.periode = periode;
+    }
+
+    public Oppholdstype getType() {
+        return type;
+    }
+
+    @Override
+    public String fieldName() {
+        return "oppholdstype";
+    }
+
+    @Override
+    public Object value() {
+        return type.toString();
+    }
+
+    @Override
+    public String toString() {
+        return "Opphold{" +
+                "type=" + type +
+                ", periode=" + periode +
+                '}';
+    }
+
+    /**
+     * <code>Null object</code> is an object with no referenced value or with defined neutral ("null") behavior
+     */
+    public static class NullableOpphold extends Opphold {
+
+        NullableOpphold() {
+            super(Oppholdstype.UKJENT, null);
+        }
+
+        @Override
+        public String value() {
+            return "INGEN_VERDI";
+        }
+    }
+
+    public enum Oppholdstype {
+        MIDLERTIDIG,
+        PERMANENT,
+        OPPLYSNING_MANGLER,
+        UKJENT
+    }
+}

--- a/src/main/java/no/nav/fo/veilarbregistrering/bruker/Periode.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/bruker/Periode.java
@@ -1,0 +1,26 @@
+package no.nav.fo.veilarbregistrering.bruker;
+
+import java.time.LocalDate;
+
+public class Periode {
+
+    private final LocalDate fra;
+    private final LocalDate til;
+
+    public static Periode of(LocalDate fra, LocalDate til) {
+        return new Periode(fra, til);
+    }
+
+    private Periode(LocalDate fra, LocalDate til) {
+        this.fra = fra;
+        this.til = til;
+    }
+
+    @Override
+    public String toString() {
+        return "Periode{" +
+                "fra=" + fra +
+                ", til=" + til +
+                '}';
+    }
+}

--- a/src/main/java/no/nav/fo/veilarbregistrering/bruker/Person.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/bruker/Person.java
@@ -1,9 +1,5 @@
 package no.nav.fo.veilarbregistrering.bruker;
 
-import no.nav.fo.veilarbregistrering.metrics.Metric;
-
-import java.time.LocalDate;
-
 public class Person {
 
     private final Opphold opphold;
@@ -19,7 +15,7 @@ public class Person {
     }
 
     public Opphold getOpphold() {
-        return opphold;
+        return opphold != null ? opphold : Opphold.nullable();
     }
 
     public Statsborgerskap getStatsborgerskap() {
@@ -34,103 +30,4 @@ public class Person {
                 '}';
     }
 
-    public static class Opphold implements Metric {
-
-        private final Oppholdstype type;
-        private final Periode periode;
-
-        public static Opphold of(Oppholdstype type, Periode periode) {
-            return new Opphold(type, periode);
-        }
-
-        private Opphold(Oppholdstype type, Periode periode) {
-            this.type = type;
-            this.periode = periode;
-        }
-
-        public Oppholdstype getType() {
-            return type;
-        }
-
-        @Override
-        public String fieldName() {
-            return "oppholdstype";
-        }
-
-        @Override
-        public Object value() {
-            return type.toString();
-        }
-
-        @Override
-        public String toString() {
-            return "Opphold{" +
-                    "type=" + type +
-                    ", periode=" + periode +
-                    '}';
-        }
-    }
-
-    public enum Oppholdstype {
-        MIDLERTIDIG,
-        PERMANENT,
-        OPPLYSNING_MANGLER
-    }
-
-    public static class Statsborgerskap implements Metric {
-
-        private final String statsborgerskap;
-        private final Periode periode;
-
-        public static Statsborgerskap of(String statsborgerskap, Periode periode) {
-            return new Statsborgerskap(statsborgerskap, periode);
-        }
-        private Statsborgerskap(String statsborgerskap, Periode periode) {
-            this.statsborgerskap = statsborgerskap;
-            this.periode = periode;
-        }
-
-        public String getStatsborgerskap() {
-            return statsborgerskap;
-        }
-
-        @Override
-        public String toString() {
-            return "Statsborgerskap{" +
-                    "statsborgerskap='" + statsborgerskap + '\'' +
-                    ", periode=" + periode +
-                    '}';
-        }
-
-        @Override
-        public String fieldName() {
-            return "statsborgerskap";
-        }
-
-        @Override
-        public Object value() {
-            return statsborgerskap;
-        }
-    }
-    public static class Periode {
-
-        private final LocalDate fra;
-        private final LocalDate til;
-
-        public static Periode of(LocalDate fra, LocalDate til) {
-            return new Periode(fra, til);
-        }
-        private Periode(LocalDate fra, LocalDate til) {
-            this.fra = fra;
-            this.til = til;
-        }
-
-        @Override
-        public String toString() {
-            return "Periode{" +
-                    "fra=" + fra +
-                    ", til=" + til +
-                    '}';
-        }
-    }
 }

--- a/src/main/java/no/nav/fo/veilarbregistrering/bruker/Statsborgerskap.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/bruker/Statsborgerskap.java
@@ -1,0 +1,39 @@
+package no.nav.fo.veilarbregistrering.bruker;
+
+import no.nav.fo.veilarbregistrering.metrics.Metric;
+
+public class Statsborgerskap implements Metric {
+
+    private final String statsborgerskap;
+    private final Periode periode;
+
+    public static Statsborgerskap of(String statsborgerskap, Periode periode) {
+        return new Statsborgerskap(statsborgerskap, periode);
+    }
+    private Statsborgerskap(String statsborgerskap, Periode periode) {
+        this.statsborgerskap = statsborgerskap;
+        this.periode = periode;
+    }
+
+    public String getStatsborgerskap() {
+        return statsborgerskap;
+    }
+
+    @Override
+    public String toString() {
+        return "Statsborgerskap{" +
+                "statsborgerskap='" + statsborgerskap + '\'' +
+                ", periode=" + periode +
+                '}';
+    }
+
+    @Override
+    public String fieldName() {
+        return "statsborgerskap";
+    }
+
+    @Override
+    public Object value() {
+        return statsborgerskap;
+    }
+}

--- a/src/main/java/no/nav/fo/veilarbregistrering/bruker/pdl/PdlOppslagMapper.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/bruker/pdl/PdlOppslagMapper.java
@@ -1,6 +1,9 @@
 package no.nav.fo.veilarbregistrering.bruker.pdl;
 
+import no.nav.fo.veilarbregistrering.bruker.Opphold;
+import no.nav.fo.veilarbregistrering.bruker.Periode;
 import no.nav.fo.veilarbregistrering.bruker.Person;
+import no.nav.fo.veilarbregistrering.bruker.Statsborgerskap;
 
 import java.time.LocalDate;
 
@@ -16,24 +19,24 @@ class PdlOppslagMapper {
                         .orElse(null));
     }
 
-    private static Person.Opphold map(PdlPersonOpphold pdlPersonOpphold) {
-        return Person.Opphold.of(
-                Person.Oppholdstype.valueOf(pdlPersonOpphold.getType().name()),
+    private static Opphold map(PdlPersonOpphold pdlPersonOpphold) {
+        return Opphold.of(
+                Opphold.Oppholdstype.valueOf(pdlPersonOpphold.getType().name()),
                 mapPeriode(pdlPersonOpphold.getOppholdFra(), pdlPersonOpphold.getOppholdTil()));
     }
 
-    private static Person.Statsborgerskap map(PdlStatsborgerskap pdlStatsborgerskap) {
-        return Person.Statsborgerskap.of(
+    private static Statsborgerskap map(PdlStatsborgerskap pdlStatsborgerskap) {
+        return Statsborgerskap.of(
                 pdlStatsborgerskap.getLand(),
                 mapPeriode(pdlStatsborgerskap.getGyldigFraOgMed(), pdlStatsborgerskap.getGyldigTilOgMed()));
     }
 
-    private static Person.Periode mapPeriode(LocalDate gyldigFraOgMed, LocalDate gyldigTilOgMed) {
+    private static Periode mapPeriode(LocalDate gyldigFraOgMed, LocalDate gyldigTilOgMed) {
         if (gyldigFraOgMed == null && gyldigTilOgMed == null) {
             return null;
         }
 
-        return Person.Periode.of(
+        return Periode.of(
                 gyldigFraOgMed,
                 gyldigTilOgMed);
     }

--- a/src/test/java/no/nav/fo/veilarbregistrering/bruker/pdl/PdlOppslagMapperTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/bruker/pdl/PdlOppslagMapperTest.java
@@ -1,5 +1,6 @@
 package no.nav.fo.veilarbregistrering.bruker.pdl;
 
+import no.nav.fo.veilarbregistrering.bruker.Opphold;
 import no.nav.fo.veilarbregistrering.bruker.Person;
 import org.junit.Test;
 
@@ -40,6 +41,6 @@ public class PdlOppslagMapperTest {
 
         Person person = PdlOppslagMapper.map(pdlPerson);
 
-        assertThat(person.getOpphold().getType()).isEqualTo(Person.Oppholdstype.PERMANENT);
+        assertThat(person.getOpphold().getType()).isEqualTo(Opphold.Oppholdstype.PERMANENT);
     }
 }


### PR DESCRIPTION
Vi ser at Opphold kan være null i produksjon, og håndterer dette ved å implementere Nullable-patternet.
Da får vi enkelt målinger på disse tilfellene også, uten å endre mye av koden rundt.