### PR TITLE
Kobler til OppgaveRouting til OppgaveService

### DIFF
--- a/src/main/java/no/nav/fo/veilarbregistrering/config/ServiceBeansConfig.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/config/ServiceBeansConfig.java
@@ -141,11 +141,12 @@ public class ServiceBeansConfig {
     OppgaveService oppgaveService(
             OppgaveGateway oppgaveGateway,
             OppgaveRepository oppgaveRepository,
+            OppgaveRouter oppgaveRouter,
             KontaktBrukerHenvendelseProducer kontaktBrukerHenvendelseProducer) {
-
         return new OppgaveService(
                 oppgaveGateway,
                 oppgaveRepository,
+                oppgaveRouter,
                 kontaktBrukerHenvendelseProducer);
     }
 
@@ -196,7 +197,6 @@ public class ServiceBeansConfig {
             BrukerRegistreringRepository brukerRegistreringRepository,
             OppfolgingGateway oppfolgingGateway,
             ArbeidssokerRegistrertProducer arbeidssokerRegistrertProducer) {
-
         return new ArenaOverforingService(
                 profileringRepository,
                 brukerRegistreringRepository,

--- a/src/main/java/no/nav/fo/veilarbregistrering/oppgave/OppgaveGateway.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/oppgave/OppgaveGateway.java
@@ -1,9 +1,10 @@
 package no.nav.fo.veilarbregistrering.oppgave;
 
 import no.nav.fo.veilarbregistrering.bruker.AktorId;
+import no.nav.fo.veilarbregistrering.orgenhet.Enhetsnr;
 
 public interface OppgaveGateway {
 
-    Oppgave opprettOppgave(AktorId aktoerId, String beskrivelse);
+    Oppgave opprettOppgave(AktorId aktoerId, Enhetsnr enhetsnr, String beskrivelse);
 
 }

--- a/src/main/java/no/nav/fo/veilarbregistrering/oppgave/OppgaveRouter.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/oppgave/OppgaveRouter.java
@@ -43,7 +43,11 @@ public class OppgaveRouter {
         this.personGateway = personGateway;
     }
 
-    public Optional<Enhetsnr> hentEnhetsnummerFor(Bruker bruker) {
+    public Optional<Enhetsnr> hentEnhetsnummerFor(Bruker bruker, OppgaveType oppgaveType) {
+        if (!oppgaveType.equals(OppgaveType.UTVANDRET)) {
+            return Optional.empty();
+        }
+
         Optional<GeografiskTilknytning> geografiskTilknytning;
         try {
             geografiskTilknytning = personGateway.hentGeografiskTilknytning(bruker.getFoedselsnummer());

--- a/src/main/java/no/nav/fo/veilarbregistrering/oppgave/adapter/OppgaveDto.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/oppgave/adapter/OppgaveDto.java
@@ -18,5 +18,6 @@ class OppgaveDto {
     private String fristFerdigstillelse;
     private String aktivDato;
     private String prioritet;
+    private String tildeltEnhetsnr;
 
 }

--- a/src/main/java/no/nav/fo/veilarbregistrering/oppgave/adapter/OppgaveGatewayImpl.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/oppgave/adapter/OppgaveGatewayImpl.java
@@ -3,6 +3,7 @@ package no.nav.fo.veilarbregistrering.oppgave.adapter;
 import no.nav.fo.veilarbregistrering.oppgave.Oppgave;
 import no.nav.fo.veilarbregistrering.oppgave.OppgaveGateway;
 import no.nav.fo.veilarbregistrering.bruker.AktorId;
+import no.nav.fo.veilarbregistrering.orgenhet.Enhetsnr;
 
 import java.time.LocalDate;
 
@@ -19,9 +20,10 @@ public class OppgaveGatewayImpl implements OppgaveGateway {
     }
 
     @Override
-    public Oppgave opprettOppgave(AktorId aktoerId, String beskrivelse) {
+    public Oppgave opprettOppgave(AktorId aktoerId, Enhetsnr enhetsnr, String beskrivelse) {
         OppgaveDto oppgaveDto = new OppgaveDto();
         oppgaveDto.setAktoerId(aktoerId.asString());
+        oppgaveDto.setTildeltEnhetsnr(enhetsnr != null ? enhetsnr.asString() : null);
         oppgaveDto.setBeskrivelse(beskrivelse);
         oppgaveDto.setTema(OPPFOLGING);
         oppgaveDto.setOppgavetype(KONTAKT_BRUKER);

--- a/src/test/java/no/nav/fo/veilarbregistrering/oppgave/OppgaveRouterTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/oppgave/OppgaveRouterTest.java
@@ -16,6 +16,7 @@ import java.util.Collections;
 import java.util.Optional;
 
 import static no.nav.fo.veilarbregistrering.arbeidsforhold.FlereArbeidsforholdTestdataBuilder.flereArbeidsforholdTilfeldigSortert;
+import static no.nav.fo.veilarbregistrering.oppgave.OppgaveType.UTVANDRET;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class OppgaveRouterTest {
@@ -32,7 +33,7 @@ public class OppgaveRouterTest {
 
         OppgaveRouter oppgaveRouter = new OppgaveRouter(arbeidsforholdGateway, enhetGateway, norg2Gateway, personGateway);
 
-        Optional<Enhetsnr> enhetsnr = oppgaveRouter.hentEnhetsnummerFor(BRUKER);
+        Optional<Enhetsnr> enhetsnr = oppgaveRouter.hentEnhetsnummerFor(BRUKER, UTVANDRET);
 
         assertThat(enhetsnr).isEmpty();
     }
@@ -46,7 +47,7 @@ public class OppgaveRouterTest {
 
         OppgaveRouter oppgaveRouter = new OppgaveRouter(arbeidsforholdGateway, enhetGateway, norg2Gateway, personGateway);
 
-        Optional<Enhetsnr> enhetsnr = oppgaveRouter.hentEnhetsnummerFor(BRUKER);
+        Optional<Enhetsnr> enhetsnr = oppgaveRouter.hentEnhetsnummerFor(BRUKER, UTVANDRET);
 
         assertThat(enhetsnr).isEmpty();
     }
@@ -67,7 +68,7 @@ public class OppgaveRouterTest {
 
         OppgaveRouter oppgaveRouter = new OppgaveRouter(arbeidsforholdGateway, enhetGateway, norg2Gateway, personGateway);
 
-        Optional<Enhetsnr> enhetsnr = oppgaveRouter.hentEnhetsnummerFor(BRUKER);
+        Optional<Enhetsnr> enhetsnr = oppgaveRouter.hentEnhetsnummerFor(BRUKER, UTVANDRET);
 
         assertThat(enhetsnr).isEmpty();
     }
@@ -88,7 +89,7 @@ public class OppgaveRouterTest {
 
         OppgaveRouter oppgaveRouter = new OppgaveRouter(arbeidsforholdGateway, enhetGateway, norg2Gateway, personGateway);
 
-        Optional<Enhetsnr> enhetsnr = oppgaveRouter.hentEnhetsnummerFor(BRUKER);
+        Optional<Enhetsnr> enhetsnr = oppgaveRouter.hentEnhetsnummerFor(BRUKER, UTVANDRET);
 
         assertThat(enhetsnr).hasValue(Enhetsnr.of("232"));
     }
@@ -102,7 +103,7 @@ public class OppgaveRouterTest {
 
         OppgaveRouter oppgaveRouter = new OppgaveRouter(arbeidsforholdGateway, enhetGateway, norg2Gateway, personGateway);
 
-        Optional<Enhetsnr> enhetsnr = oppgaveRouter.hentEnhetsnummerFor(BRUKER);
+        Optional<Enhetsnr> enhetsnr = oppgaveRouter.hentEnhetsnummerFor(BRUKER, UTVANDRET);
 
         assertThat(enhetsnr).isEmpty();
     }

--- a/src/test/java/no/nav/fo/veilarbregistrering/oppgave/adapter/OppgaveGatewayConfig.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/oppgave/adapter/OppgaveGatewayConfig.java
@@ -10,6 +10,6 @@ public class OppgaveGatewayConfig {
     @Bean
     OppgaveGateway oppgaveGateway() {
 
-        return (aktoerId, beskrivelse) -> null;
+        return (aktoerId, enhetsnr, beskrivelse) -> null;
     }
 }

--- a/src/test/java/no/nav/fo/veilarbregistrering/oppgave/adapter/OppgaveGatewayTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/oppgave/adapter/OppgaveGatewayTest.java
@@ -81,7 +81,8 @@ class OppgaveGatewayTest {
                                 "\"aktivDato\":\"" +
                                 dagensdato +
                                 "\"," +
-                                "\"prioritet\":\"NORM\"" +
+                                "\"prioritet\":\"NORM\"," +
+                                "\"tildeltEnhetsnr\":null" +
                                 "}"))
                 .respond(response()
                         .withStatusCode(201)
@@ -91,6 +92,7 @@ class OppgaveGatewayTest {
                 new Subject("foo", IdentType.EksternBruker, SsoToken.oidcToken("bar", new HashMap<>())),
                 () -> oppgaveGateway.opprettOppgave(
                         AktorId.valueOf("12e1e3"),
+                        null,
                         "Brukeren får ikke registrert seg som arbeidssøker pga. manglende oppholdstillatelse i Arena, " +
                                 "og har selv opprettet denne oppgaven. " +
                                 "Ring bruker og følg midlertidig rutine på navet om løsning for registreringen av arbeids- og oppholdstillatelse."));


### PR DESCRIPTION
Sørger for å opprette oppgaver med tilknyttetEnhetsnr dersom det er en UTVANDRET-oppgave, bruker mangler geografisk tilknytning og vi finne enhetsnr via siste arbeidsforhold.