### PR TITLE
Mindre justeringer ift. første løsning

### DIFF
--- a/src/main/java/no/nav/fo/veilarbregistrering/arbeidssoker/Arbeidssokerperiode.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/arbeidssoker/Arbeidssokerperiode.java
@@ -4,6 +4,7 @@ import no.nav.fo.veilarbregistrering.bruker.Periode;
 import no.nav.fo.veilarbregistrering.oppfolging.Formidlingsgruppe;
 
 import java.time.LocalDate;
+import java.util.Comparator;
 import java.util.Objects;
 
 public class Arbeidssokerperiode {
@@ -18,6 +19,10 @@ public class Arbeidssokerperiode {
     public Arbeidssokerperiode(Formidlingsgruppe formidlingsgruppe, Periode periode) {
         this.formidlingsgruppe = formidlingsgruppe;
         this.periode = periode;
+    }
+
+    public Arbeidssokerperiode tilOgMed(LocalDate nyTildato) {
+        return new Arbeidssokerperiode(formidlingsgruppe, periode.tilOgMed(nyTildato));
     }
 
     public Periode getPeriode() {
@@ -50,10 +55,16 @@ public class Arbeidssokerperiode {
                 '}';
     }
 
-    public static Arbeidssokerperiode kopiMedNyTilDato(Arbeidssokerperiode arbeidssokerperiode, LocalDate tilDato) {
-        return Arbeidssokerperiode.of(
-                arbeidssokerperiode.getFormidlingsgruppe(),
-                Periode.of(arbeidssokerperiode.getPeriode().getFra(), tilDato)
-        );
+    static class EldsteFoerst implements Comparator<Arbeidssokerperiode> {
+
+        static EldsteFoerst eldsteFoerst() {
+            return new EldsteFoerst();
+        }
+
+        @Override
+        public int compare(Arbeidssokerperiode t0, Arbeidssokerperiode t1) {
+            return t0.getPeriode().compareTo(t1.getPeriode());
+        }
+
     }
 }

--- a/src/main/java/no/nav/fo/veilarbregistrering/arbeidssoker/Arbeidssokerperioder.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/arbeidssoker/Arbeidssokerperioder.java
@@ -2,14 +2,17 @@ package no.nav.fo.veilarbregistrering.arbeidssoker;
 
 import no.nav.fo.veilarbregistrering.bruker.Periode;
 
+import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyList;
-import static java.util.Optional.*;
+import static java.util.Optional.of;
+import static java.util.stream.Collectors.toList;
+import static no.nav.fo.veilarbregistrering.arbeidssoker.Arbeidssokerperiode.EldsteFoerst.eldsteFoerst;
 
 public class Arbeidssokerperioder {
 
@@ -24,7 +27,7 @@ public class Arbeidssokerperioder {
                 .filter(p -> p.getPeriode().overlapperMed(forespurtPeriode))
                 .filter(p -> p.getFormidlingsgruppe().erArbeidssoker())
                 .sorted(Comparator.comparing(e -> e.getPeriode().getFra()))
-                .collect(Collectors.toList());
+                .collect(toList());
     }
 
     public boolean dekkerHele(Periode forespurtPeriode) {
@@ -38,18 +41,27 @@ public class Arbeidssokerperioder {
     }
 
     public Arbeidssokerperioder sorterOgPopulerTilDato() {
-        return new Arbeidssokerperioder(of(this.arbeidssokerperioder.stream()
-                .sorted(Comparator.comparing(e -> e.getPeriode().getFra())).collect(Collectors.toList()))
-                .map(populerTilDato).get());
+        return new Arbeidssokerperioder(
+                of(arbeidssokerperioder.stream()
+                        .sorted(eldsteFoerst().reversed())
+                        .collect(toList())
+                ).map(populerTilDato)
+                        .map(a -> a.stream()
+                                .sorted(eldsteFoerst())
+                                .collect(toList())).get());
     }
 
     public static Function<List<Arbeidssokerperiode>, List<Arbeidssokerperiode>> populerTilDato =
-        (arbeidssokerperioder) -> {
-            for (int i = 0; i < arbeidssokerperioder.size() - 1; i++) {
-                arbeidssokerperioder.set(i, Arbeidssokerperiode.kopiMedNyTilDato(arbeidssokerperioder.get(i), arbeidssokerperioder.get(i + 1).getPeriode().getFra().minusDays(1)));
-            }
-            return arbeidssokerperioder;
-        };
+            (arbeidssokerperioder) -> {
+                List<Arbeidssokerperiode> nyListe = new ArrayList(arbeidssokerperioder.size());
+
+                LocalDate nyTildato = null;
+                for (Arbeidssokerperiode arbeidssokerperiode : arbeidssokerperioder) {
+                    nyListe.add(arbeidssokerperiode.tilOgMed(nyTildato));
+                    nyTildato = arbeidssokerperiode.getPeriode().getFra().minusDays(1);
+                }
+                return nyListe;
+            };
 
     public List<Arbeidssokerperiode> asList() {
         return arbeidssokerperioder;

--- a/src/main/java/no/nav/fo/veilarbregistrering/bruker/Periode.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/bruker/Periode.java
@@ -3,7 +3,7 @@ package no.nav.fo.veilarbregistrering.bruker;
 import java.time.LocalDate;
 import java.util.Objects;
 
-public class Periode {
+public class Periode implements Comparable<Periode> {
 
     private final LocalDate fra;
     private final LocalDate til;
@@ -25,6 +25,10 @@ public class Periode {
     private Periode(LocalDate fra, LocalDate til) {
         this.fra = fra;
         this.til = til;
+    }
+
+    public Periode tilOgMed(LocalDate tilDato) {
+        return new Periode(fra, tilDato);
     }
 
     /**
@@ -94,5 +98,10 @@ public class Periode {
     @Override
     public int hashCode() {
         return Objects.hash(fra, til);
+    }
+
+    @Override
+    public int compareTo(Periode periode) {
+        return fra.compareTo(periode.getFra());
     }
 }

--- a/src/test/java/no/nav/fo/veilarbregistrering/arbeidssoker/ArbeidssokerServiceTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/arbeidssoker/ArbeidssokerServiceTest.java
@@ -45,9 +45,9 @@ public class ArbeidssokerServiceTest {
         List<Arbeidssokerperiode> arbeidssokerperiodes = arbeidssokerService.hentArbeidssokerperioder(FOEDSELSNUMMER, forespurtPeriode);
         assertThat(arbeidssokerperiodes).hasSize(4);
         assertThat(arbeidssokerperiodes).containsSequence(
-                StubArbeidssokerRepository.ARBEIDSSOKERPERIODE_1,
-                StubArbeidssokerRepository.ARBEIDSSOKERPERIODE_2,
-                StubArbeidssokerRepository.ARBEIDSSOKERPERIODE_3,
+                StubArbeidssokerRepository.ARBEIDSSOKERPERIODE_1.tilOgMed(LocalDate.of(2020, 1,31)),
+                StubArbeidssokerRepository.ARBEIDSSOKERPERIODE_2.tilOgMed(LocalDate.of(2020, 2, 29)),
+                StubArbeidssokerRepository.ARBEIDSSOKERPERIODE_3.tilOgMed(LocalDate.of(2020, 3, 31)),
                 StubArbeidssokerRepository.ARBEIDSSOKERPERIODE_4);
     }
 


### PR DESCRIPTION
Ved å sortere listen etter nyeste først, kan en lettere løpe igjennom listen å finne ny tildata. Men en må huske å sortere listen tilbake igjen før visning.
Har også laget metoder på Arbeidssokerperiode og Periode som lager en kopi med ny tildato, men som jobber på objektet fremfor en static metode som tar seg selv som input.