### PR TITLE
Fjerner proxy-metode for harJobbetSammenhengendeSeksAvTolvSisteManeder

### DIFF
--- a/src/main/java/no/nav/fo/veilarbregistrering/profilering/StartRegistreringUtils.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/profilering/StartRegistreringUtils.java
@@ -14,14 +14,6 @@ public class StartRegistreringUtils {
             Supplier<FlereArbeidsforhold> arbeidsforholdSupplier,
             LocalDate dagensDato, Besvarelse besvarelse
     ) {
-        return Profilering.of(besvarelse, alder, harJobbetSammenhengendeSeksAvTolvSisteManeder(arbeidsforholdSupplier, dagensDato));
-    }
-
-    //FIXME: Burde kunne være static
-    public boolean harJobbetSammenhengendeSeksAvTolvSisteManeder(
-            Supplier<FlereArbeidsforhold> arbeidsforholdSupplier,
-            LocalDate dagensDato) {
-
-        return arbeidsforholdSupplier.get().harJobbetSammenhengendeSeksAvTolvSisteManeder(dagensDato);
+        return Profilering.of(besvarelse, alder, arbeidsforholdSupplier.get().harJobbetSammenhengendeSeksAvTolvSisteManeder(dagensDato));
     }
 }

--- a/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/BrukerRegistreringService.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/BrukerRegistreringService.java
@@ -148,9 +148,9 @@ public class BrukerRegistreringService {
 
         Boolean oppfyllerBetingelseOmArbeidserfaring = null;
         if (ORDINAER_REGISTRERING.equals(registreringType)) {
-            oppfyllerBetingelseOmArbeidserfaring = startRegistreringUtils.harJobbetSammenhengendeSeksAvTolvSisteManeder(
-                    () -> arbeidsforholdGateway.hentArbeidsforhold(fnr),
-                    now());
+            oppfyllerBetingelseOmArbeidserfaring =
+                    arbeidsforholdGateway.hentArbeidsforhold(fnr)
+                            .harJobbetSammenhengendeSeksAvTolvSisteManeder(now());
         }
 
         StartRegistreringStatusDto startRegistreringStatus = map(

--- a/src/test/java/no/nav/fo/veilarbregistrering/oppfolging/adapter/OppfolgingClientTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/oppfolging/adapter/OppfolgingClientTest.java
@@ -28,6 +28,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.InternalServerErrorException;
 import javax.ws.rs.WebApplicationException;
 
+import static no.nav.fo.veilarbregistrering.arbeidsforhold.FlereArbeidsforholdTestdataBuilder.flereArbeidsforholdTilfeldigSortert;
 import static no.nav.fo.veilarbregistrering.profilering.ProfileringTestdataBuilder.lagProfilering;
 import static no.nav.fo.veilarbregistrering.registrering.bruker.OrdinaerBrukerRegistreringTestdataBuilder.gyldigBrukerRegistrering;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -49,6 +50,7 @@ class OppfolgingClientTest {
     private BrukerRegistreringRepository brukerRegistreringRepository;
     private BrukerRegistreringService brukerRegistreringService;
     private OppfolgingClient oppfolgingClient;
+    private ArbeidsforholdGateway arbeidsforholdGateway;
     private StartRegistreringUtils startRegistreringUtils;
     private ClientAndServer mockServer;
 
@@ -67,7 +69,7 @@ class OppfolgingClientTest {
 
         brukerRegistreringRepository = mock(BrukerRegistreringRepository.class);
         ProfileringRepository profileringRepository = mock(ProfileringRepository.class);
-        ArbeidsforholdGateway arbeidsforholdGateway = mock(ArbeidsforholdGateway.class);
+        arbeidsforholdGateway = mock(ArbeidsforholdGateway.class);
         SykmeldtInfoClient sykeforloepMetadataClient = mock(SykmeldtInfoClient.class);
         startRegistreringUtils = mock(StartRegistreringUtils.class);
         ManuellRegistreringService manuellRegistreringService = mock(ManuellRegistreringService.class);
@@ -90,7 +92,6 @@ class OppfolgingClientTest {
                         arbeidssokerRegistrertProducer,
                         arbeidssokerProfilertProducer);
 
-        when(startRegistreringUtils.harJobbetSammenhengendeSeksAvTolvSisteManeder(any(), any())).thenReturn(true);
         when(startRegistreringUtils.profilerBruker(anyInt(), any(), any(), any()))
                 .thenReturn(new Profilering()
                         .setInnsatsgruppe(Innsatsgruppe.STANDARD_INNSATS)
@@ -208,6 +209,8 @@ class OppfolgingClientTest {
     public void testAtGirIngenExceptionsDersomKun200MedKanReaktiveresNull() {
         mockServer.when(request().withMethod("GET").withPath("/oppfolging"))
                 .respond(response().withBody(settOppfolgingOgReaktivering(null, null), MediaType.JSON_UTF_8).withStatusCode(200));
+
+        when(arbeidsforholdGateway.hentArbeidsforhold(any())).thenReturn(flereArbeidsforholdTilfeldigSortert());
 
         assertNotNull(brukerRegistreringService.hentStartRegistreringStatus(IDENT));
     }

--- a/src/test/java/no/nav/fo/veilarbregistrering/profilering/StartRegistreringUtilsTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/profilering/StartRegistreringUtilsTest.java
@@ -93,7 +93,7 @@ class StartRegistreringUtilsTest {
         if (besvarelse.getHelseHinder().equals(HelseHinderSvar.JA) || besvarelse.getAndreForhold().equals(AndreForholdSvar.JA)) {
             onsketInnsatsgruppe = Innsatsgruppe.BEHOV_FOR_ARBEIDSEVNEVURDERING;
         } else if ((18 <= alder && alder <= 59)
-                    && startRegistreringUtils.harJobbetSammenhengendeSeksAvTolvSisteManeder(arbeidsforholdSupplier, dagensDato)
+                    && arbeidsforholdSupplier.get().harJobbetSammenhengendeSeksAvTolvSisteManeder(dagensDato)
                     && !besvarelse.getUtdanning().equals(UtdanningSvar.INGEN_UTDANNING)
                     && besvarelse.getUtdanningBestatt().equals(UtdanningBestattSvar.JA)
                     && besvarelse.getUtdanningGodkjent().equals(UtdanningGodkjentSvar.JA)

--- a/src/test/java/no/nav/fo/veilarbregistrering/sykemelding/adapter/SykmeldtInfoClientTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/sykemelding/adapter/SykmeldtInfoClientTest.java
@@ -83,7 +83,6 @@ class SykmeldtInfoClientTest {
                         arbeidssokerProfileringProducer);
 
 
-        when(startRegistreringUtils.harJobbetSammenhengendeSeksAvTolvSisteManeder(any(), any())).thenReturn(true);
         when(unleashService.isEnabled(any())).thenReturn(true);
     }
 

--- a/src/test/java/no/nav/veilarbregistrering/integrasjonstest/BrukerRegistreringServiceIntegrationTest.java
+++ b/src/test/java/no/nav/veilarbregistrering/integrasjonstest/BrukerRegistreringServiceIntegrationTest.java
@@ -107,7 +107,6 @@ class BrukerRegistreringServiceIntegrationTest {
         when(unleashService.isEnabled("veilarbregistrering.lagreTilstandErAktiv")).thenReturn(true);
         when(unleashService.isEnabled("veilarbregistrering.lagreUtenArenaOverforing")).thenReturn(false);
         when(oppfolgingClient.hentOppfolgingsstatus(any())).thenReturn(new OppfolgingStatusData().withUnderOppfolging(false).withKanReaktiveres(false));
-        when(startRegistreringUtils.harJobbetSammenhengendeSeksAvTolvSisteManeder(any(), any())).thenReturn(true);
         when(startRegistreringUtils.profilerBruker(anyInt(), any(), any(), any())).thenReturn(lagProfilering());
     }
 


### PR DESCRIPTION
StartRegisteringUtil har fungert som en dum proxy, og ikke tilført så mye verdi. Ved å ha mer logikk på domenet, kan denne metoden nå fjernes.
Neste steg blir å fjerne/endre resterende metode.