### PR TITLE
Utvider KontaktBrukerOpprettetEvent m/ oppgavetype

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
         <dependency>
             <groupId>no.nav.arbeid</groupId>
             <artifactId>veilarbregistrering-skjema</artifactId>
-            <version>1.202004301354-b728b07</version>
+            <version>1.202005251110-cb2c669</version>
         </dependency>
         <dependency>
             <groupId>io.confluent</groupId>

--- a/src/main/java/no/nav/fo/veilarbregistrering/oppgave/KontaktBrukerHenvendelseProducer.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/oppgave/KontaktBrukerHenvendelseProducer.java
@@ -4,5 +4,5 @@ import no.nav.fo.veilarbregistrering.bruker.AktorId;
 
 public interface KontaktBrukerHenvendelseProducer {
 
-    void publiserHenvendelse(AktorId aktorId);
+    void publiserHenvendelse(AktorId aktorId, OppgaveType oppgaveType);
 }

--- a/src/main/java/no/nav/fo/veilarbregistrering/oppgave/OppgaveService.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/oppgave/OppgaveService.java
@@ -59,8 +59,7 @@ public class OppgaveService {
     public Oppgave opprettOppgave(Bruker bruker, OppgaveType oppgaveType) {
         validerNyOppgaveMotAktive(bruker, oppgaveType);
 
-        //TODO: Utvide event med type oppgave
-        kontaktBrukerHenvendelseProducer.publiserHenvendelse(bruker.getAktorId());
+        kontaktBrukerHenvendelseProducer.publiserHenvendelse(bruker.getAktorId(), oppgaveType);
 
         Optional<Enhetsnr> enhetsnr = oppgaveRouter.hentEnhetsnummerFor(bruker, oppgaveType);
 

--- a/src/test/java/no/nav/fo/veilarbregistrering/oppgave/OppgaveServiceTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/oppgave/OppgaveServiceTest.java
@@ -38,7 +38,7 @@ public class OppgaveServiceTest {
                 oppgaveGateway,
                 oppgaveRepository,
                 oppgaveRouter,
-                aktorId -> {
+                (aktorId, oppgaveType) -> {
                 });
     }
 

--- a/src/test/java/no/nav/fo/veilarbregistrering/oppgave/adapter/OppgaveIntegrationTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/oppgave/adapter/OppgaveIntegrationTest.java
@@ -56,7 +56,7 @@ public class OppgaveIntegrationTest {
                 oppgaveGateway,
                 oppgaveRepository,
                 oppgaveRouter,
-                aktorId -> { });
+                (aktorId, oppgaveType) -> { });
     }
 
     private OppgaveRestClient buildClient() {


### PR DESCRIPTION
For å kunne skille på UTVANDRET eller MANGLENDE OPPHOLDSTILLATELSE når vi konsumerer meldingen, har vi behov for å kunne få med oppgavetype.
Det er ikke relevant å hente status på opphold for brukere som er utvandret.