### PR TITLE
Flytter Swagger ut i interface for oppgave + rydding

### DIFF
--- a/src/main/java/no/nav/fo/veilarbregistrering/config/ServiceBeansConfig.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/config/ServiceBeansConfig.java
@@ -185,10 +185,9 @@ public class ServiceBeansConfig {
     OppgaveResource oppgaveResource(
             VeilarbAbacPepClient pepClient,
             UserService userService,
-            OppgaveService oppgaveService,
-            OppgaveRouter oppgaveRouterProxy
+            OppgaveService oppgaveService
     ) {
-        return new OppgaveResource(pepClient, userService, oppgaveService, oppgaveRouterProxy);
+        return new OppgaveResource(pepClient, userService, oppgaveService);
     }
 
     @Bean

--- a/src/main/java/no/nav/fo/veilarbregistrering/oppgave/resources/OppgaveApi.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/oppgave/resources/OppgaveApi.java
@@ -1,0 +1,16 @@
+package no.nav.fo.veilarbregistrering.oppgave.resources;
+
+import io.swagger.annotations.*;
+
+@Api(value = "OppgaveResource")
+public interface OppgaveApi {
+
+    @ApiOperation(value = "Oppretter 'kontakt bruker'-oppgave på vegne av bruker.")
+    @ApiResponses({
+            @ApiResponse(code = 200, message = "Oppgave opprettet OK"),
+            @ApiResponse(code = 403, message = "Duplikat - fant tilsvarende oppgave " +
+                    "som ble opprettet innenfor de siste 2 arbeidsdager"),
+            @ApiResponse(code = 500, message = "Ukjent teknisk feil")
+    })
+    OppgaveDto opprettOppgave(OppgaveDto oppgaveDto);
+}

--- a/src/main/java/no/nav/fo/veilarbregistrering/oppgave/resources/OppgaveResource.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/oppgave/resources/OppgaveResource.java
@@ -1,17 +1,12 @@
 package no.nav.fo.veilarbregistrering.oppgave.resources;
 
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
 import no.nav.apiapp.security.veilarbabac.VeilarbAbacPepClient;
 import no.nav.fo.veilarbregistrering.bruker.Bruker;
 import no.nav.fo.veilarbregistrering.bruker.UserService;
 import no.nav.fo.veilarbregistrering.oppgave.OppgaveResponse;
-import no.nav.fo.veilarbregistrering.oppgave.OppgaveRouter;
 import no.nav.fo.veilarbregistrering.oppgave.OppgaveService;
-import no.nav.fo.veilarbregistrering.orgenhet.Enhetsnr;
 import org.springframework.stereotype.Component;
 
-import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
@@ -22,29 +17,24 @@ import static no.nav.fo.veilarbregistrering.oppgave.resources.OppgaveMapper.map;
 @Component
 @Path("/oppgave")
 @Produces("application/json")
-@Api(value = "OppgaveResource")
-public class OppgaveResource {
+public class OppgaveResource implements OppgaveApi {
 
     private final OppgaveService oppgaveService;
-    private final OppgaveRouter oppgaveRouter;
     private final UserService userService;
     private final VeilarbAbacPepClient pepClient;
 
     public OppgaveResource(
             VeilarbAbacPepClient pepClient,
             UserService userService,
-            OppgaveService oppgaveService,
-            OppgaveRouter oppgaveRouter
+            OppgaveService oppgaveService
     ) {
         this.pepClient = pepClient;
         this.userService = userService;
         this.oppgaveService = oppgaveService;
-        this.oppgaveRouter = oppgaveRouter;
     }
 
     @POST
-    @Path("/")
-    @ApiOperation(value = "Oppretter oppgave 'kontakt bruker'")
+    @Override
     public OppgaveDto opprettOppgave(OppgaveDto oppgaveDto) {
         final Bruker bruker = userService.hentBruker();
 
@@ -55,16 +45,4 @@ public class OppgaveResource {
         return map(oppgaveResponse, oppgaveDto.getOppgaveType());
     }
 
-    @GET
-    @Path("/routing")
-    @ApiOperation(value = "Henter enhetsId på bakgrunn av siste arbeidsforhold")
-    public String hentEnhetsId() {
-        final Bruker bruker = userService.hentBruker();
-
-        pepClient.sjekkSkrivetilgangTilBruker(map(bruker));
-
-        return oppgaveRouter.hentEnhetsnummerForSisteArbeidsforholdTil(bruker)
-                .map(Enhetsnr::asString)
-                .orElse("0");
-    }
 }


### PR DESCRIPTION
Flytter Swagger-dokumentasjonen for OppgaveResource ut i interface for å rydde litt. Hvis det funker, ønsker jeg å gjøre det samme for de andre APIene våre.

Fjerner samtidig endepunkt som kun var ment til uttesting, og som nå ikke lenger har noen funksjon.
n Please enter the commit message for your changes. Lines starting