### PR TITLE
Utelater bruk av Cookie i Header ved asynk overføring

### DIFF
--- a/src/main/java/no/nav/fo/veilarbregistrering/oppfolging/adapter/OppfolgingGatewayConfig.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/oppfolging/adapter/OppfolgingGatewayConfig.java
@@ -3,6 +3,7 @@ package no.nav.fo.veilarbregistrering.oppfolging.adapter;
 import no.nav.common.oidc.SystemUserTokenProvider;
 import no.nav.fo.veilarbregistrering.config.GammelSystemUserTokenProvider;
 import no.nav.fo.veilarbregistrering.oppfolging.OppfolgingGateway;
+import no.nav.sbl.featuretoggle.unleash.UnleashService;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -19,8 +20,16 @@ public class OppfolgingGatewayConfig {
     public static final String OPPFOLGING_API_PROPERTY_NAME = "VEILARBOPPFOLGINGAPI_URL";
 
     @Bean
-    OppfolgingClient oppfolgingClient(Provider<HttpServletRequest> provider, SystemUserTokenProvider systemUserTokenProvider, GammelSystemUserTokenProvider gammelSystemUserTokenProvider) {
-        return new OppfolgingClient(getRequiredProperty(OPPFOLGING_API_PROPERTY_NAME), provider, systemUserTokenProvider, gammelSystemUserTokenProvider);
+    OppfolgingClient oppfolgingClient(
+            Provider<HttpServletRequest> provider,
+            SystemUserTokenProvider systemUserTokenProvider,
+            GammelSystemUserTokenProvider gammelSystemUserTokenProvider,
+            UnleashService unleashService) {
+        return new OppfolgingClient(
+                getRequiredProperty(OPPFOLGING_API_PROPERTY_NAME),
+                provider, systemUserTokenProvider,
+                gammelSystemUserTokenProvider,
+                unleashService);
     }
 
     @Bean

--- a/src/test/java/no/nav/fo/veilarbregistrering/oppfolging/adapter/OppfolgingClientMock.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/oppfolging/adapter/OppfolgingClientMock.java
@@ -9,7 +9,7 @@ import javax.ws.rs.core.Response;
 public class OppfolgingClientMock extends OppfolgingClient {
 
     OppfolgingClientMock() {
-        super(null, null, null, null);
+        super(null, null, null, null, null);
     }
 
     @Override

--- a/src/test/java/no/nav/fo/veilarbregistrering/oppfolging/adapter/OppfolgingClientTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/oppfolging/adapter/OppfolgingClientTest.java
@@ -111,7 +111,9 @@ class OppfolgingClientTest {
         when(systemUserTokenProvider.getSystemUserAccessToken()).thenReturn("testToken");
         when(gammelSystemUserTokenProvider.getToken()).thenReturn("testToken");
         String baseUrl = "http://" + MOCKSERVER_URL + ":" + MOCKSERVER_PORT;
-        OppfolgingClient oppfolgingClient = this.oppfolgingClient = new OppfolgingClient(baseUrl, httpServletRequestProvider, systemUserTokenProvider, gammelSystemUserTokenProvider);
+        UnleashService unleashService = mock(UnleashService.class);
+        when(unleashService.isEnabled(any())).thenReturn(false);
+        OppfolgingClient oppfolgingClient = this.oppfolgingClient = new OppfolgingClient(baseUrl, httpServletRequestProvider, systemUserTokenProvider, gammelSystemUserTokenProvider, unleashService);
         return oppfolgingClient;
     }
 

--- a/src/test/java/no/nav/fo/veilarbregistrering/sykemelding/adapter/SykmeldtInfoClientTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/sykemelding/adapter/SykmeldtInfoClientTest.java
@@ -95,7 +95,7 @@ class SykmeldtInfoClientTest {
     private OppfolgingClient buildOppfolgingClient() {
         Provider<HttpServletRequest> httpServletRequestProvider = new ConfigBuildClient().invoke();
         String baseUrl = "http://" + MOCKSERVER_URL + ":" + MOCKSERVER_PORT;
-        return oppfolgingClient = new OppfolgingClient(baseUrl, httpServletRequestProvider, null, null);
+        return oppfolgingClient = new OppfolgingClient(baseUrl, httpServletRequestProvider, null, null, null);
     }
 
     @Test


### PR DESCRIPTION
Da vi ikke har tilgang på servlet requesten når vi kjører asynk, må vi kalle veilarboppfolging uten.
Vi kjører det bak toggle for å ikke påvirke produksjon mens vi tester.