### PR TITLE
Sjekker om geografisk tilknytning inneholder landkode ifm. Oppgave-ro…

### DIFF
--- a/src/main/java/no/nav/fo/veilarbregistrering/bruker/GeografiskTilknytning.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/bruker/GeografiskTilknytning.java
@@ -74,7 +74,7 @@ public class GeografiskTilknytning implements Metric {
         return fieldName;
     }
 
-    private boolean utland() {
+    public boolean utland() {
         return geografisktilknytning.length() == 3 && geografisktilknytning.matches("^[a-åA-Å]*$");
     }
 

--- a/src/main/java/no/nav/fo/veilarbregistrering/oppgave/RoutingStep.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/oppgave/RoutingStep.java
@@ -6,6 +6,7 @@ public enum  RoutingStep implements Metric {
 
     GeografiskTilknytning_Feilet,
     GeografiskTilknytning_Funnet,
+    GeografiskTilknytning_Utland,
     Enhetsnummer_Feilet,
     SisteArbeidsforhold_IkkeFunnet,
     OrgNummer_ikkeFunnet,


### PR DESCRIPTION
…uting

Geografisk tilknytning kan inneholde en landkode (3 bokstaver). Da ønsker vi å route via siste arbeidsforhold, på lik linje som om geografisk tilknytning ikke fantes.