### PR TITLE
Ruller tilbake common_java pga bug

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>no.nav.common</groupId>
         <artifactId>mor-pom</artifactId>
-        <version>1.2020.03.09_15.32-9fad31995403</version>
+        <version>1.2020.03.06_08.57-4e0010fee887</version>
     </parent>
 
     <groupId>no.nav.fo</groupId>


### PR DESCRIPTION
Det har blitt lagt på et complance-filter paa alle innkommende requests, inkl /ping som maa vaere et unntak. Denne feilen ble funnet og fikset 24. mars