### PR TITLE
Tilgjengeliggjor henting av arbeidssokerperioder for gjeldende og historiske fnr for person

### DIFF
--- a/src/main/java/no/nav/fo/veilarbregistrering/arbeidssoker/ArbeidssokerService.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/arbeidssoker/ArbeidssokerService.java
@@ -1,5 +1,6 @@
 package no.nav.fo.veilarbregistrering.arbeidssoker;
 
+import no.nav.fo.veilarbregistrering.bruker.Bruker;
 import no.nav.fo.veilarbregistrering.bruker.Foedselsnummer;
 import no.nav.fo.veilarbregistrering.bruker.Periode;
 import no.nav.fo.veilarbregistrering.metrics.Metric;
@@ -10,6 +11,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static java.lang.String.format;
 
@@ -41,6 +43,47 @@ public class ArbeidssokerService {
         }
 
         arbeidssokerRepository.lagre(endretFormidlingsgruppeCommand);
+    }
+
+    public List<Arbeidssokerperiode> hentArbeidssokerperioder(Bruker bruker, Periode forespurtPeriode) {
+        // Hent arbeidssøkerperioder lokalt for alle fnr fordi det er billig
+        Arbeidssokerperioder arbeidssokerperioderLokalt = hentAlleArbeidssokerperioderLokalt(bruker).sorterOgPopulerTilDato();
+
+        if (arbeidssokerperioderLokalt.dekkerHele(forespurtPeriode) && brukLokalCache()) {
+            List<Arbeidssokerperiode> overlappendeArbeidssokerperioderLokalt = arbeidssokerperioderLokalt.overlapperMed(forespurtPeriode);
+            Metrics.reportTags(Metrics.Event.HENT_ARBEIDSSOKERPERIODER_KILDE, Kilde.LOKAL);
+            LOG.info(String.format("Arbeidssokerperiodene fra egen database dekker hele perioden, og returneres: %s", overlappendeArbeidssokerperioderLokalt));
+            return overlappendeArbeidssokerperioderLokalt;
+        }
+
+
+        // Hvis ikke dekkende, sjekk ORDS for gjeldende fnr
+        Arbeidssokerperioder arbeidssokerperioderORDS = formidlingsgruppeGateway.finnArbeissokerperioder(bruker.getGjeldendeFoedselsnummer(), forespurtPeriode);
+
+        if (arbeidssokerperioderORDS.dekkerHele(forespurtPeriode)) {
+            List<Arbeidssokerperiode> overlappendeArbeidssokerperioderORDS = arbeidssokerperioderORDS.overlapperMed(forespurtPeriode);
+            Metrics.reportTags(Metrics.Event.HENT_ARBEIDSSOKERPERIODER_KILDE, Kilde.ORDS);
+            LOG.info(String.format("Returnerer arbeidssokerperioder fra Arena sin ORDS-tjeneste: %s", overlappendeArbeidssokerperioderORDS));
+            return overlappendeArbeidssokerperioderORDS;
+        }
+
+        // Hvis ikke dekkende, sjekk ORDS for alle fnr
+        List<Arbeidssokerperioder> historiskeArbeidssokerperioderORDS = bruker.getHistoriskeFoedselsnummer().stream()
+                .map(foedselsnummer -> formidlingsgruppeGateway.finnArbeissokerperioder(foedselsnummer, forespurtPeriode))
+                .collect(Collectors.toList());
+
+        return arbeidssokerperioderORDS.slaaSammenMed(historiskeArbeidssokerperioderORDS).overlapperMed(forespurtPeriode);
+    }
+
+    Arbeidssokerperioder hentAlleArbeidssokerperioderLokalt(Bruker bruker) {
+        Arbeidssokerperioder arbeidssokerperioder = arbeidssokerRepository
+                .finnFormidlingsgrupper(bruker.getGjeldendeFoedselsnummer());
+
+        List<Arbeidssokerperioder> historiskeArbeidssokerperioder = bruker.getHistoriskeFoedselsnummer().stream()
+                .map(arbeidssokerRepository::finnFormidlingsgrupper)
+                .collect(Collectors.toList());
+
+        return arbeidssokerperioder.slaaSammenMed(historiskeArbeidssokerperioder);
     }
 
     public List<Arbeidssokerperiode> hentArbeidssokerperioder(Foedselsnummer foedselsnummer, Periode forespurtPeriode) {

--- a/src/main/java/no/nav/fo/veilarbregistrering/arbeidssoker/adapter/FormidlingsgruppeResponseDto.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/arbeidssoker/adapter/FormidlingsgruppeResponseDto.java
@@ -1,6 +1,5 @@
 package no.nav.fo.veilarbregistrering.arbeidssoker.adapter;
 
-import java.util.Collections;
 import java.util.List;
 
 import static java.util.Collections.emptyList;

--- a/src/main/java/no/nav/fo/veilarbregistrering/db/arbeidssoker/ArbeidssokerRepositoryImpl.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/db/arbeidssoker/ArbeidssokerRepositoryImpl.java
@@ -59,6 +59,6 @@ public class ArbeidssokerRepositoryImpl implements ArbeidssokerRepository {
                 )
         );
 
-        return Arbeidssokerperioder.of(arbeidssokerperioder);
+        return Arbeidssokerperioder.ofRaaData(arbeidssokerperioder);
     }
 }

