### PR TITLE
Kobler routing til OppgaveService

### DIFF
--- a/src/main/java/no/nav/fo/veilarbregistrering/config/ServiceBeansConfig.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/config/ServiceBeansConfig.java
@@ -138,11 +138,13 @@ public class ServiceBeansConfig {
     @Bean
     OppgaveService oppgaveService(
             OppgaveGateway oppgaveGateway,
+            OppgaveRouterProxy oppgaveRouterProxy,
             OppgaveRepository oppgaveRepository,
             KontaktBrukerHenvendelseProducer kontaktBrukerHenvendelseProducer) {
 
         return new OppgaveService(
                 oppgaveGateway,
+                oppgaveRouterProxy,
                 oppgaveRepository,
                 kontaktBrukerHenvendelseProducer);
     }
@@ -156,8 +158,8 @@ public class ServiceBeansConfig {
     }
 
     @Bean
-    OppgaveRouterProxy oppgaveRouterProxy(OppgaveRouter oppgaveRouter) {
-        return new OppgaveRouterProxy(oppgaveRouter);
+    OppgaveRouterProxy oppgaveRouterProxy(OppgaveRouter oppgaveRouter, PersonGateway personGateway) {
+        return new OppgaveRouterProxy(oppgaveRouter, personGateway);
     }
 
     @Bean

--- a/src/main/java/no/nav/fo/veilarbregistrering/oppgave/OppgaveGateway.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/oppgave/OppgaveGateway.java
@@ -1,9 +1,10 @@
 package no.nav.fo.veilarbregistrering.oppgave;
 
 import no.nav.fo.veilarbregistrering.bruker.AktorId;
+import no.nav.fo.veilarbregistrering.orgenhet.Enhetsnr;
 
 public interface OppgaveGateway {
 
-    Oppgave opprettOppgave(AktorId aktoerId, String beskrivelse);
+    Oppgave opprettOppgave(AktorId aktoerId, String beskrivelse, Enhetsnr enhetsnr);
 
 }

--- a/src/main/java/no/nav/fo/veilarbregistrering/oppgave/OppgaveRouter.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/oppgave/OppgaveRouter.java
@@ -29,7 +29,10 @@ public class OppgaveRouter implements HentEnhetsIdForSisteArbeidsforhold {
     private final EnhetGateway enhetGateway;
     private final Norg2Gateway norg2Gateway;
 
-    public OppgaveRouter(ArbeidsforholdGateway arbeidsforholdGateway, EnhetGateway enhetGateway, Norg2Gateway norg2Gateway) {
+    public OppgaveRouter(
+            ArbeidsforholdGateway arbeidsforholdGateway,
+            EnhetGateway enhetGateway,
+            Norg2Gateway norg2Gateway) {
         this.arbeidsforholdGateway = arbeidsforholdGateway;
         this.enhetGateway = enhetGateway;
         this.norg2Gateway = norg2Gateway;

--- a/src/main/java/no/nav/fo/veilarbregistrering/oppgave/OppgaveRouterProxy.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/oppgave/OppgaveRouterProxy.java
@@ -1,6 +1,8 @@
 package no.nav.fo.veilarbregistrering.oppgave;
 
 import no.nav.fo.veilarbregistrering.bruker.Bruker;
+import no.nav.fo.veilarbregistrering.bruker.GeografiskTilknytning;
+import no.nav.fo.veilarbregistrering.bruker.PersonGateway;
 import no.nav.fo.veilarbregistrering.orgenhet.Enhetsnr;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -16,9 +18,20 @@ public class OppgaveRouterProxy implements HentEnhetsIdForSisteArbeidsforhold {
     private static final Logger LOG = LoggerFactory.getLogger(OppgaveRouterProxy.class);
 
     private final OppgaveRouter oppgaveRouter;
+    private final PersonGateway personGateway;
 
-    public OppgaveRouterProxy(OppgaveRouter oppgaveRouter) {
+    public OppgaveRouterProxy(OppgaveRouter oppgaveRouter, PersonGateway personGateway) {
         this.oppgaveRouter = oppgaveRouter;
+        this.personGateway = personGateway;
+    }
+
+    public Optional<GeografiskTilknytning> hentGeografiskTilknytningFor(Bruker bruker) {
+        try {
+            return personGateway.hentGeografiskTilknytning(bruker.getFoedselsnummer());
+        } catch (RuntimeException e) {
+            LOG.warn("Henting av geografisk tilknytning feilet", e);
+            return Optional.empty();
+        }
     }
 
     @Override
@@ -27,7 +40,7 @@ public class OppgaveRouterProxy implements HentEnhetsIdForSisteArbeidsforhold {
             return oppgaveRouter.hentEnhetsnummerForSisteArbeidsforholdTil(bruker);
         } catch (RuntimeException e) {
             LOG.warn("Henting av enhetsnummer for siste arbeidsforhold feilet", e);
-            return Optional.of(Enhetsnr.of("-1"));
+            return Optional.empty();
         }
     }
 }

--- a/src/main/java/no/nav/fo/veilarbregistrering/oppgave/adapter/OppgaveDto.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/oppgave/adapter/OppgaveDto.java
@@ -18,5 +18,6 @@ class OppgaveDto {
     private String fristFerdigstillelse;
     private String aktivDato;
     private String prioritet;
+    private String tildeltEnhetsnr;
 
 }

--- a/src/main/java/no/nav/fo/veilarbregistrering/oppgave/adapter/OppgaveGatewayImpl.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/oppgave/adapter/OppgaveGatewayImpl.java
@@ -3,6 +3,7 @@ package no.nav.fo.veilarbregistrering.oppgave.adapter;
 import no.nav.fo.veilarbregistrering.oppgave.Oppgave;
 import no.nav.fo.veilarbregistrering.oppgave.OppgaveGateway;
 import no.nav.fo.veilarbregistrering.bruker.AktorId;
+import no.nav.fo.veilarbregistrering.orgenhet.Enhetsnr;
 
 import java.time.LocalDate;
 
@@ -19,7 +20,7 @@ public class OppgaveGatewayImpl implements OppgaveGateway {
     }
 
     @Override
-    public Oppgave opprettOppgave(AktorId aktoerId, String beskrivelse) {
+    public Oppgave opprettOppgave(AktorId aktoerId, String beskrivelse, Enhetsnr enhetsnr) {
         OppgaveDto oppgaveDto = new OppgaveDto();
         oppgaveDto.setAktoerId(aktoerId.asString());
         oppgaveDto.setBeskrivelse(beskrivelse);

--- a/src/test/java/no/nav/fo/veilarbregistrering/oppgave/OppgaveServiceTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/oppgave/OppgaveServiceTest.java
@@ -26,43 +26,52 @@ public class OppgaveServiceTest {
     private OppgaveService oppgaveService;
     private OppgaveGateway oppgaveGateway;
     private OppgaveRepository oppgaveRepository;
+    private OppgaveRouterProxy oppgaveRouterProxy;
 
     @Before
     public void setUp() {
         oppgaveGateway = mock(OppgaveGateway.class);
         oppgaveRepository = mock(OppgaveRepository.class);
+        oppgaveRouterProxy = mock(OppgaveRouterProxy.class);
         oppgaveService = new CustomOppgaveService(
                 oppgaveGateway,
                 oppgaveRepository,
                 aktorId -> {
-                });
+                },
+                oppgaveRouterProxy);
     }
 
     @Test
     public void opprettOppgave_ang_opphold_skal_gi_beskrivelse_om_rutine() {
-        when(oppgaveGateway.opprettOppgave(any(), any())).thenReturn(new DummyOppgaveResponse());
+        when(oppgaveGateway.opprettOppgave(any(), any(), any())).thenReturn(new DummyOppgaveResponse());
 
         oppgaveService.opprettOppgave(BRUKER, OPPHOLDSTILLATELSE);
 
-        verify(oppgaveGateway, times(1)).opprettOppgave(BRUKER.getAktorId(), "Brukeren får ikke registrert seg som arbeidssøker pga. manglende oppholdstillatelse i Arena, " +
+        verify(oppgaveGateway, times(1)).opprettOppgave(
+                BRUKER.getAktorId(),
+                "Brukeren får ikke registrert seg som arbeidssøker pga. manglende oppholdstillatelse i Arena, " +
                 "og har selv opprettet denne oppgaven. " +
-                "Ring bruker og følg midlertidig rutine på navet om løsning for registreringen av arbeids- og oppholdstillatelse.");
+                "Ring bruker og følg midlertidig rutine på navet om løsning for registreringen av arbeids- og oppholdstillatelse.",
+                null);
     }
 
     @Test
     public void opprettOppgave_ang_dod_utvandret_skal_gi_beskrivelse_om_rutine() {
-        when(oppgaveGateway.opprettOppgave(any(), any())).thenReturn(new DummyOppgaveResponse());
+        when(oppgaveGateway.opprettOppgave(any(), any(), any())).thenReturn(new DummyOppgaveResponse());
 
         oppgaveService.opprettOppgave(BRUKER, UTVANDRET);
 
-        verify(oppgaveGateway, times(1)).opprettOppgave(BRUKER.getAktorId(), "Brukeren får ikke registrert seg som arbeidssøker fordi bruker står som utvandret i Arena, " +
+        verify(oppgaveGateway, times(1)).opprettOppgave(
+                BRUKER.getAktorId(),
+                "Brukeren får ikke registrert seg som arbeidssøker fordi bruker står som utvandret i Arena, " +
                 "og har selv opprettet denne oppgaven. " +
-                "Ring bruker og følg vanlig rutine for slike tilfeller.");
+                "Ring bruker og følg vanlig rutine for slike tilfeller.",
+                null);
     }
 
     @Test
     public void skal_lagre_oppgave_ved_vellykket_opprettelse_av_oppgave() {
-        when(oppgaveGateway.opprettOppgave(any(), any())).thenReturn(new DummyOppgaveResponse());
+        when(oppgaveGateway.opprettOppgave(any(), any(), any())).thenReturn(new DummyOppgaveResponse());
         oppgaveService.opprettOppgave(BRUKER, OPPHOLDSTILLATELSE);
 
         verify(oppgaveRepository, times(1))
@@ -87,25 +96,31 @@ public class OppgaveServiceTest {
         List<OppgaveImpl> oppgaver = Collections.singletonList(oppgaveSomBleOpprettetTreDagerFor);
 
         when(oppgaveRepository.hentOppgaverFor(any())).thenReturn(oppgaver);
-        when(oppgaveGateway.opprettOppgave(any(), any())).thenReturn(new DummyOppgaveResponse());
+        when(oppgaveGateway.opprettOppgave(any(), any(), any())).thenReturn(new DummyOppgaveResponse());
 
         oppgaveService.opprettOppgave(BRUKER, OPPHOLDSTILLATELSE);
 
-        verify(oppgaveGateway, times(1)).opprettOppgave(BRUKER.getAktorId(), "Brukeren får ikke registrert seg som arbeidssøker pga. manglende oppholdstillatelse i Arena, " +
+        verify(oppgaveGateway, times(1)).opprettOppgave(
+                BRUKER.getAktorId(),
+                "Brukeren får ikke registrert seg som arbeidssøker pga. manglende oppholdstillatelse i Arena, " +
                 "og har selv opprettet denne oppgaven. " +
-                "Ring bruker og følg midlertidig rutine på navet om løsning for registreringen av arbeids- og oppholdstillatelse.");
+                "Ring bruker og følg midlertidig rutine på navet om løsning for registreringen av arbeids- og oppholdstillatelse.",
+                null);
     }
 
     @Test
     public void ingen_tidligere_oppgaver() {
         when(oppgaveRepository.hentOppgaverFor(any())).thenReturn(emptyList());
-        when(oppgaveGateway.opprettOppgave(any(), any())).thenReturn(new DummyOppgaveResponse());
+        when(oppgaveGateway.opprettOppgave(any(), any(), any())).thenReturn(new DummyOppgaveResponse());
 
         oppgaveService.opprettOppgave(BRUKER, OPPHOLDSTILLATELSE);
 
-        verify(oppgaveGateway, times(1)).opprettOppgave(BRUKER.getAktorId(), "Brukeren får ikke registrert seg som arbeidssøker pga. manglende oppholdstillatelse i Arena, " +
+        verify(oppgaveGateway, times(1)).opprettOppgave(
+                BRUKER.getAktorId(),
+                "Brukeren får ikke registrert seg som arbeidssøker pga. manglende oppholdstillatelse i Arena, " +
                 "og har selv opprettet denne oppgaven. " +
-                "Ring bruker og følg midlertidig rutine på navet om løsning for registreringen av arbeids- og oppholdstillatelse.");
+                "Ring bruker og følg midlertidig rutine på navet om løsning for registreringen av arbeids- og oppholdstillatelse.",
+                null);
     }
 
     private static class DummyOppgaveResponse implements Oppgave {
@@ -123,8 +138,12 @@ public class OppgaveServiceTest {
 
     private static class CustomOppgaveService extends OppgaveService {
 
-        public CustomOppgaveService(OppgaveGateway oppgaveGateway, OppgaveRepository oppgaveRepository, KontaktBrukerHenvendelseProducer kontaktBrukerHenvendelseProducer) {
-            super(oppgaveGateway, oppgaveRepository, kontaktBrukerHenvendelseProducer);
+        public CustomOppgaveService(
+                OppgaveGateway oppgaveGateway,
+                OppgaveRepository oppgaveRepository,
+                KontaktBrukerHenvendelseProducer kontaktBrukerHenvendelseProducer,
+                OppgaveRouterProxy oppgaveRouterProxy) {
+            super(oppgaveGateway, oppgaveRouterProxy, oppgaveRepository, kontaktBrukerHenvendelseProducer);
         }
 
         @Override

--- a/src/test/java/no/nav/fo/veilarbregistrering/oppgave/adapter/OppgaveGatewayConfig.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/oppgave/adapter/OppgaveGatewayConfig.java
@@ -10,6 +10,6 @@ public class OppgaveGatewayConfig {
     @Bean
     OppgaveGateway oppgaveGateway() {
 
-        return (aktoerId, beskrivelse) -> null;
+        return (aktoerId, beskrivelse, enhetsnr) -> null;
     }
 }

--- a/src/test/java/no/nav/fo/veilarbregistrering/oppgave/adapter/OppgaveGatewayTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/oppgave/adapter/OppgaveGatewayTest.java
@@ -81,7 +81,8 @@ class OppgaveGatewayTest {
                                 "\"aktivDato\":\"" +
                                 dagensdato +
                                 "\"," +
-                                "\"prioritet\":\"NORM\"" +
+                                "\"prioritet\":\"NORM\"," +
+                                "\"tildeltEnhetsnr\":null" +
                                 "}"))
                 .respond(response()
                         .withStatusCode(201)
@@ -93,7 +94,8 @@ class OppgaveGatewayTest {
                         AktorId.valueOf("12e1e3"),
                         "Brukeren får ikke registrert seg som arbeidssøker pga. manglende oppholdstillatelse i Arena, " +
                                 "og har selv opprettet denne oppgaven. " +
-                                "Ring bruker og følg midlertidig rutine på navet om løsning for registreringen av arbeids- og oppholdstillatelse."));
+                                "Ring bruker og følg midlertidig rutine på navet om løsning for registreringen av arbeids- og oppholdstillatelse.",
+                        null));
 
         assertThat(oppgave.getId()).isEqualTo(5436732);
         assertThat(oppgave.getTildeltEnhetsnr()).isEqualTo("3012");

--- a/src/test/java/no/nav/fo/veilarbregistrering/oppgave/adapter/OppgaveIntegrationTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/oppgave/adapter/OppgaveIntegrationTest.java
@@ -46,9 +46,11 @@ public class OppgaveIntegrationTest {
         OppgaveRepository oppgaveRepository = mock(OppgaveRepository.class);
         mockServer = ClientAndServer.startClientAndServer(MOCKSERVER_PORT);
         OppgaveGateway oppgaveGateway = new OppgaveGatewayImpl(buildClient());
+        OppgaveRouterProxy oppgaveRouterProxy = mock(OppgaveRouterProxy.class);
 
         oppgaveService = new OppgaveService(
                 oppgaveGateway,
+                oppgaveRouterProxy,
                 oppgaveRepository,
                 aktorId -> { });
     }
@@ -88,7 +90,8 @@ public class OppgaveIntegrationTest {
                                 "\"aktivDato\":\"" +
                                 dagensdato +
                                 "\"," +
-                                "\"prioritet\":\"NORM\"" +
+                                "\"prioritet\":\"NORM\"," +
+                                "\"tildeltEnhetsnr\":null" +
                                 "}"))
                 .respond(response()
                         .withStatusCode(201)


### PR DESCRIPTION
Sørger for å route oppgaver av typen UTVANDRET til riktig enhetsnummer dersom bruker ikke har geografisk tilknytning, og vi finner enhetsnummer knytte ttil siste arbeidsforhold til bruker. Hvis ikke så sendes `null` til Oppgave, så de router som normalt.