### PR TITLE
Eksponerer `alder` via `/startregistrering`

### DIFF
--- a/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/BrukerRegistreringService.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/BrukerRegistreringService.java
@@ -154,7 +154,10 @@ public class BrukerRegistreringService {
         }
 
         StartRegistreringStatusDto startRegistreringStatus = map(
-                brukersTilstand, muligGeografiskTilknytning, oppfyllerBetingelseOmArbeidserfaring);
+                brukersTilstand,
+                muligGeografiskTilknytning,
+                oppfyllerBetingelseOmArbeidserfaring,
+                fnr.alder(now()));
 
         LOG.info("Returnerer startregistreringsstatus {}", startRegistreringStatus);
         return startRegistreringStatus;

--- a/src/main/java/no/nav/fo/veilarbregistrering/registrering/resources/StartRegistreringStatusDto.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/registrering/resources/StartRegistreringStatusDto.java
@@ -16,4 +16,5 @@ public class StartRegistreringStatusDto {
     private String servicegruppe;
     private String rettighetsgruppe;
     private String geografiskTilknytning;
+    private int alder;
 }

--- a/src/main/java/no/nav/fo/veilarbregistrering/registrering/resources/StartRegistreringStatusDtoMapper.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/registrering/resources/StartRegistreringStatusDtoMapper.java
@@ -13,7 +13,8 @@ public class StartRegistreringStatusDtoMapper {
     public static StartRegistreringStatusDto map(
             BrukersTilstand brukersTilstand,
             Optional<GeografiskTilknytning> muligGeografiskTilknytning,
-            Boolean oppfyllerBetingelseOmArbeidserfaring) {
+            Boolean oppfyllerBetingelseOmArbeidserfaring,
+            int alder) {
 
         return new StartRegistreringStatusDto()
                 .setUnderOppfolging(brukersTilstand.isUnderOppfolging())
@@ -24,6 +25,7 @@ public class StartRegistreringStatusDtoMapper {
                 .setFormidlingsgruppe(brukersTilstand.getFormidlingsgruppe().orElse(Formidlingsgruppe.nullable()).stringValue())
                 .setServicegruppe(brukersTilstand.getServicegruppe().orElse(Servicegruppe.nullable()).stringValue())
                 .setRettighetsgruppe(brukersTilstand.getRettighetsgruppe().orElse(Rettighetsgruppe.nullable()).stringValue())
-                .setGeografiskTilknytning(muligGeografiskTilknytning.map(GeografiskTilknytning::stringValue).orElse(null));
+                .setGeografiskTilknytning(muligGeografiskTilknytning.map(GeografiskTilknytning::stringValue).orElse(null))
+                .setAlder(alder);
     }
 }

--- a/src/test/java/no/nav/fo/veilarbregistrering/registrering/resources/StartRegistreringStatusDtoMapperTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/registrering/resources/StartRegistreringStatusDtoMapperTest.java
@@ -33,7 +33,8 @@ public class StartRegistreringStatusDtoMapperTest {
         StartRegistreringStatusDto dto = StartRegistreringStatusDtoMapper.map(
                 brukersTilstand,
                 Optional.empty(),
-                false);
+                false,
+                0);
 
         SoftAssertions softAssertions = new SoftAssertions();
         softAssertions.assertThat(dto.getRegistreringType()).isEqualTo(ORDINAER_REGISTRERING);
@@ -64,7 +65,8 @@ public class StartRegistreringStatusDtoMapperTest {
         StartRegistreringStatusDto dto = StartRegistreringStatusDtoMapper.map(
                 brukersTilstand,
                 Optional.of(GeografiskTilknytning.of("030109")),
-                true);
+                true,
+                30);
 
         SoftAssertions softAssertions = new SoftAssertions();
         softAssertions.assertThat(dto.getRegistreringType()).isEqualTo(SYKMELDT_REGISTRERING);
@@ -95,7 +97,8 @@ public class StartRegistreringStatusDtoMapperTest {
         StartRegistreringStatusDto dto = StartRegistreringStatusDtoMapper.map(
                 brukersTilstand,
                 Optional.of(GeografiskTilknytning.of("030109")),
-                false);
+                false,
+                30);
 
         assertThat(dto.isErSykmeldtMedArbeidsgiver()).isEqualTo(false);
     }


### PR DESCRIPTION
Dette er den raskeste og enkleste implementasjonen som også brukes ifm. profilering, men alder bør hentes fra TPS/PDL, fremfor å utledes via Fødselsnummer.