--- a/src/test/java/no/nav/fo/veilarbregistrering/arbeidssoker/ArbeidssokerServiceTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/arbeidssoker/ArbeidssokerServiceTest.java
@@ -1,5 +1,7 @@
 package no.nav.fo.veilarbregistrering.arbeidssoker;
 
+import no.nav.fo.veilarbregistrering.bruker.AktorId;
+import no.nav.fo.veilarbregistrering.bruker.Bruker;
 import no.nav.fo.veilarbregistrering.bruker.Foedselsnummer;
 import no.nav.fo.veilarbregistrering.bruker.Periode;
 import no.nav.fo.veilarbregistrering.oppfolging.Formidlingsgruppe;
@@ -18,8 +20,10 @@ import static org.mockito.Mockito.when;
 
 public class ArbeidssokerServiceTest {
 
-    public static final Foedselsnummer FOEDSELSNUMMER = Foedselsnummer.of("12345678911");
+    public static final Foedselsnummer FOEDSELSNUMMER_1 = Foedselsnummer.of("12345678911");
     public static final Foedselsnummer FOEDSELSNUMMER_2 = Foedselsnummer.of("11234567890");
+    private static final Foedselsnummer FOEDSELSNUMMER_3 = Foedselsnummer.of("22334455661");
+    private static final Foedselsnummer FOEDSELSNUMMER_4 = Foedselsnummer.of("99887766554");
 
     private ArbeidssokerService arbeidssokerService;
     private UnleashService unleashService;
@@ -41,12 +45,12 @@ public class ArbeidssokerServiceTest {
                 LocalDate.of(2020, 1, 2),
                 LocalDate.of(2020, 5, 1));
 
-        List<Arbeidssokerperiode> arbeidssokerperiodes = arbeidssokerService.hentArbeidssokerperioder(FOEDSELSNUMMER, forespurtPeriode);
+        List<Arbeidssokerperiode> arbeidssokerperiodes = arbeidssokerService.hentArbeidssokerperioder(FOEDSELSNUMMER_1, forespurtPeriode);
         assertThat(arbeidssokerperiodes).hasSize(4);
         assertThat(arbeidssokerperiodes).containsSequence(
-                StubArbeidssokerRepository.ARBEIDSSOKERPERIODE_1,
-                StubArbeidssokerRepository.ARBEIDSSOKERPERIODE_2,
-                StubArbeidssokerRepository.ARBEIDSSOKERPERIODE_3,
+                StubArbeidssokerRepository.ARBEIDSSOKERPERIODE_1.tilOgMed(LocalDate.of(2020,1,31)),
+                StubArbeidssokerRepository.ARBEIDSSOKERPERIODE_2.tilOgMed(LocalDate.of(2020,2,29)),
+                StubArbeidssokerRepository.ARBEIDSSOKERPERIODE_3.tilOgMed(LocalDate.of(2020,3,31)),
                 StubArbeidssokerRepository.ARBEIDSSOKERPERIODE_4);
     }
 
@@ -56,22 +60,131 @@ public class ArbeidssokerServiceTest {
                 LocalDate.of(2019, 12, 1),
                 LocalDate.of(2020, 5, 1));
 
-        List<Arbeidssokerperiode> arbeidssokerperiodes = arbeidssokerService.hentArbeidssokerperioder(FOEDSELSNUMMER, forespurtPeriode);
+        List<Arbeidssokerperiode> arbeidssokerperiodes = arbeidssokerService.hentArbeidssokerperioder(FOEDSELSNUMMER_1, forespurtPeriode);
 
         assertThat(arbeidssokerperiodes).hasSize(5);
-        assertThat(arbeidssokerperiodes).contains(StubArbeidssokerRepository.ARBEIDSSOKERPERIODE_0);
-        assertThat(arbeidssokerperiodes).contains(StubArbeidssokerRepository.ARBEIDSSOKERPERIODE_1);
-        assertThat(arbeidssokerperiodes).contains(StubArbeidssokerRepository.ARBEIDSSOKERPERIODE_2);
-        assertThat(arbeidssokerperiodes).contains(StubArbeidssokerRepository.ARBEIDSSOKERPERIODE_3);
-        assertThat(arbeidssokerperiodes).contains(StubArbeidssokerRepository.ARBEIDSSOKERPERIODE_4);
+        assertThat(arbeidssokerperiodes).containsSequence(
+                StubFormidlingsgruppeGateway.ARBEIDSSOKERPERIODE_0,
+                StubFormidlingsgruppeGateway.ARBEIDSSOKERPERIODE_1,
+                StubFormidlingsgruppeGateway.ARBEIDSSOKERPERIODE_2,
+                StubFormidlingsgruppeGateway.ARBEIDSSOKERPERIODE_3,
+                StubFormidlingsgruppeGateway.ARBEIDSSOKERPERIODE_4);
+    }
 
