### PR TITLE
Kommune med bydel routes intern brukerstotte

### DIFF
--- a/src/main/java/no/nav/fo/veilarbregistrering/enhet/Kommunenummer.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/enhet/Kommunenummer.java
@@ -1,5 +1,6 @@
 package no.nav.fo.veilarbregistrering.enhet;
 
+import java.util.Arrays;
 import java.util.Objects;
 
 public class Kommunenummer {
@@ -8,6 +9,10 @@ public class Kommunenummer {
 
     public static Kommunenummer of(String kommunenummer) {
         return new Kommunenummer(kommunenummer);
+    }
+
+    public static Kommunenummer of(KommuneMedBydel kommuneMedBydel) {
+        return new Kommunenummer(kommuneMedBydel.kommenummer);
     }
 
     private Kommunenummer(String kommunenummer) {
@@ -29,5 +34,30 @@ public class Kommunenummer {
     @Override
     public int hashCode() {
         return Objects.hash(kommunenummer);
+    }
+
+    public boolean kommuneMedBydeler() {
+        return KommuneMedBydel.contains(kommunenummer);
+    }
+
+    public enum KommuneMedBydel {
+
+        OSLO("0301"),
+        BERGEN("4601"),
+        STAVANGER("1103"),
+        TRONDHEIM("5001");
+
+        private final String kommenummer;
+
+        KommuneMedBydel(String kommenummer) {
+            this.kommenummer = kommenummer;
+        }
+
+        private static boolean contains(String kommenummer) {
+            return Arrays.stream(KommuneMedBydel.values())
+                    .filter(k -> k.kommenummer.equals(kommenummer))
+                    .findFirst()
+                    .isPresent();
+        }
     }
 }

--- a/src/main/java/no/nav/fo/veilarbregistrering/orgenhet/Enhetsnr.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/orgenhet/Enhetsnr.java
@@ -35,4 +35,10 @@ public class Enhetsnr {
         return Objects.hash(enhetId);
     }
 
+    @Override
+    public String toString() {
+        return "{" +
+                "enhetId='" + enhetId + '\'' +
+                '}';
+    }
 }

--- a/src/test/java/no/nav/fo/veilarbregistrering/enhet/KommunenummerTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/enhet/KommunenummerTest.java
@@ -1,0 +1,39 @@
+package no.nav.fo.veilarbregistrering.enhet;
+
+import org.junit.jupiter.api.Test;
+
+import static no.nav.fo.veilarbregistrering.enhet.Kommunenummer.KommuneMedBydel.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class KommunenummerTest {
+
+    @Test
+    public void oslo_er_en_kommune_med_flere_bydeler() {
+        Kommunenummer osloKommune = Kommunenummer.of(OSLO);
+        assertThat(osloKommune.kommuneMedBydeler()).isTrue();
+    }
+
+    @Test
+    public void bergen_er_en_kommune_med_flere_bydeler() {
+        Kommunenummer bergenKommune = Kommunenummer.of(BERGEN);
+        assertThat(bergenKommune.kommuneMedBydeler()).isTrue();
+    }
+
+    @Test
+    public void trondheim_er_en_kommune_med_flere_bydeler() {
+        Kommunenummer trondheimKommune = Kommunenummer.of(TRONDHEIM);
+        assertThat(trondheimKommune.kommuneMedBydeler()).isTrue();
+    }
+
+    @Test
+    public void stavanger_er_en_kommune_med_flere_bydeler() {
+        Kommunenummer stavangerKommune = Kommunenummer.of(STAVANGER);
+        assertThat(stavangerKommune.kommuneMedBydeler()).isTrue();
+    }
+
+    @Test
+    public void horten_er_ikke_en_kommune_med_flere_bydeler() {
+        Kommunenummer hortenKommune = Kommunenummer.of("3801");
+        assertThat(hortenKommune.kommuneMedBydeler()).isFalse();
+    }
+}

--- a/src/test/java/no/nav/fo/veilarbregistrering/oppgave/OppgaveRouterTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/oppgave/OppgaveRouterTest.java
@@ -17,6 +17,7 @@ import java.util.Collections;
 import java.util.Optional;
 
 import static no.nav.fo.veilarbregistrering.arbeidsforhold.FlereArbeidsforholdTestdataBuilder.flereArbeidsforholdTilfeldigSortert;
+import static no.nav.fo.veilarbregistrering.enhet.Kommunenummer.KommuneMedBydel.STAVANGER;
 import static no.nav.fo.veilarbregistrering.oppgave.OppgaveType.UTVANDRET;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -128,5 +129,26 @@ public class OppgaveRouterTest {
         Optional<Enhetsnr> enhetsnr = oppgaveRouter.hentEnhetsnummerFor(BRUKER, UTVANDRET);
 
         assertThat(enhetsnr).hasValue(Enhetsnr.of("232"));
+    }
+
+    @Test
+    public void kommunenummer_tilhorende_kommune_med_bydeler_skal_tildeles_intern_brukerstotte() {
+        ArbeidsforholdGateway arbeidsforholdGateway = fnr -> flereArbeidsforholdTilfeldigSortert();
+
+        Forretningsadresse forretningsadresse = new Forretningsadresse(
+                Kommunenummer.of(STAVANGER),
+                Periode.of(LocalDate.of(2020, 1, 1), null));
+
+        EnhetGateway enhetGateway = organisasjonsnummer -> Optional.of(Organisasjonsdetaljer.of(
+                Arrays.asList(forretningsadresse), Collections.emptyList()));
+
+        Norg2Gateway norg2Gateway = kommunenummer -> Optional.of(Enhetsnr.of("1103"));
+        PersonGateway personGateway = foedselsnummer -> Optional.of(GeografiskTilknytning.of("DNK"));
+
+        OppgaveRouter oppgaveRouter = new OppgaveRouter(arbeidsforholdGateway, enhetGateway, norg2Gateway, personGateway);
+
+        Optional<Enhetsnr> enhetsnr = oppgaveRouter.hentEnhetsnummerFor(BRUKER, UTVANDRET);
+
+        assertThat(enhetsnr).hasValue(Enhetsnr.internBrukerstotte());
     }
 }


### PR DESCRIPTION
Vi har en hypotese om at kommuner som har bydeler (Oslo, Stavanger, Bergen og Trondheim) ikke finner noen NAV-enhet, og derfor fallbacker til NAV Utland. For å unngå at dette skjer, routes alle disse tilfellene til intern brukerstøtte.