### PR TITLE
Fikser test som feiler pga. dato

### DIFF
--- a/src/main/java/no/nav/fo/veilarbregistrering/oppgave/OppgaveGateway.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/oppgave/OppgaveGateway.java
@@ -7,6 +7,11 @@ import java.time.LocalDate;
 
 public interface OppgaveGateway {
 
-    Oppgave opprettOppgave(AktorId aktoerId, Enhetsnr enhetsnr, String beskrivelse, LocalDate fristFerdigstillelse);
+    Oppgave opprettOppgave(
+            AktorId aktoerId,
+            Enhetsnr enhetsnr,
+            String beskrivelse,
+            LocalDate fristFerdigstillelse,
+            LocalDate aktivDato);
 
 }

--- a/src/main/java/no/nav/fo/veilarbregistrering/oppgave/OppgaveService.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/oppgave/OppgaveService.java
@@ -68,7 +68,8 @@ public class OppgaveService {
                 bruker.getAktorId(),
                 enhetsnr.orElse(null),
                 beskrivelser.get(oppgaveType),
-                fristFerdigstillelse
+                fristFerdigstillelse,
+                idag()
         );
 
         LOG.info("Oppgave (type:{}) ble opprettet med id: {} og ble tildelt enhet: {}",

--- a/src/main/java/no/nav/fo/veilarbregistrering/oppgave/adapter/OppgaveGatewayImpl.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/oppgave/adapter/OppgaveGatewayImpl.java
@@ -20,7 +20,12 @@ public class OppgaveGatewayImpl implements OppgaveGateway {
     }
 
     @Override
-    public Oppgave opprettOppgave(AktorId aktoerId, Enhetsnr enhetsnr, String beskrivelse, LocalDate fristFerdigstillelse) {
+    public Oppgave opprettOppgave(
+            AktorId aktoerId,
+            Enhetsnr enhetsnr,
+            String beskrivelse,
+            LocalDate fristFerdigstillelse,
+            LocalDate aktivDato) {
         OppgaveDto oppgaveDto = new OppgaveDto();
         oppgaveDto.setAktoerId(aktoerId.asString());
         oppgaveDto.setTildeltEnhetsnr(enhetsnr != null ? enhetsnr.asString() : null);
@@ -28,7 +33,7 @@ public class OppgaveGatewayImpl implements OppgaveGateway {
         oppgaveDto.setTema(OPPFOLGING);
         oppgaveDto.setOppgavetype(KONTAKT_BRUKER);
         oppgaveDto.setFristFerdigstillelse(fristFerdigstillelse.toString());
-        oppgaveDto.setAktivDato(LocalDate.now().toString());
+        oppgaveDto.setAktivDato(aktivDato.toString());
         oppgaveDto.setPrioritet(NORM);
 
         return restClient.opprettOppgave(oppgaveDto);

--- a/src/test/java/no/nav/fo/veilarbregistrering/oppgave/adapter/OppgaveGatewayConfig.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/oppgave/adapter/OppgaveGatewayConfig.java
@@ -10,6 +10,6 @@ public class OppgaveGatewayConfig {
     @Bean
     OppgaveGateway oppgaveGateway() {
 
-        return (aktoerId, enhetsnr, beskrivelse, fristFerdigstillelse) -> null;
+        return (aktoerId, enhetsnr, beskrivelse, fristFerdigstillelse, aktivDato) -> null;
     }
 }

--- a/src/test/java/no/nav/fo/veilarbregistrering/oppgave/adapter/OppgaveGatewayTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/oppgave/adapter/OppgaveGatewayTest.java
@@ -60,8 +60,8 @@ class OppgaveGatewayTest {
 
         OppgaveGateway oppgaveGateway = new OppgaveGatewayImpl(buildClient());
 
-        String dagensdato = LocalDate.now().toString();
-        String to_dager_senere = LocalDate.now().plusDays(2).toString();
+        LocalDate dagensdato = LocalDate.now();
+        LocalDate toDagerSenere = LocalDate.now().plusDays(2);
 
         mockServer.when(
                 request()
@@ -76,10 +76,10 @@ class OppgaveGatewayTest {
                                 "\"tema\":\"OPP\"," +
                                 "\"oppgavetype\":\"KONT_BRUK\"," +
                                 "\"fristFerdigstillelse\":\"" +
-                                to_dager_senere +
+                                toDagerSenere.toString() +
                                 "\"," +
                                 "\"aktivDato\":\"" +
-                                dagensdato +
+                                dagensdato.toString() +
                                 "\"," +
                                 "\"prioritet\":\"NORM\"," +
                                 "\"tildeltEnhetsnr\":null" +
@@ -96,7 +96,9 @@ class OppgaveGatewayTest {
                         "Brukeren får ikke registrert seg som arbeidssøker pga. manglende oppholdstillatelse i Arena, " +
                                 "og har selv opprettet denne oppgaven. " +
                                 "Ring bruker og følg midlertidig rutine på navet om løsning for registreringen av arbeids- og oppholdstillatelse.",
-                        LocalDate.now().plusDays(2)));
+                        LocalDate.now().plusDays(2),
+                        dagensdato
+                        ));
 
         assertThat(oppgave.getId()).isEqualTo(5436732);
         assertThat(oppgave.getTildeltEnhetsnr()).isEqualTo("3012");

--- a/src/test/java/no/nav/fo/veilarbregistrering/oppgave/adapter/OppgaveIntegrationTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/oppgave/adapter/OppgaveIntegrationTest.java
@@ -52,7 +52,7 @@ public class OppgaveIntegrationTest {
         OppgaveGateway oppgaveGateway = new OppgaveGatewayImpl(buildClient());
         oppgaveRouter = mock(OppgaveRouter.class);
 
-        oppgaveService = new OppgaveService(
+        oppgaveService = new CustomOppgaveService(
                 oppgaveGateway,
                 oppgaveRepository,
                 oppgaveRouter,
@@ -73,8 +73,8 @@ public class OppgaveIntegrationTest {
 
     @Test
     public void vellykket_opprettelse_av_oppgave_skal_gi_201() {
-        String dagensdato = LocalDate.now().toString();
-        String to_dager_senere = LocalDate.now().plusDays(2).toString();
+        String dagensdato = LocalDate.of(2020, 5, 27).toString();
+        String toArbeidsdagerSenere = LocalDate.of(2020, 5, 29).toString();
 
         when(oppgaveRouter.hentEnhetsnummerFor(BRUKER, OppgaveType.UTVANDRET)).thenReturn(Optional.of(Enhetsnr.of("0301")));
 
@@ -91,7 +91,7 @@ public class OppgaveIntegrationTest {
                                 "\"tema\":\"OPP\"," +
                                 "\"oppgavetype\":\"KONT_BRUK\"," +
                                 "\"fristFerdigstillelse\":\"" +
-                                to_dager_senere +
+                                toArbeidsdagerSenere +
                                 "\"," +
                                 "\"aktivDato\":\"" +
                                 dagensdato +
@@ -119,5 +119,21 @@ public class OppgaveIntegrationTest {
                 "\"aktoerId\": \"12e1e3\",\n" +
                 "\"tildeltEnhetsnr\": \"3012\"\n" +
                 "}";
+    }
+
+    private static class CustomOppgaveService extends OppgaveService {
+
+        public CustomOppgaveService(
+                OppgaveGateway oppgaveGateway,
+                OppgaveRepository oppgaveRepository,
+                OppgaveRouter oppgaveRouter,
+                KontaktBrukerHenvendelseProducer kontaktBrukerHenvendelseProducer) {
+            super(oppgaveGateway, oppgaveRepository, oppgaveRouter, kontaktBrukerHenvendelseProducer);
+        }
+
+        @Override
+        protected LocalDate idag() {
+            return LocalDate.of(2020, 5, 27);
+        }
     }
 }


### PR DESCRIPTION
Test begynte å feile når fristdato ikke alltid var +2 dager. Da må vi også tilpasse datoen som brukes i testene, og gjøre den overstyrbar.