+    @Test
+    public void hentArbeidssokerperioder_skal_returnere_alle_perioder_for_person_innenfor_forespurt_periode_lokalt() {
+        when(unleashService.isEnabled(VEILARBREGISTRERING_FORMIDLINGSGRUPPE_LOCALCACHE)).thenReturn(true);
+
+        Bruker bruker = Bruker.of(
+                FOEDSELSNUMMER_3,
+                AktorId.of("100002345678"),
+                asList(FOEDSELSNUMMER_2, FOEDSELSNUMMER_1)
+        );
+
+        Periode forespurtPeriode = Periode.of(
+                LocalDate.of(2020, 3, 20),
+                LocalDate.of(2020, 6, 10));
+
+        List<Arbeidssokerperiode> arbeidssokerperioder = arbeidssokerService.hentArbeidssokerperioder(bruker, forespurtPeriode);
+
+        assertThat(arbeidssokerperioder).containsSequence(
+                StubArbeidssokerRepository.ARBEIDSSOKERPERIODE_4.tilOgMed(LocalDate.of(2020,5,2)),
+                StubArbeidssokerRepository.ARBEIDSSOKERPERIODE_5.tilOgMed(LocalDate.of(2020,5,9)),
+                StubArbeidssokerRepository.ARBEIDSSOKERPERIODE_6.tilOgMed(LocalDate.of(2020,5,29)),
+                StubArbeidssokerRepository.ARBEIDSSOKERPERIODE_7.tilOgMed(LocalDate.of(2020,6,30))
+        );
+
+    }
+
+    @Test
+    public void hentArbeidssokerperioder_skal_returnere_alle_perioder_for_person_innenfor_forespurt_periode_ORDS() {
+        when(unleashService.isEnabled(VEILARBREGISTRERING_FORMIDLINGSGRUPPE_LOCALCACHE)).thenReturn(true);
+
+        Bruker bruker = Bruker.of(
+                FOEDSELSNUMMER_2,
+                AktorId.of("100002345678"),
+                asList(FOEDSELSNUMMER_1)
+        );
+
+        Periode forespurtPeriode = Periode.of(
+                LocalDate.of(2019, 12, 1),
+                LocalDate.of(2020, 5, 9));
+
+        List<Arbeidssokerperiode> arbeidssokerperioder = arbeidssokerService.hentArbeidssokerperioder(bruker, forespurtPeriode);
+
+        assertThat(arbeidssokerperioder).containsExactly(
+                StubFormidlingsgruppeGateway.ARBEIDSSOKERPERIODE_0,
+                StubFormidlingsgruppeGateway.ARBEIDSSOKERPERIODE_1,
+                StubFormidlingsgruppeGateway.ARBEIDSSOKERPERIODE_2,
+                StubFormidlingsgruppeGateway.ARBEIDSSOKERPERIODE_3,
+                StubFormidlingsgruppeGateway.ARBEIDSSOKERPERIODE_4,
+                StubFormidlingsgruppeGateway.ARBEIDSSOKERPERIODE_5
+        );
     }
 
     private static class StubArbeidssokerRepository implements ArbeidssokerRepository {
 
+        public static final Arbeidssokerperiode ARBEIDSSOKERPERIODE_1 = new Arbeidssokerperiode(
+                Formidlingsgruppe.of("ARBS"),
+                Periode.of(LocalDate.of(2020, 1, 1), null));
+        public static final Arbeidssokerperiode ARBEIDSSOKERPERIODE_2 = new Arbeidssokerperiode(
+                Formidlingsgruppe.of("ARBS"),
+                Periode.of(LocalDate.of(2020, 2, 1), null));
+        public static final Arbeidssokerperiode ARBEIDSSOKERPERIODE_3 = new Arbeidssokerperiode(
+                Formidlingsgruppe.of("ARBS"),
+                Periode.of(LocalDate.of(2020, 3, 1), null));
+        public static final Arbeidssokerperiode ARBEIDSSOKERPERIODE_4 = new Arbeidssokerperiode(
+                Formidlingsgruppe.of("ARBS"),
+                Periode.of(LocalDate.of(2020, 4, 1), null));
+        public static final Arbeidssokerperiode ARBEIDSSOKERPERIODE_5 = new Arbeidssokerperiode(
+                Formidlingsgruppe.of("ARBS"),
+                Periode.of(LocalDate.of(2020, 5, 3), null));
+        public static final Arbeidssokerperiode ARBEIDSSOKERPERIODE_6 = new Arbeidssokerperiode(
+                Formidlingsgruppe.of("ARBS"),
+                Periode.of(LocalDate.of(2020, 5, 10), null));
+        public static final Arbeidssokerperiode ARBEIDSSOKERPERIODE_7 = new Arbeidssokerperiode(
+                Formidlingsgruppe.of("ARBS"),
+                Periode.of(LocalDate.of(2020, 5, 30), null));
+        public static final Arbeidssokerperiode ARBEIDSSOKERPERIODE_8 = new Arbeidssokerperiode(
+                Formidlingsgruppe.of("ARBS"),
+                Periode.of(LocalDate.of(2020, 7, 1), null));
+
+        @Override
+        public long lagre(EndretFormidlingsgruppeCommand arenaFormidlingsgruppeEvent) {
+            return 0;
+        }
+
+        @Override
+        public Arbeidssokerperioder finnFormidlingsgrupper(Foedselsnummer foedselsnummer) {
+            Map<Foedselsnummer, Arbeidssokerperioder> map = new HashMap<>();
+
+            map.put(FOEDSELSNUMMER_1, new Arbeidssokerperioder(asList(
+                    ARBEIDSSOKERPERIODE_3,
+                    ARBEIDSSOKERPERIODE_1,
+                    ARBEIDSSOKERPERIODE_4,
+                    ARBEIDSSOKERPERIODE_2)));
+
+            map.put(FOEDSELSNUMMER_2, new Arbeidssokerperioder(asList(
+                    ARBEIDSSOKERPERIODE_6,
+                    ARBEIDSSOKERPERIODE_5
+            )));
+
+            map.put(FOEDSELSNUMMER_3, new Arbeidssokerperioder(asList(
+                    ARBEIDSSOKERPERIODE_7,
+                    ARBEIDSSOKERPERIODE_8
+            )));
+
+            map.put(FOEDSELSNUMMER_4, new Arbeidssokerperioder(null));
+
+            return map.get(foedselsnummer);
+        }
+    }
+
+    private static class StubFormidlingsgruppeGateway implements FormidlingsgruppeGateway {
+
         public static final Arbeidssokerperiode ARBEIDSSOKERPERIODE_0 = new Arbeidssokerperiode(
                 Formidlingsgruppe.of("ARBS"),
-                Periode.of(LocalDate.of(2019, 12, 1), LocalDate.of(2020, 12, 31)));
+                Periode.of(LocalDate.of(2019, 12, 1), LocalDate.of(2019, 12, 31)));
         public static final Arbeidssokerperiode ARBEIDSSOKERPERIODE_1 = new Arbeidssokerperiode(
                 Formidlingsgruppe.of("ARBS"),
                 Periode.of(LocalDate.of(2020, 1, 1), LocalDate.of(2020, 1, 31)));
