### PR TITLE
Flytter mapping av arbeidssokerperiode

### DIFF
--- a/src/main/java/no/nav/fo/veilarbregistrering/arbeidssoker/ArbeidssokerService.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/arbeidssoker/ArbeidssokerService.java
@@ -45,8 +45,7 @@ public class ArbeidssokerService {
 
     public List<Arbeidssokerperiode> hentArbeidssokerperioder(Foedselsnummer foedselsnummer, Periode forespurtPeriode) {
         Arbeidssokerperioder arbeidssokerperioder = arbeidssokerRepository
-                .finnFormidlingsgrupper(foedselsnummer)
-                .sorterOgPopulerTilDato();
+                .finnFormidlingsgrupper(foedselsnummer);
         LOG.info(String.format("Fant følgende arbeidssokerperioder i egen database: %s", arbeidssokerperioder));
 
         Arbeidssokerperioder historiskePerioder = formidlingsgruppeGateway.finnArbeissokerperioder(foedselsnummer, forespurtPeriode);

--- a/src/main/java/no/nav/fo/veilarbregistrering/arbeidssoker/Arbeidssokerperiode.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/arbeidssoker/Arbeidssokerperiode.java
@@ -58,9 +58,9 @@ public class Arbeidssokerperiode {
                 '}';
     }
 
-    static class EldsteFoerst implements Comparator<Arbeidssokerperiode> {
+    public static class EldsteFoerst implements Comparator<Arbeidssokerperiode> {
 
-        static EldsteFoerst eldsteFoerst() {
+        public static EldsteFoerst eldsteFoerst() {
             return new EldsteFoerst();
         }
 
@@ -68,6 +68,5 @@ public class Arbeidssokerperiode {
         public int compare(Arbeidssokerperiode t0, Arbeidssokerperiode t1) {
             return t0.getPeriode().compareTo(t1.getPeriode());
         }
-
     }
 }

--- a/src/main/java/no/nav/fo/veilarbregistrering/arbeidssoker/Arbeidssokerperioder.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/arbeidssoker/Arbeidssokerperioder.java
@@ -1,30 +1,17 @@
 package no.nav.fo.veilarbregistrering.arbeidssoker;
 
 import no.nav.fo.veilarbregistrering.bruker.Periode;
-import no.nav.fo.veilarbregistrering.oppfolging.Formidlingsgruppe;
 
-import java.time.LocalDate;
-import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
-import java.util.function.Function;
 
 import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toList;
-import static no.nav.fo.veilarbregistrering.arbeidssoker.Arbeidssokerperiode.EldsteFoerst.eldsteFoerst;
-import static no.nav.fo.veilarbregistrering.arbeidssoker.ArbeidssokerperiodeRaaData.NyesteFoerst.nyesteFoerst;
 
 public class Arbeidssokerperioder {
 
     private final List<Arbeidssokerperiode> arbeidssokerperioder;
-
-    public static Arbeidssokerperioder of(List<ArbeidssokerperiodeRaaData> arbeidssokerperiodeRaaData) {
-        return new Arbeidssokerperioder(Optional.of(arbeidssokerperiodeRaaData.stream()
-                .sorted(nyesteFoerst()).collect(toList()))
-                .map(beholdKunSisteEndringPerDagIListen).get().stream()
-                .sorted(eldsteFoerst()).collect(toList()));
-    }
 
     public Arbeidssokerperioder(List<Arbeidssokerperiode> arbeidssokerperioder) {
         this.arbeidssokerperioder = arbeidssokerperioder != null ? arbeidssokerperioder : emptyList();
@@ -47,56 +34,6 @@ public class Arbeidssokerperioder {
                 .map(arbeidssokerperiode -> forespurtPeriode.fraOgMed(arbeidssokerperiode.getPeriode()))
                 .orElse(false);
     }
-
-    public Arbeidssokerperioder sorterOgPopulerTilDato() {
-        return new Arbeidssokerperioder(
-                Optional.of(arbeidssokerperioder.stream()
-                        .sorted(eldsteFoerst().reversed())
-                        .collect(toList())
-                ).map(populerTilDato)
-                        .map(a -> a.stream()
-                                .sorted(eldsteFoerst())
-                                .collect(toList())).get());
-    }
-
-    public static Function<List<Arbeidssokerperiode>, List<Arbeidssokerperiode>> populerTilDato =
-            (arbeidssokerperioder) -> {
-                List<Arbeidssokerperiode> nyListe = new ArrayList(arbeidssokerperioder.size());
-
-                LocalDate nyTildato = null;
-                for (Arbeidssokerperiode arbeidssokerperiode : arbeidssokerperioder) {
-                    nyListe.add(arbeidssokerperiode.tilOgMed(nyTildato));
-                    nyTildato = arbeidssokerperiode.getPeriode().getFra().minusDays(1);
-                }
-                return nyListe;
-            };
-
-    public static Function<List<ArbeidssokerperiodeRaaData>, List<Arbeidssokerperiode>> beholdKunSisteEndringPerDagIListen =
-            (arbeidssokerperiodeRaaData) -> {
-                List<Arbeidssokerperiode> arbeidssokerperioder = new ArrayList<>(arbeidssokerperiodeRaaData.size());
-
-                LocalDate forrigeEndretDato = null;
-
-                for(ArbeidssokerperiodeRaaData raaDataPeriode : arbeidssokerperiodeRaaData) {
-                    LocalDate endretDato = raaDataPeriode.getFormidlingsgruppeEndret().toLocalDateTime().toLocalDate();
-
-                    if(forrigeEndretDato != null && endretDato.isEqual(forrigeEndretDato)) {
-                        continue;
-                    }
-
-                    arbeidssokerperioder.add(new Arbeidssokerperiode(
-                            Formidlingsgruppe.of(raaDataPeriode.getFormidlingsgruppe()),
-                            Periode.of(
-                                    endretDato,
-                                    null
-                            )
-                    ));
-
-                    forrigeEndretDato = endretDato;
-                }
-
-                return arbeidssokerperioder;
-            };
 
     public List<Arbeidssokerperiode> asList() {
         return arbeidssokerperioder;

--- a/src/main/java/no/nav/fo/veilarbregistrering/db/arbeidssoker/ArbeidssokerRepositoryImpl.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/db/arbeidssoker/ArbeidssokerRepositoryImpl.java
@@ -1,6 +1,8 @@
 package no.nav.fo.veilarbregistrering.db.arbeidssoker;
 
-import no.nav.fo.veilarbregistrering.arbeidssoker.*;
+import no.nav.fo.veilarbregistrering.arbeidssoker.ArbeidssokerRepository;
+import no.nav.fo.veilarbregistrering.arbeidssoker.Arbeidssokerperioder;
+import no.nav.fo.veilarbregistrering.arbeidssoker.EndretFormidlingsgruppeCommand;
 import no.nav.fo.veilarbregistrering.bruker.Foedselsnummer;
 import no.nav.fo.veilarbregistrering.oppfolging.Formidlingsgruppe;
 import no.nav.sbl.sql.SqlUtils;
@@ -9,6 +11,8 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.util.List;
+
+import static no.nav.fo.veilarbregistrering.db.arbeidssoker.ArbeidssokerperioderMapper.map;
 
 public class ArbeidssokerRepositoryImpl implements ArbeidssokerRepository {
 
@@ -59,6 +63,6 @@ public class ArbeidssokerRepositoryImpl implements ArbeidssokerRepository {
                 )
         );
 
-        return Arbeidssokerperioder.of(arbeidssokerperioder);
+        return map(arbeidssokerperioder);
     }
 }

--- a/src/main/java/no/nav/fo/veilarbregistrering/db/arbeidssoker/ArbeidssokerperiodeRaaData.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/db/arbeidssoker/ArbeidssokerperiodeRaaData.java
@@ -1,23 +1,23 @@
-package no.nav.fo.veilarbregistrering.arbeidssoker;
+package no.nav.fo.veilarbregistrering.db.arbeidssoker;
 
 import java.sql.Timestamp;
 import java.util.Comparator;
 
-public class ArbeidssokerperiodeRaaData {
+class ArbeidssokerperiodeRaaData {
 
     private final String formidlingsgruppe;
     private final Timestamp formidlingsgruppeEndret;
 
-    public ArbeidssokerperiodeRaaData(String formidlingsgruppe, Timestamp formidlingsgruppeEndret) {
+    ArbeidssokerperiodeRaaData(String formidlingsgruppe, Timestamp formidlingsgruppeEndret) {
         this.formidlingsgruppe = formidlingsgruppe;
         this.formidlingsgruppeEndret = formidlingsgruppeEndret;
     }
 
-    public Timestamp getFormidlingsgruppeEndret() {
+    Timestamp getFormidlingsgruppeEndret() {
         return this.formidlingsgruppeEndret;
     }
 
-    public String getFormidlingsgruppe() {
+    String getFormidlingsgruppe() {
         return this.formidlingsgruppe;
     }
 
@@ -33,5 +33,4 @@ public class ArbeidssokerperiodeRaaData {
         }
 
     }
-
 }

--- a/src/main/java/no/nav/fo/veilarbregistrering/db/arbeidssoker/ArbeidssokerperioderMapper.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/db/arbeidssoker/ArbeidssokerperioderMapper.java
@@ -1,0 +1,72 @@
+package no.nav.fo.veilarbregistrering.db.arbeidssoker;
+
+import no.nav.fo.veilarbregistrering.arbeidssoker.Arbeidssokerperiode;
+import no.nav.fo.veilarbregistrering.arbeidssoker.Arbeidssokerperioder;
+import no.nav.fo.veilarbregistrering.bruker.Periode;
+import no.nav.fo.veilarbregistrering.oppfolging.Formidlingsgruppe;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+
+import static java.util.stream.Collectors.toList;
+import static no.nav.fo.veilarbregistrering.arbeidssoker.Arbeidssokerperiode.EldsteFoerst.eldsteFoerst;
+import static no.nav.fo.veilarbregistrering.db.arbeidssoker.ArbeidssokerperiodeRaaData.NyesteFoerst.nyesteFoerst;
+
+class ArbeidssokerperioderMapper {
+
+    static Arbeidssokerperioder map(List<ArbeidssokerperiodeRaaData> arbeidssokerperioder) {
+        return new Arbeidssokerperioder(
+                Optional.of(
+                        arbeidssokerperioder.stream()
+                                .sorted(nyesteFoerst())
+                                .collect(toList()))
+                        .map(beholdKunSisteEndringPerDagIListen)
+                        .map(populerTilDato)
+                        .get()
+                        .stream()
+                        .sorted(eldsteFoerst())
+                        .collect(toList()));
+    }
+
+    private static Function<List<ArbeidssokerperiodeRaaData>, List<Arbeidssokerperiode>> beholdKunSisteEndringPerDagIListen =
+            (arbeidssokerperiodeRaaData) -> {
+                List<Arbeidssokerperiode> arbeidssokerperioder = new ArrayList<>(arbeidssokerperiodeRaaData.size());
+
+                LocalDate forrigeEndretDato = null;
+
+                for (ArbeidssokerperiodeRaaData raaDataPeriode : arbeidssokerperiodeRaaData) {
+                    LocalDate endretDato = raaDataPeriode.getFormidlingsgruppeEndret().toLocalDateTime().toLocalDate();
+
+                    if (forrigeEndretDato != null && endretDato.isEqual(forrigeEndretDato)) {
+                        continue;
+                    }
+
+                    arbeidssokerperioder.add(new Arbeidssokerperiode(
+                            Formidlingsgruppe.of(raaDataPeriode.getFormidlingsgruppe()),
+                            Periode.of(
+                                    endretDato,
+                                    null
+                            )
+                    ));
+
+                    forrigeEndretDato = endretDato;
+                }
+
+                return arbeidssokerperioder;
+            };
+
+    private static Function<List<Arbeidssokerperiode>, List<Arbeidssokerperiode>> populerTilDato =
+            (arbeidssokerperioder) -> {
+                List<Arbeidssokerperiode> nyListe = new ArrayList(arbeidssokerperioder.size());
+
+                LocalDate nyTildato = null;
+                for (Arbeidssokerperiode arbeidssokerperiode : arbeidssokerperioder) {
+                    nyListe.add(arbeidssokerperiode.tilOgMed(nyTildato));
+                    nyTildato = arbeidssokerperiode.getPeriode().getFra().minusDays(1);
+                }
+                return nyListe;
+            };
+}

--- a/src/test/java/no/nav/fo/veilarbregistrering/arbeidssoker/ArbeidssokerperioderTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/arbeidssoker/ArbeidssokerperioderTest.java
@@ -4,14 +4,12 @@ import no.nav.fo.veilarbregistrering.bruker.Periode;
 import no.nav.fo.veilarbregistrering.oppfolging.Formidlingsgruppe;
 import org.junit.jupiter.api.Test;
 
-import java.sql.Timestamp;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import static no.nav.fo.veilarbregistrering.arbeidssoker.ArbeidssokerperiodeTestdataBuilder.*;
+import static no.nav.fo.veilarbregistrering.arbeidssoker.ArbeidssokerperiodeTestdataBuilder.medArbs;
+import static no.nav.fo.veilarbregistrering.arbeidssoker.ArbeidssokerperiodeTestdataBuilder.medIserv;
 import static no.nav.fo.veilarbregistrering.arbeidssoker.ArbeidssokerperioderTestdataBuilder.arbeidssokerperioder;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -102,111 +100,4 @@ public class ArbeidssokerperioderTest {
 
         assertThat(arbeidssokerperiodes).hasSize(2);
     }
-
-    @Test
-    public void kun_siste_periode_kan_ha_blank_tildato() {
-        Arbeidssokerperioder arbeidssokerperioder = arbeidssokerperioder()
-                .periode(medArbs()
-                        .fra(LocalDate.of(2020, 3, 19)))
-                .periode(medIserv()
-                        .fra(LocalDate.of(2020, 4, 21)))
-                .periode(medArbs()
-                        .fra(LocalDate.of(2020, 5, 30)))
-                .build()
-                .sorterOgPopulerTilDato();
-
-        assertThat(funnetTilDatoForIndeks(0, arbeidssokerperioder)).isNotNull();
-        assertThat(funnetTilDatoForIndeks(1, arbeidssokerperioder)).isNotNull();
-        assertThat(funnetTilDatoForSistePeriode(arbeidssokerperioder)).isNull();
-    }
-
-    @Test
-    public void foerste_periode_skal_ha_tildato_lik_dagen_foer_andre_periode_sin_fradato() {
-        Arbeidssokerperioder arbeidssokerperioder = arbeidssokerperioder()
-                .periode(medArbs()
-                        .fra(LocalDate.of(2020, 3, 19)))
-                .periode(medIserv()
-                        .fra(LocalDate.of(2020, 4, 21)))
-                .build()
-                .sorterOgPopulerTilDato();
-
-        assertThat(funnetTilDatoForIndeks(0, arbeidssokerperioder)).isEqualTo(LocalDate.of(2020, 4, 20));
-        assertThat(funnetTilDatoForSistePeriode(arbeidssokerperioder)).isNull();
-    }
-
-    @Test
-    public void skal_populere_tildato_korrekt_selv_om_listen_kommer_usortert() {
-        Arbeidssokerperioder arbeidssokerperioder = arbeidssokerperioder()
-                .periode(medArbs()
-                        .fra(LocalDate.of(2020, 5, 30)))
-                .periode(medArbs()
-                        .fra(LocalDate.of(2020, 3, 19)))
-                .periode(medIserv()
-                        .fra(LocalDate.of(2020, 4, 21)))
-                .build()
-                .sorterOgPopulerTilDato();
-
-        assertThat(funnetFraDatoForIndeks(0, arbeidssokerperioder)).isEqualTo(LocalDate.of(2020, 3, 19));
-        assertThat(funnetFraDatoForIndeks(1, arbeidssokerperioder)).isEqualTo(LocalDate.of(2020, 4, 21));
-        assertThat(funnetFraDatoForIndeks(2, arbeidssokerperioder)).isEqualTo(LocalDate.of(2020, 5, 30));
-
-        assertThat(funnetTilDatoForIndeks(0, arbeidssokerperioder)).isEqualTo(LocalDate.of(2020, 4, 20));
-        assertThat(funnetTilDatoForIndeks(1, arbeidssokerperioder)).isEqualTo(LocalDate.of(2020, 5, 29));
-        assertThat(funnetTilDatoForSistePeriode(arbeidssokerperioder)).isNull();
-
-    }
-
-    @Test
-    public void skal_kun_beholde_siste_formidlingsgruppeendring_fra_samme_dag() {
-        LocalDateTime now = LocalDateTime.now();
-        List<ArbeidssokerperiodeRaaData> arbeidssokerperiodeRaaData = new ArrayList<>();
-        arbeidssokerperiodeRaaData.add(new ArbeidssokerperiodeRaaData("ISERV", Timestamp.valueOf(now)));
-        arbeidssokerperiodeRaaData.add(new ArbeidssokerperiodeRaaData("ARBS", Timestamp.valueOf(now.plusSeconds(2))));
-        arbeidssokerperiodeRaaData.add(new ArbeidssokerperiodeRaaData("IARBS", Timestamp.valueOf(now.plusSeconds(4))));
-
-        Arbeidssokerperioder arbeidssokerperioder = Arbeidssokerperioder.of(arbeidssokerperiodeRaaData);
-
-        assertThat(arbeidssokerperioder.asList().size()).isEqualTo(1);
-        assertThat(arbeidssokerperioder.asList().get(0).getFormidlingsgruppe().stringValue()).isEqualTo("IARBS");
-        assertThat(arbeidssokerperioder.asList().get(0).getPeriode().getFra()).isEqualTo(now.toLocalDate());
-    }
-
-    @Test
-    public void skal_kun_beholde_siste_formidlingsgruppeendring_fra_samme_dag_flere_dager() {
-        LocalDateTime now = LocalDateTime.now();
-        List<ArbeidssokerperiodeRaaData> arbeidssokerperiodeRaaData = new ArrayList<>();
-        arbeidssokerperiodeRaaData.add(new ArbeidssokerperiodeRaaData("ISERV", Timestamp.valueOf(now)));
-        arbeidssokerperiodeRaaData.add(new ArbeidssokerperiodeRaaData("ARBS", Timestamp.valueOf(now.plusSeconds(2))));
-        arbeidssokerperiodeRaaData.add(new ArbeidssokerperiodeRaaData("IARBS", Timestamp.valueOf(now.plusSeconds(4))));
-
-        arbeidssokerperiodeRaaData.add(new ArbeidssokerperiodeRaaData("ISERV", Timestamp.valueOf(now.plusDays(7))));
-        arbeidssokerperiodeRaaData.add(new ArbeidssokerperiodeRaaData("ARBS", Timestamp.valueOf(now.plusDays(7).plusSeconds(3))));
-
-        arbeidssokerperiodeRaaData.add(new ArbeidssokerperiodeRaaData("ISERV", Timestamp.valueOf(now.plusDays(50))));
-        arbeidssokerperiodeRaaData.add(new ArbeidssokerperiodeRaaData("ARBS", Timestamp.valueOf(now.plusDays(50).plusSeconds(2))));
-        arbeidssokerperiodeRaaData.add(new ArbeidssokerperiodeRaaData("ISERV", Timestamp.valueOf(now.plusDays(50).plusSeconds(5))));
-
-        Arbeidssokerperioder arbeidssokerperioder = Arbeidssokerperioder.of(arbeidssokerperiodeRaaData);
-
-        assertThat(arbeidssokerperioder.asList().size()).isEqualTo(3);
-        assertThat(arbeidssokerperioder.asList().get(0).getFormidlingsgruppe().stringValue()).isEqualTo("IARBS");
-        assertThat(arbeidssokerperioder.asList().get(1).getFormidlingsgruppe().stringValue()).isEqualTo("ARBS");
-        assertThat(arbeidssokerperioder.asList().get(2).getFormidlingsgruppe().stringValue()).isEqualTo("ISERV");
-        assertThat(arbeidssokerperioder.asList().get(0).getPeriode().getFra()).isEqualTo(now.toLocalDate());
-        assertThat(arbeidssokerperioder.asList().get(1).getPeriode().getFra()).isEqualTo(now.plusDays(7).toLocalDate());
-        assertThat(arbeidssokerperioder.asList().get(2).getPeriode().getFra()).isEqualTo(now.plusDays(50).toLocalDate());
-    }
-
-    private LocalDate funnetFraDatoForIndeks(int indeks, Arbeidssokerperioder arbeidssokerperioder) {
-        return arbeidssokerperioder.asList().get(indeks).getPeriode().getFra();
-    }
-
-    private LocalDate funnetTilDatoForSistePeriode(Arbeidssokerperioder arbeidssokerperioder) {
-        return arbeidssokerperioder.asList().get(arbeidssokerperioder.asList().size()-1).getPeriode().getTil();
-    }
-
-    private LocalDate funnetTilDatoForIndeks(int indeks, Arbeidssokerperioder arbeidssokerperioder) {
-        return arbeidssokerperioder.asList().get(indeks).getPeriode().getTil();
-    }
-
 }

--- a/src/test/java/no/nav/fo/veilarbregistrering/db/arbeidssoker/ArbeidssokerperiodeMapperTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/db/arbeidssoker/ArbeidssokerperiodeMapperTest.java
@@ -1,0 +1,116 @@
+package no.nav.fo.veilarbregistrering.db.arbeidssoker;
+
+import no.nav.fo.veilarbregistrering.arbeidssoker.Arbeidssokerperioder;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import static no.nav.fo.veilarbregistrering.db.arbeidssoker.ArbeidssokerperioderMapper.map;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ArbeidssokerperiodeMapperTest {
+
+    @Test
+    public void kun_siste_periode_kan_ha_blank_tildato() {
+        List<ArbeidssokerperiodeRaaData> arbeidssokerperiodeRaaData = new ArrayList<>();
+        arbeidssokerperiodeRaaData.add(new ArbeidssokerperiodeRaaData("ARBS", Timestamp.valueOf(LocalDate.of(2020, 3, 19).atStartOfDay())));
+        arbeidssokerperiodeRaaData.add(new ArbeidssokerperiodeRaaData("ISERV", Timestamp.valueOf(LocalDate.of(2020, 4, 21).atStartOfDay())));
+        arbeidssokerperiodeRaaData.add(new ArbeidssokerperiodeRaaData("ISERV", Timestamp.valueOf(LocalDate.of(2020, 5, 30).atStartOfDay())));
+
+        Arbeidssokerperioder arbeidssokerperioder = map(arbeidssokerperiodeRaaData);
+
+        assertThat(funnetTilDatoForIndeks(0, arbeidssokerperioder)).isNotNull();
+        assertThat(funnetTilDatoForIndeks(1, arbeidssokerperioder)).isNotNull();
+        assertThat(funnetTilDatoForSistePeriode(arbeidssokerperioder)).isNull();
+    }
+
+    @Test
+    public void foerste_periode_skal_ha_tildato_lik_dagen_foer_andre_periode_sin_fradato() {
+        List<ArbeidssokerperiodeRaaData> arbeidssokerperiodeRaaData = new ArrayList<>();
+        arbeidssokerperiodeRaaData.add(new ArbeidssokerperiodeRaaData("ARBS", Timestamp.valueOf(LocalDate.of(2020, 3, 19).atStartOfDay())));
+        arbeidssokerperiodeRaaData.add(new ArbeidssokerperiodeRaaData("ISERV", Timestamp.valueOf(LocalDate.of(2020, 4, 21).atStartOfDay())));
+
+        Arbeidssokerperioder arbeidssokerperioder = map(arbeidssokerperiodeRaaData);
+
+        assertThat(funnetTilDatoForIndeks(0, arbeidssokerperioder)).isEqualTo(LocalDate.of(2020, 4, 20));
+        assertThat(funnetTilDatoForSistePeriode(arbeidssokerperioder)).isNull();
+    }
+
+
+    @Test
+    public void skal_populere_tildato_korrekt_selv_om_listen_kommer_usortert() {
+        List<ArbeidssokerperiodeRaaData> arbeidssokerperiodeRaaData = new ArrayList<>();
+        arbeidssokerperiodeRaaData.add(new ArbeidssokerperiodeRaaData("ARBS", Timestamp.valueOf(LocalDate.of(2020, 5, 30).atStartOfDay())));
+        arbeidssokerperiodeRaaData.add(new ArbeidssokerperiodeRaaData("ARBS", Timestamp.valueOf(LocalDate.of(2020, 3, 19).atStartOfDay())));
+        arbeidssokerperiodeRaaData.add(new ArbeidssokerperiodeRaaData("ISERV", Timestamp.valueOf(LocalDate.of(2020, 4, 21).atStartOfDay())));
+
+        Arbeidssokerperioder arbeidssokerperioder = map(arbeidssokerperiodeRaaData);
+
+        assertThat(funnetFraDatoForIndeks(0, arbeidssokerperioder)).isEqualTo(LocalDate.of(2020, 3, 19));
+        assertThat(funnetFraDatoForIndeks(1, arbeidssokerperioder)).isEqualTo(LocalDate.of(2020, 4, 21));
+        assertThat(funnetFraDatoForIndeks(2, arbeidssokerperioder)).isEqualTo(LocalDate.of(2020, 5, 30));
+
+        assertThat(funnetTilDatoForIndeks(0, arbeidssokerperioder)).isEqualTo(LocalDate.of(2020, 4, 20));
+        assertThat(funnetTilDatoForIndeks(1, arbeidssokerperioder)).isEqualTo(LocalDate.of(2020, 5, 29));
+        assertThat(funnetTilDatoForSistePeriode(arbeidssokerperioder)).isNull();
+
+    }
+
+    private LocalDate funnetFraDatoForIndeks(int indeks, Arbeidssokerperioder arbeidssokerperioder) {
+        return arbeidssokerperioder.asList().get(indeks).getPeriode().getFra();
+    }
+
+    private LocalDate funnetTilDatoForSistePeriode(Arbeidssokerperioder arbeidssokerperioder) {
+        return arbeidssokerperioder.asList().get(arbeidssokerperioder.asList().size()-1).getPeriode().getTil();
+    }
+
+    private LocalDate funnetTilDatoForIndeks(int indeks, Arbeidssokerperioder arbeidssokerperioder) {
+        return arbeidssokerperioder.asList().get(indeks).getPeriode().getTil();
+    }
+
+
+    @Test
+    public void skal_kun_beholde_siste_formidlingsgruppeendring_fra_samme_dag() {
+        LocalDateTime now = LocalDateTime.now();
+        List<ArbeidssokerperiodeRaaData> arbeidssokerperiodeRaaData = new ArrayList<>();
+        arbeidssokerperiodeRaaData.add(new ArbeidssokerperiodeRaaData("ISERV", Timestamp.valueOf(now)));
+        arbeidssokerperiodeRaaData.add(new ArbeidssokerperiodeRaaData("ARBS", Timestamp.valueOf(now.plusSeconds(2))));
+        arbeidssokerperiodeRaaData.add(new ArbeidssokerperiodeRaaData("IARBS", Timestamp.valueOf(now.plusSeconds(4))));
+
+        Arbeidssokerperioder arbeidssokerperioder = map(arbeidssokerperiodeRaaData);
+
+        assertThat(arbeidssokerperioder.asList().size()).isEqualTo(1);
+        assertThat(arbeidssokerperioder.asList().get(0).getFormidlingsgruppe().stringValue()).isEqualTo("IARBS");
+        assertThat(arbeidssokerperioder.asList().get(0).getPeriode().getFra()).isEqualTo(now.toLocalDate());
+    }
+
+    @Test
+    public void skal_kun_beholde_siste_formidlingsgruppeendring_fra_samme_dag_flere_dager() {
+        LocalDateTime now = LocalDateTime.now();
+        List<ArbeidssokerperiodeRaaData> arbeidssokerperiodeRaaData = new ArrayList<>();
+        arbeidssokerperiodeRaaData.add(new ArbeidssokerperiodeRaaData("ISERV", Timestamp.valueOf(now)));
+        arbeidssokerperiodeRaaData.add(new ArbeidssokerperiodeRaaData("ARBS", Timestamp.valueOf(now.plusSeconds(2))));
+        arbeidssokerperiodeRaaData.add(new ArbeidssokerperiodeRaaData("IARBS", Timestamp.valueOf(now.plusSeconds(4))));
+
+        arbeidssokerperiodeRaaData.add(new ArbeidssokerperiodeRaaData("ISERV", Timestamp.valueOf(now.plusDays(7))));
+        arbeidssokerperiodeRaaData.add(new ArbeidssokerperiodeRaaData("ARBS", Timestamp.valueOf(now.plusDays(7).plusSeconds(3))));
+
+        arbeidssokerperiodeRaaData.add(new ArbeidssokerperiodeRaaData("ISERV", Timestamp.valueOf(now.plusDays(50))));
+        arbeidssokerperiodeRaaData.add(new ArbeidssokerperiodeRaaData("ARBS", Timestamp.valueOf(now.plusDays(50).plusSeconds(2))));
+        arbeidssokerperiodeRaaData.add(new ArbeidssokerperiodeRaaData("ISERV", Timestamp.valueOf(now.plusDays(50).plusSeconds(5))));
+
+        Arbeidssokerperioder arbeidssokerperioder = map(arbeidssokerperiodeRaaData);
+
+        assertThat(arbeidssokerperioder.asList().size()).isEqualTo(3);
+        assertThat(arbeidssokerperioder.asList().get(0).getFormidlingsgruppe().stringValue()).isEqualTo("IARBS");
+        assertThat(arbeidssokerperioder.asList().get(1).getFormidlingsgruppe().stringValue()).isEqualTo("ARBS");
+        assertThat(arbeidssokerperioder.asList().get(2).getFormidlingsgruppe().stringValue()).isEqualTo("ISERV");
+        assertThat(arbeidssokerperioder.asList().get(0).getPeriode().getFra()).isEqualTo(now.toLocalDate());
+        assertThat(arbeidssokerperioder.asList().get(1).getPeriode().getFra()).isEqualTo(now.plusDays(7).toLocalDate());
+        assertThat(arbeidssokerperioder.asList().get(2).getPeriode().getFra()).isEqualTo(now.plusDays(50).toLocalDate());
+    }
+}


### PR DESCRIPTION
Ønsker ikke at RaaData-klassen skal dependes på fra domenet. Dette er en Entity/DTO for databasen, og bør derfor behandles på samme måte som andre DTOer for adaptere.

Flytter da logikk ut fra constuctor og over til Repository (egen mapper), og sørger samtidig for å sortere listen bare én gang. Det gjør koden litt lettere å lese.