### PR TITLE
Bedre håndtering av "ikke treff i KRR"

### DIFF
--- a/src/main/java/no/nav/fo/veilarbregistrering/bruker/krr/KrrClient.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/bruker/krr/KrrClient.java
@@ -72,6 +72,10 @@ class KrrClient {
 
             KrrFeilDto feil = gson.fromJson(response.toString(), KrrFeilDto.class);
 
+            if ("Ingen kontaktinformasjon er registrert på personen".equals(feil.getMelding())) {
+                throw new NotFoundException(feil.getMelding());
+            }
+
             throw new RuntimeException(String.format("Henting av kontaktinfo fra KRR feilet: %s", feil.getMelding()));
         }
         throw new RuntimeException("Ukjent feil");


### PR DESCRIPTION
KRR returnerer en tekststreng dersom vi ikke får treff på personen. Bruker denne for å skille på ikke funnet og tekniske feil.