@@ -83,40 +196,27 @@ public class ArbeidssokerServiceTest {
                 Periode.of(LocalDate.of(2020, 3, 1), LocalDate.of(2020, 3, 31)));
         public static final Arbeidssokerperiode ARBEIDSSOKERPERIODE_4 = new Arbeidssokerperiode(
                 Formidlingsgruppe.of("ARBS"),
-                Periode.of(LocalDate.of(2020, 4, 1), null));
-
-        @Override
-        public long lagre(EndretFormidlingsgruppeCommand arenaFormidlingsgruppeEvent) {
-            return 0;
-        }
-
-        @Override
-        public Arbeidssokerperioder finnFormidlingsgrupper(Foedselsnummer foedselsnummer) {
-            Map<Foedselsnummer, Arbeidssokerperioder> map = new HashMap<>();
-
-            Arbeidssokerperioder arbeidssokerperioder = new Arbeidssokerperioder(asList(
-                    ARBEIDSSOKERPERIODE_3,
-                    ARBEIDSSOKERPERIODE_1,
-                    ARBEIDSSOKERPERIODE_4,
-                    ARBEIDSSOKERPERIODE_2));
-            map.put(FOEDSELSNUMMER, arbeidssokerperioder);
-            map.put(FOEDSELSNUMMER_2, new Arbeidssokerperioder(Collections.emptyList()));
-
-            return map.get(foedselsnummer);
-        }
-    }
-
-    private class StubFormidlingsgruppeGateway implements FormidlingsgruppeGateway {
+                Periode.of(LocalDate.of(2020, 4, 1), LocalDate.of(2020, 5, 2)));
+        public static final Arbeidssokerperiode ARBEIDSSOKERPERIODE_5 = new Arbeidssokerperiode(
+                Formidlingsgruppe.of("ARBS"),
+                Periode.of(LocalDate.of(2020, 5, 3), LocalDate.of(2020, 5, 9)));
+        public static final Arbeidssokerperiode ARBEIDSSOKERPERIODE_6 = new Arbeidssokerperiode(
+                Formidlingsgruppe.of("ARBS"),
+                Periode.of(LocalDate.of(2020, 5, 10), null));
 
         @Override
         public Arbeidssokerperioder finnArbeissokerperioder(Foedselsnummer foedselsnummer, Periode periode) {
             Map<Foedselsnummer, Arbeidssokerperioder> map = new HashMap<>();
-            map.put(FOEDSELSNUMMER, new Arbeidssokerperioder(asList(
-                    StubArbeidssokerRepository.ARBEIDSSOKERPERIODE_0,
-                    StubArbeidssokerRepository.ARBEIDSSOKERPERIODE_1,
-                    StubArbeidssokerRepository.ARBEIDSSOKERPERIODE_2,
-                    StubArbeidssokerRepository.ARBEIDSSOKERPERIODE_3,
-                    StubArbeidssokerRepository.ARBEIDSSOKERPERIODE_4
+            map.put(FOEDSELSNUMMER_1, new Arbeidssokerperioder(asList(
+                    ARBEIDSSOKERPERIODE_2,
+                    ARBEIDSSOKERPERIODE_4,
+                    ARBEIDSSOKERPERIODE_3,
+                    ARBEIDSSOKERPERIODE_0,
+                    ARBEIDSSOKERPERIODE_1
+            )));
+            map.put(FOEDSELSNUMMER_2, new Arbeidssokerperioder(asList(
+                    ARBEIDSSOKERPERIODE_5,
+                    ARBEIDSSOKERPERIODE_6
             )));
             return map.get(foedselsnummer);
         }

--- a/src/test/java/no/nav/fo/veilarbregistrering/arbeidssoker/ArbeidssokerServiceTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/arbeidssoker/ArbeidssokerServiceTest.java
@@ -45,11 +45,11 @@ public class ArbeidssokerServiceTest {
                 LocalDate.of(2020, 5, 1));
 
         List<Arbeidssokerperiode> arbeidssokerperiodes = arbeidssokerService.hentArbeidssokerperioder(FOEDSELSNUMMER_1, forespurtPeriode);
-        assertThat(arbeidssokerperiodes).hasSize(4);
-        assertThat(arbeidssokerperiodes).containsSequence(
-                StubArbeidssokerRepository.ARBEIDSSOKERPERIODE_1.tilOgMed(LocalDate.of(2020,1,31)),
-                StubArbeidssokerRepository.ARBEIDSSOKERPERIODE_2.tilOgMed(LocalDate.of(2020,2,29)),
-                StubArbeidssokerRepository.ARBEIDSSOKERPERIODE_3.tilOgMed(LocalDate.of(2020,3,31)),
+
+        assertThat(arbeidssokerperiodes).containsExactly(
+                StubArbeidssokerRepository.ARBEIDSSOKERPERIODE_1,
+                StubArbeidssokerRepository.ARBEIDSSOKERPERIODE_2,
+                StubArbeidssokerRepository.ARBEIDSSOKERPERIODE_3,
                 StubArbeidssokerRepository.ARBEIDSSOKERPERIODE_4);
     }
 
@@ -61,8 +61,7 @@ public class ArbeidssokerServiceTest {
 
         List<Arbeidssokerperiode> arbeidssokerperiodes = arbeidssokerService.hentArbeidssokerperioder(FOEDSELSNUMMER_1, forespurtPeriode);
 
-        assertThat(arbeidssokerperiodes).hasSize(5);
-        assertThat(arbeidssokerperiodes).containsSequence(
+        assertThat(arbeidssokerperiodes).containsExactly(
                 StubFormidlingsgruppeGateway.ARBEIDSSOKERPERIODE_0,
                 StubFormidlingsgruppeGateway.ARBEIDSSOKERPERIODE_1,
                 StubFormidlingsgruppeGateway.ARBEIDSSOKERPERIODE_2,
@@ -86,11 +85,12 @@ public class ArbeidssokerServiceTest {
 
         List<Arbeidssokerperiode> arbeidssokerperioder = arbeidssokerService.hentArbeidssokerperioder(bruker, forespurtPeriode);
 
-        assertThat(arbeidssokerperioder).containsSequence(
-                StubArbeidssokerRepository.ARBEIDSSOKERPERIODE_4.tilOgMed(LocalDate.of(2020,5,2)),
-                StubArbeidssokerRepository.ARBEIDSSOKERPERIODE_5.tilOgMed(LocalDate.of(2020,5,9)),
-                StubArbeidssokerRepository.ARBEIDSSOKERPERIODE_6.tilOgMed(LocalDate.of(2020,5,29)),
-                StubArbeidssokerRepository.ARBEIDSSOKERPERIODE_7.tilOgMed(LocalDate.of(2020,6,30))
+        assertThat(arbeidssokerperioder).containsExactly(
+                StubArbeidssokerRepository.ARBEIDSSOKERPERIODE_3,
+                StubArbeidssokerRepository.ARBEIDSSOKERPERIODE_4,
+                StubArbeidssokerRepository.ARBEIDSSOKERPERIODE_5,
+                StubArbeidssokerRepository.ARBEIDSSOKERPERIODE_6,
+                StubArbeidssokerRepository.ARBEIDSSOKERPERIODE_7
         );
 
     }

--- a/src/test/java/no/nav/fo/veilarbregistrering/arbeidssoker/ArbeidssokerperioderTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/arbeidssoker/ArbeidssokerperioderTest.java
@@ -7,6 +7,7 @@ import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.List;
 
+import static java.util.Arrays.asList;
 import static no.nav.fo.veilarbregistrering.arbeidssoker.ArbeidssokerperiodeTestdataBuilder.medArbs;
 import static no.nav.fo.veilarbregistrering.arbeidssoker.ArbeidssokerperiodeTestdataBuilder.medIserv;
 import static no.nav.fo.veilarbregistrering.arbeidssoker.ArbeidssokerperioderTestdataBuilder.arbeidssokerperioder;
@@ -101,5 +102,52 @@ public class ArbeidssokerperioderTest {
                         LocalDate.of(2020, 6, 28)));
 
         assertThat(arbeidssokerperiodes).hasSize(2);
+    }
+
+    @Test
+    public void skal_slaa_sammen_Arbeidssokerperioder_korrekt() {
+
+        Arbeidssokerperioder arbeidssokerperioder = new Arbeidssokerperioder(Arrays.asList(
+                ARBEIDSSOKERPERIODE_6,
+                ARBEIDSSOKERPERIODE_5,
+                ARBEIDSSOKERPERIODE_4
+        ));
+
+        List<Arbeidssokerperioder> andreArbeidssokerperioder = asList(
+                new Arbeidssokerperioder(asList(ARBEIDSSOKERPERIODE_1)),
+                new Arbeidssokerperioder(asList(ARBEIDSSOKERPERIODE_2, ARBEIDSSOKERPERIODE_3))
+        );
+
+        Arbeidssokerperioder alleArbeidssokerperioder = arbeidssokerperioder.slaaSammenMed(andreArbeidssokerperioder);
+
+        assertThat(alleArbeidssokerperioder.asList()).containsExactly(
+                ARBEIDSSOKERPERIODE_1,
+                ARBEIDSSOKERPERIODE_2,
+                ARBEIDSSOKERPERIODE_3,
+                ARBEIDSSOKERPERIODE_4,
+                ARBEIDSSOKERPERIODE_5,
+                ARBEIDSSOKERPERIODE_6
+        );
+    }
+
+    @Test
+    public void skal_forsoke_aa_slaa_sammen_Arbeidssokerperioder_selv_om_argument_er_tomt() {
+        Arbeidssokerperioder arbeidssokerperioder = new Arbeidssokerperioder(Arrays.asList(
+                ARBEIDSSOKERPERIODE_6,
+                ARBEIDSSOKERPERIODE_5,
+                ARBEIDSSOKERPERIODE_4
+        ));
+
+        List<Arbeidssokerperioder> andreArbeidssokerperioder = asList(
+                new Arbeidssokerperioder(null)
+        );
+
+        Arbeidssokerperioder alleArbeidssokerperioder = arbeidssokerperioder.slaaSammenMed(andreArbeidssokerperioder);
+
+        assertThat(alleArbeidssokerperioder.asList()).containsExactly(
+                ARBEIDSSOKERPERIODE_4,
+                ARBEIDSSOKERPERIODE_5,
+                ARBEIDSSOKERPERIODE_6
+        );
     }
 }

--- a/src/test/java/no/nav/fo/veilarbregistrering/arbeidssoker/ArbeidssokerperioderTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/arbeidssoker/ArbeidssokerperioderTest.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import static java.util.Arrays.asList;
 import static no.nav.fo.veilarbregistrering.arbeidssoker.ArbeidssokerperiodeTestdataBuilder.*;
 import static no.nav.fo.veilarbregistrering.arbeidssoker.ArbeidssokerperioderTestdataBuilder.arbeidssokerperioder;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -18,25 +19,28 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class ArbeidssokerperioderTest {
 
     private static final Arbeidssokerperiode ARBEIDSSOKERPERIODE_1 = new Arbeidssokerperiode(
-            Formidlingsgruppe.of("ARBS"),
-            Periode.of(LocalDate.of(2020, 1, 1), null));
-    private static final Arbeidssokerperiode ARBEIDSSOKERPERIODE_2 = new Arbeidssokerperiode(
-            Formidlingsgruppe.of("ARBS"),
-            Periode.of(LocalDate.of(2020, 2, 1), null));
-    private static final Arbeidssokerperiode ARBEIDSSOKERPERIODE_3 = new Arbeidssokerperiode(
-            Formidlingsgruppe.of("ARBS"),
-            Periode.of(LocalDate.of(2020, 3, 1), null));
-    private static final Arbeidssokerperiode ARBEIDSSOKERPERIODE_4 = new Arbeidssokerperiode(
-            Formidlingsgruppe.of("ARBS"),
-            Periode.of(LocalDate.of(2020, 4, 1), null));
-    private static final Arbeidssokerperiode ARBEIDSSOKERPERIODE_5 = new Arbeidssokerperiode(
             Formidlingsgruppe.of("ISERV"),
             Periode.of(LocalDate.of(2016, 9, 24), null));
+    private static final Arbeidssokerperiode ARBEIDSSOKERPERIODE_2 = new Arbeidssokerperiode(
+            Formidlingsgruppe.of("ARBS"),
+            Periode.of(LocalDate.of(2020, 1, 1), null));
+    private static final Arbeidssokerperiode ARBEIDSSOKERPERIODE_3 = new Arbeidssokerperiode(
+            Formidlingsgruppe.of("ARBS"),
+            Periode.of(LocalDate.of(2020, 2, 1), null));
+    private static final Arbeidssokerperiode ARBEIDSSOKERPERIODE_4 = new Arbeidssokerperiode(
+            Formidlingsgruppe.of("ISERV"),
+            Periode.of(LocalDate.of(2020, 3, 1), null));
+    private static final Arbeidssokerperiode ARBEIDSSOKERPERIODE_5 = new Arbeidssokerperiode(
+            Formidlingsgruppe.of("ARBS"),
+            Periode.of(LocalDate.of(2020, 4, 1), null));
+    private static final Arbeidssokerperiode ARBEIDSSOKERPERIODE_6 = new Arbeidssokerperiode(
+            Formidlingsgruppe.of("ARBS"),
+            Periode.of(LocalDate.of(2020, 6, 9), null));
 
     @Test
     public void gitt_at_forespurt_periode_starter_etter_eldste_periode_dekkes_hele() {
         Arbeidssokerperioder arbeidssokerperioder = new Arbeidssokerperioder(Arrays.asList(
-                ARBEIDSSOKERPERIODE_1));
+                ARBEIDSSOKERPERIODE_2));
 
         Periode forespurtPeriode = Periode.of(
                 LocalDate.of(2020, 2, 1),
@@ -48,7 +52,7 @@ public class ArbeidssokerperioderTest {
     @Test
     public void gitt_at_forespurt_periode_starter_før_eldste_periode_dekkes_ikke_hele() {
         Arbeidssokerperioder arbeidssokerperioder = new Arbeidssokerperioder(Arrays.asList(
-                ARBEIDSSOKERPERIODE_1));
+                ARBEIDSSOKERPERIODE_2));
 
         Periode forespurtPeriode = Periode.of(
                 LocalDate.of(2019, 2, 1),
@@ -60,7 +64,7 @@ public class ArbeidssokerperioderTest {
     @Test
     public void gitt_at_forespurt_periode_starter_samme_dag_som_eldste_periode_dekkes_hele_perioden() {
         Arbeidssokerperioder arbeidssokerperioder = new Arbeidssokerperioder(Arrays.asList(
-                ARBEIDSSOKERPERIODE_1));
+                ARBEIDSSOKERPERIODE_2));
 
         Periode forespurtPeriode = Periode.of(
                 LocalDate.of(2020, 1, 1),
@@ -72,7 +76,7 @@ public class ArbeidssokerperioderTest {
     @Test
     public void gitt_at_forespurt_periode_slutter_dagen_etter_siste_periode() {
         Arbeidssokerperioder arbeidssokerperioder = new Arbeidssokerperioder(Arrays.asList(
-                ARBEIDSSOKERPERIODE_5));
+                ARBEIDSSOKERPERIODE_1));
 
         Periode forespurtPeriode = Periode.of(
                 LocalDate.of(2016, 10, 1),
@@ -104,56 +108,24 @@ public class ArbeidssokerperioderTest {
     }
 
     @Test
-    public void kun_siste_periode_kan_ha_blank_tildato() {
-        Arbeidssokerperioder arbeidssokerperioder = arbeidssokerperioder()
-                .periode(medArbs()
-                        .fra(LocalDate.of(2020, 3, 19)))
-                .periode(medIserv()
-                        .fra(LocalDate.of(2020, 4, 21)))
-                .periode(medArbs()
-                        .fra(LocalDate.of(2020, 5, 30)))
-                .build()
-                .sorterOgPopulerTilDato();
+    public void skal_sette_tilDato_korrekt() {
+        // Listen skal sorteres
+        // Tildato for en periode er dagen før neste periode
+        // Tildato for siste periode er null
 
-        assertThat(funnetTilDatoForIndeks(0, arbeidssokerperioder)).isNotNull();
-        assertThat(funnetTilDatoForIndeks(1, arbeidssokerperioder)).isNotNull();
-        assertThat(funnetTilDatoForSistePeriode(arbeidssokerperioder)).isNull();
-    }
+        Arbeidssokerperioder arbeidssokerperioder = new Arbeidssokerperioder(Arrays.asList(
+                ARBEIDSSOKERPERIODE_5,
+                ARBEIDSSOKERPERIODE_4,
+                ARBEIDSSOKERPERIODE_1,
+                ARBEIDSSOKERPERIODE_3
+        )).sorterOgPopulerTilDato();
 
-    @Test
-    public void foerste_periode_skal_ha_tildato_lik_dagen_foer_andre_periode_sin_fradato() {
-        Arbeidssokerperioder arbeidssokerperioder = arbeidssokerperioder()
-                .periode(medArbs()
-                        .fra(LocalDate.of(2020, 3, 19)))
-                .periode(medIserv()
-                        .fra(LocalDate.of(2020, 4, 21)))
-                .build()
-                .sorterOgPopulerTilDato();
-
-        assertThat(funnetTilDatoForIndeks(0, arbeidssokerperioder)).isEqualTo(LocalDate.of(2020, 4, 20));
-        assertThat(funnetTilDatoForSistePeriode(arbeidssokerperioder)).isNull();
-    }
-
-    @Test
-    public void skal_populere_tildato_korrekt_selv_om_listen_kommer_usortert() {
-        Arbeidssokerperioder arbeidssokerperioder = arbeidssokerperioder()
-                .periode(medArbs()
-                        .fra(LocalDate.of(2020, 5, 30)))
-                .periode(medArbs()
-                        .fra(LocalDate.of(2020, 3, 19)))
-                .periode(medIserv()
-                        .fra(LocalDate.of(2020, 4, 21)))
-                .build()
-                .sorterOgPopulerTilDato();
-
-        assertThat(funnetFraDatoForIndeks(0, arbeidssokerperioder)).isEqualTo(LocalDate.of(2020, 3, 19));
-        assertThat(funnetFraDatoForIndeks(1, arbeidssokerperioder)).isEqualTo(LocalDate.of(2020, 4, 21));
-        assertThat(funnetFraDatoForIndeks(2, arbeidssokerperioder)).isEqualTo(LocalDate.of(2020, 5, 30));
-
-        assertThat(funnetTilDatoForIndeks(0, arbeidssokerperioder)).isEqualTo(LocalDate.of(2020, 4, 20));
-        assertThat(funnetTilDatoForIndeks(1, arbeidssokerperioder)).isEqualTo(LocalDate.of(2020, 5, 29));
-        assertThat(funnetTilDatoForSistePeriode(arbeidssokerperioder)).isNull();
-
+        assertThat(arbeidssokerperioder.asList()).containsSequence(
+                ARBEIDSSOKERPERIODE_1.tilOgMed(LocalDate.of(2020,1,31)),
+                ARBEIDSSOKERPERIODE_3.tilOgMed(LocalDate.of(2020,2,29)),
+                ARBEIDSSOKERPERIODE_4.tilOgMed(LocalDate.of(2020,3,31)),
+                ARBEIDSSOKERPERIODE_5
+        );
     }
 
     @Test
@@ -164,7 +136,7 @@ public class ArbeidssokerperioderTest {
         arbeidssokerperiodeRaaData.add(new ArbeidssokerperiodeRaaData("ARBS", Timestamp.valueOf(now.plusSeconds(2))));
         arbeidssokerperiodeRaaData.add(new ArbeidssokerperiodeRaaData("IARBS", Timestamp.valueOf(now.plusSeconds(4))));
 
-        Arbeidssokerperioder arbeidssokerperioder = Arbeidssokerperioder.of(arbeidssokerperiodeRaaData);
+        Arbeidssokerperioder arbeidssokerperioder = Arbeidssokerperioder.ofRaaData(arbeidssokerperiodeRaaData);
 
         assertThat(arbeidssokerperioder.asList().size()).isEqualTo(1);
         assertThat(arbeidssokerperioder.asList().get(0).getFormidlingsgruppe().stringValue()).isEqualTo("IARBS");
@@ -186,7 +158,7 @@ public class ArbeidssokerperioderTest {
         arbeidssokerperiodeRaaData.add(new ArbeidssokerperiodeRaaData("ARBS", Timestamp.valueOf(now.plusDays(50).plusSeconds(2))));
         arbeidssokerperiodeRaaData.add(new ArbeidssokerperiodeRaaData("ISERV", Timestamp.valueOf(now.plusDays(50).plusSeconds(5))));
 
-        Arbeidssokerperioder arbeidssokerperioder = Arbeidssokerperioder.of(arbeidssokerperiodeRaaData);
+        Arbeidssokerperioder arbeidssokerperioder = Arbeidssokerperioder.ofRaaData(arbeidssokerperiodeRaaData);
 
         assertThat(arbeidssokerperioder.asList().size()).isEqualTo(3);
         assertThat(arbeidssokerperioder.asList().get(0).getFormidlingsgruppe().stringValue()).isEqualTo("IARBS");
@@ -197,16 +169,50 @@ public class ArbeidssokerperioderTest {
         assertThat(arbeidssokerperioder.asList().get(2).getPeriode().getFra()).isEqualTo(now.plusDays(50).toLocalDate());
     }
 
-    private LocalDate funnetFraDatoForIndeks(int indeks, Arbeidssokerperioder arbeidssokerperioder) {
-        return arbeidssokerperioder.asList().get(indeks).getPeriode().getFra();
+    @Test
+    public void skal_slaa_sammen_Arbeidssokerperioder_korrekt() {
+
+        Arbeidssokerperioder arbeidssokerperioder = new Arbeidssokerperioder(Arrays.asList(
+                ARBEIDSSOKERPERIODE_6,
+                ARBEIDSSOKERPERIODE_5,
+                ARBEIDSSOKERPERIODE_4
+                ));
+
+        List<Arbeidssokerperioder> andreArbeidssokerperioder = asList(
+                new Arbeidssokerperioder(asList(ARBEIDSSOKERPERIODE_1)),
+                new Arbeidssokerperioder(asList(ARBEIDSSOKERPERIODE_2, ARBEIDSSOKERPERIODE_3))
+        );
+
+        Arbeidssokerperioder alleArbeidssokerperioder = arbeidssokerperioder.slaaSammenMed(andreArbeidssokerperioder);
+
+        assertThat(alleArbeidssokerperioder.asList()).containsExactly(
+                ARBEIDSSOKERPERIODE_1,
+                ARBEIDSSOKERPERIODE_2,
+                ARBEIDSSOKERPERIODE_3,
+                ARBEIDSSOKERPERIODE_4,
+                ARBEIDSSOKERPERIODE_5,
+                ARBEIDSSOKERPERIODE_6
+        );
     }
 
-    private LocalDate funnetTilDatoForSistePeriode(Arbeidssokerperioder arbeidssokerperioder) {
-        return arbeidssokerperioder.asList().get(arbeidssokerperioder.asList().size()-1).getPeriode().getTil();
-    }
+    @Test
+    public void skal_forsoke_aa_slaa_sammen_Arbeidssokerperioder_selv_om_argument_er_tomt() {
+        Arbeidssokerperioder arbeidssokerperioder = new Arbeidssokerperioder(Arrays.asList(
+                ARBEIDSSOKERPERIODE_6,
+                ARBEIDSSOKERPERIODE_5,
+                ARBEIDSSOKERPERIODE_4
+        ));
 
-    private LocalDate funnetTilDatoForIndeks(int indeks, Arbeidssokerperioder arbeidssokerperioder) {
-        return arbeidssokerperioder.asList().get(indeks).getPeriode().getTil();
-    }
+        List<Arbeidssokerperioder> andreArbeidssokerperioder = asList(
+                new Arbeidssokerperioder(null)
+        );
 
+        Arbeidssokerperioder alleArbeidssokerperioder = arbeidssokerperioder.slaaSammenMed(andreArbeidssokerperioder);
+
+        assertThat(alleArbeidssokerperioder.asList()).containsExactly(
+                ARBEIDSSOKERPERIODE_4,
+                ARBEIDSSOKERPERIODE_5,
+                ARBEIDSSOKERPERIODE_6
+        );
+    }
 }


### PR DESCRIPTION
Tydeliggjor metodenavn og oppretter en mer korrekt statisk of-metode paa objekt

Forbedrer test aa gjore mockdata mer realistisk

Oppdaterer mockdata

Henter alle arbeidssokerperioder fra lokal cache for gjeldende og historiske fnr

Oppdaterer variabelnavn innad i metode

Fikser test ved aa aktivere feature toggle

Forenkler testing ved aa benytte containsSequence - tester mer  paa en gang

Refaktorerer hjelpemetode til en statisk metode paa Arbeidssokerperioder

Strukturerer testdata bedre

Henter arbeidssokerperioder fra Arena-ORDS for alle fnr til person