### PR TITLE
Flytter Formidlingsgruppe til `arbeidssoker`

### DIFF
--- a/src/main/java/no/nav/fo/veilarbregistrering/arbeidssoker/Arbeidssokerperiode.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/arbeidssoker/Arbeidssokerperiode.java
@@ -1,7 +1,6 @@
 package no.nav.fo.veilarbregistrering.arbeidssoker;
 
 import no.nav.fo.veilarbregistrering.bruker.Periode;
-import no.nav.fo.veilarbregistrering.oppfolging.Formidlingsgruppe;
 
 import java.time.LocalDate;
 import java.util.Comparator;

--- a/src/main/java/no/nav/fo/veilarbregistrering/arbeidssoker/EndretFormidlingsgruppeCommand.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/arbeidssoker/EndretFormidlingsgruppeCommand.java
@@ -1,7 +1,6 @@
 package no.nav.fo.veilarbregistrering.arbeidssoker;
 
 import no.nav.fo.veilarbregistrering.bruker.Foedselsnummer;
-import no.nav.fo.veilarbregistrering.oppfolging.Formidlingsgruppe;
 
 import java.time.LocalDateTime;
 import java.util.Optional;

--- a/src/main/java/no/nav/fo/veilarbregistrering/arbeidssoker/Formidlingsgruppe.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/arbeidssoker/Formidlingsgruppe.java
@@ -1,4 +1,4 @@
-package no.nav.fo.veilarbregistrering.oppfolging;
+package no.nav.fo.veilarbregistrering.arbeidssoker;
 
 import no.nav.fo.veilarbregistrering.metrics.Metric;
 

--- a/src/main/java/no/nav/fo/veilarbregistrering/arbeidssoker/adapter/FormidlingshistorikkMapper.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/arbeidssoker/adapter/FormidlingshistorikkMapper.java
@@ -1,8 +1,8 @@
 package no.nav.fo.veilarbregistrering.arbeidssoker.adapter;
 
 import no.nav.fo.veilarbregistrering.arbeidssoker.Arbeidssokerperiode;
+import no.nav.fo.veilarbregistrering.arbeidssoker.Formidlingsgruppe;
 import no.nav.fo.veilarbregistrering.bruker.Periode;
-import no.nav.fo.veilarbregistrering.oppfolging.Formidlingsgruppe;
 
 import java.util.List;
 

--- a/src/main/java/no/nav/fo/veilarbregistrering/db/arbeidssoker/ArbeidssokerRepositoryImpl.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/db/arbeidssoker/ArbeidssokerRepositoryImpl.java
@@ -3,8 +3,8 @@ package no.nav.fo.veilarbregistrering.db.arbeidssoker;
 import no.nav.fo.veilarbregistrering.arbeidssoker.ArbeidssokerRepository;
 import no.nav.fo.veilarbregistrering.arbeidssoker.Arbeidssokerperioder;
 import no.nav.fo.veilarbregistrering.arbeidssoker.EndretFormidlingsgruppeCommand;
-import no.nav.fo.veilarbregistrering.bruker.Foedselsnummer;
 import no.nav.fo.veilarbregistrering.arbeidssoker.Formidlingsgruppe;
+import no.nav.fo.veilarbregistrering.bruker.Foedselsnummer;
 import no.nav.sbl.sql.SqlUtils;
 import org.springframework.jdbc.core.JdbcTemplate;
 

--- a/src/main/java/no/nav/fo/veilarbregistrering/db/arbeidssoker/ArbeidssokerRepositoryImpl.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/db/arbeidssoker/ArbeidssokerRepositoryImpl.java
@@ -4,7 +4,7 @@ import no.nav.fo.veilarbregistrering.arbeidssoker.ArbeidssokerRepository;
 import no.nav.fo.veilarbregistrering.arbeidssoker.Arbeidssokerperioder;
 import no.nav.fo.veilarbregistrering.arbeidssoker.EndretFormidlingsgruppeCommand;
 import no.nav.fo.veilarbregistrering.bruker.Foedselsnummer;
-import no.nav.fo.veilarbregistrering.oppfolging.Formidlingsgruppe;
+import no.nav.fo.veilarbregistrering.arbeidssoker.Formidlingsgruppe;
 import no.nav.sbl.sql.SqlUtils;
 import org.springframework.jdbc.core.JdbcTemplate;
 

--- a/src/main/java/no/nav/fo/veilarbregistrering/db/arbeidssoker/ArbeidssokerperioderMapper.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/db/arbeidssoker/ArbeidssokerperioderMapper.java
@@ -3,7 +3,7 @@ package no.nav.fo.veilarbregistrering.db.arbeidssoker;
 import no.nav.fo.veilarbregistrering.arbeidssoker.Arbeidssokerperiode;
 import no.nav.fo.veilarbregistrering.arbeidssoker.Arbeidssokerperioder;
 import no.nav.fo.veilarbregistrering.bruker.Periode;
-import no.nav.fo.veilarbregistrering.oppfolging.Formidlingsgruppe;
+import no.nav.fo.veilarbregistrering.arbeidssoker.Formidlingsgruppe;
 
 import java.time.LocalDate;
 import java.util.ArrayList;

--- a/src/main/java/no/nav/fo/veilarbregistrering/db/arbeidssoker/ArbeidssokerperioderMapper.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/db/arbeidssoker/ArbeidssokerperioderMapper.java
@@ -2,8 +2,8 @@ package no.nav.fo.veilarbregistrering.db.arbeidssoker;
 
 import no.nav.fo.veilarbregistrering.arbeidssoker.Arbeidssokerperiode;
 import no.nav.fo.veilarbregistrering.arbeidssoker.Arbeidssokerperioder;
-import no.nav.fo.veilarbregistrering.bruker.Periode;
 import no.nav.fo.veilarbregistrering.arbeidssoker.Formidlingsgruppe;
+import no.nav.fo.veilarbregistrering.bruker.Periode;
 
 import java.time.LocalDate;
 import java.util.ArrayList;

--- a/src/main/java/no/nav/fo/veilarbregistrering/kafka/FormidlingsgruppeEvent.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/kafka/FormidlingsgruppeEvent.java
@@ -3,7 +3,7 @@ package no.nav.fo.veilarbregistrering.kafka;
 import no.nav.fo.veilarbregistrering.arbeidssoker.EndretFormidlingsgruppeCommand;
 import no.nav.fo.veilarbregistrering.arbeidssoker.Operation;
 import no.nav.fo.veilarbregistrering.bruker.Foedselsnummer;
-import no.nav.fo.veilarbregistrering.oppfolging.Formidlingsgruppe;
+import no.nav.fo.veilarbregistrering.arbeidssoker.Formidlingsgruppe;
 
 import java.time.LocalDateTime;
 import java.util.Optional;

--- a/src/main/java/no/nav/fo/veilarbregistrering/kafka/FormidlingsgruppeEvent.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/kafka/FormidlingsgruppeEvent.java
@@ -1,9 +1,9 @@
 package no.nav.fo.veilarbregistrering.kafka;
 
 import no.nav.fo.veilarbregistrering.arbeidssoker.EndretFormidlingsgruppeCommand;
+import no.nav.fo.veilarbregistrering.arbeidssoker.Formidlingsgruppe;
 import no.nav.fo.veilarbregistrering.arbeidssoker.Operation;
 import no.nav.fo.veilarbregistrering.bruker.Foedselsnummer;
-import no.nav.fo.veilarbregistrering.arbeidssoker.Formidlingsgruppe;
 
 import java.time.LocalDateTime;
 import java.util.Optional;

--- a/src/main/java/no/nav/fo/veilarbregistrering/kafka/FormidlingsgruppeMapper.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/kafka/FormidlingsgruppeMapper.java
@@ -1,9 +1,9 @@
 package no.nav.fo.veilarbregistrering.kafka;
 
 import com.google.gson.Gson;
+import no.nav.fo.veilarbregistrering.arbeidssoker.Formidlingsgruppe;
 import no.nav.fo.veilarbregistrering.arbeidssoker.Operation;
 import no.nav.fo.veilarbregistrering.bruker.Foedselsnummer;
-import no.nav.fo.veilarbregistrering.arbeidssoker.Formidlingsgruppe;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;

--- a/src/main/java/no/nav/fo/veilarbregistrering/kafka/FormidlingsgruppeMapper.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/kafka/FormidlingsgruppeMapper.java
@@ -3,7 +3,7 @@ package no.nav.fo.veilarbregistrering.kafka;
 import com.google.gson.Gson;
 import no.nav.fo.veilarbregistrering.arbeidssoker.Operation;
 import no.nav.fo.veilarbregistrering.bruker.Foedselsnummer;
-import no.nav.fo.veilarbregistrering.oppfolging.Formidlingsgruppe;
+import no.nav.fo.veilarbregistrering.arbeidssoker.Formidlingsgruppe;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;

--- a/src/main/java/no/nav/fo/veilarbregistrering/oppfolging/Oppfolgingsstatus.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/oppfolging/Oppfolgingsstatus.java
@@ -1,5 +1,7 @@
 package no.nav.fo.veilarbregistrering.oppfolging;
 
+import no.nav.fo.veilarbregistrering.arbeidssoker.Formidlingsgruppe;
+
 import java.util.Optional;
 
 import static java.util.Optional.ofNullable;

--- a/src/main/java/no/nav/fo/veilarbregistrering/oppfolging/adapter/OppfolgingGatewayImpl.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/oppfolging/adapter/OppfolgingGatewayImpl.java
@@ -5,7 +5,7 @@ import no.nav.fo.veilarbregistrering.oppfolging.OppfolgingGateway;
 import no.nav.fo.veilarbregistrering.oppfolging.Oppfolgingsstatus;
 import no.nav.fo.veilarbregistrering.profilering.Innsatsgruppe;
 import no.nav.fo.veilarbregistrering.besvarelse.Besvarelse;
-import no.nav.fo.veilarbregistrering.oppfolging.Formidlingsgruppe;
+import no.nav.fo.veilarbregistrering.arbeidssoker.Formidlingsgruppe;
 import no.nav.fo.veilarbregistrering.oppfolging.Rettighetsgruppe;
 import no.nav.fo.veilarbregistrering.oppfolging.Servicegruppe;
 

--- a/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/BrukersTilstand.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/BrukersTilstand.java
@@ -2,7 +2,7 @@ package no.nav.fo.veilarbregistrering.registrering.bruker;
 
 import no.nav.fo.veilarbregistrering.metrics.HasMetrics;
 import no.nav.fo.veilarbregistrering.metrics.Metric;
-import no.nav.fo.veilarbregistrering.oppfolging.Formidlingsgruppe;
+import no.nav.fo.veilarbregistrering.arbeidssoker.Formidlingsgruppe;
 import no.nav.fo.veilarbregistrering.oppfolging.Oppfolgingsstatus;
 import no.nav.fo.veilarbregistrering.oppfolging.Rettighetsgruppe;
 import no.nav.fo.veilarbregistrering.oppfolging.Servicegruppe;

--- a/src/main/java/no/nav/fo/veilarbregistrering/registrering/resources/StartRegistreringStatusDtoMapper.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/registrering/resources/StartRegistreringStatusDtoMapper.java
@@ -1,7 +1,7 @@
 package no.nav.fo.veilarbregistrering.registrering.resources;
 
 import no.nav.fo.veilarbregistrering.bruker.GeografiskTilknytning;
-import no.nav.fo.veilarbregistrering.oppfolging.Formidlingsgruppe;
+import no.nav.fo.veilarbregistrering.arbeidssoker.Formidlingsgruppe;
 import no.nav.fo.veilarbregistrering.oppfolging.Rettighetsgruppe;
 import no.nav.fo.veilarbregistrering.oppfolging.Servicegruppe;
 import no.nav.fo.veilarbregistrering.registrering.bruker.BrukersTilstand;

--- a/src/test/java/no/nav/fo/veilarbregistrering/arbeidssoker/ArbeidssokerServiceTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/arbeidssoker/ArbeidssokerServiceTest.java
@@ -2,7 +2,6 @@ package no.nav.fo.veilarbregistrering.arbeidssoker;
 
 import no.nav.fo.veilarbregistrering.bruker.Foedselsnummer;
 import no.nav.fo.veilarbregistrering.bruker.Periode;
-import no.nav.fo.veilarbregistrering.oppfolging.Formidlingsgruppe;
 import no.nav.sbl.featuretoggle.unleash.UnleashService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/no/nav/fo/veilarbregistrering/arbeidssoker/ArbeidssokerperiodeTestdataBuilder.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/arbeidssoker/ArbeidssokerperiodeTestdataBuilder.java
@@ -1,7 +1,6 @@
 package no.nav.fo.veilarbregistrering.arbeidssoker;
 
 import no.nav.fo.veilarbregistrering.bruker.Periode;
-import no.nav.fo.veilarbregistrering.oppfolging.Formidlingsgruppe;
 
 import java.time.LocalDate;
 

--- a/src/test/java/no/nav/fo/veilarbregistrering/arbeidssoker/ArbeidssokerperioderTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/arbeidssoker/ArbeidssokerperioderTest.java
@@ -1,7 +1,6 @@
 package no.nav.fo.veilarbregistrering.arbeidssoker;
 
 import no.nav.fo.veilarbregistrering.bruker.Periode;
-import no.nav.fo.veilarbregistrering.oppfolging.Formidlingsgruppe;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDate;

--- a/src/test/java/no/nav/fo/veilarbregistrering/arbeidssoker/adapter/FormidlingshistorikkMapperTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/arbeidssoker/adapter/FormidlingshistorikkMapperTest.java
@@ -2,7 +2,7 @@ package no.nav.fo.veilarbregistrering.arbeidssoker.adapter;
 
 import no.nav.fo.veilarbregistrering.arbeidssoker.Arbeidssokerperiode;
 import no.nav.fo.veilarbregistrering.bruker.Periode;
-import no.nav.fo.veilarbregistrering.oppfolging.Formidlingsgruppe;
+import no.nav.fo.veilarbregistrering.arbeidssoker.Formidlingsgruppe;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDate;

--- a/src/test/java/no/nav/fo/veilarbregistrering/db/arbeidssoker/ArbeidssokerRepositoryDbIntegrationTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/db/arbeidssoker/ArbeidssokerRepositoryDbIntegrationTest.java
@@ -6,7 +6,7 @@ import no.nav.fo.veilarbregistrering.arbeidssoker.EndretFormidlingsgruppeCommand
 import no.nav.fo.veilarbregistrering.arbeidssoker.Operation;
 import no.nav.fo.veilarbregistrering.bruker.Foedselsnummer;
 import no.nav.fo.veilarbregistrering.db.DbIntegrasjonsTest;
-import no.nav.fo.veilarbregistrering.oppfolging.Formidlingsgruppe;
+import no.nav.fo.veilarbregistrering.arbeidssoker.Formidlingsgruppe;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.jdbc.core.JdbcTemplate;

--- a/src/test/java/no/nav/fo/veilarbregistrering/kafka/FormidlingsgruppeMapperTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/kafka/FormidlingsgruppeMapperTest.java
@@ -2,7 +2,7 @@ package no.nav.fo.veilarbregistrering.kafka;
 
 import no.nav.fo.veilarbregistrering.FileToJson;
 import no.nav.fo.veilarbregistrering.arbeidssoker.Operation;
-import no.nav.fo.veilarbregistrering.oppfolging.Formidlingsgruppe;
+import no.nav.fo.veilarbregistrering.arbeidssoker.Formidlingsgruppe;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;

--- a/src/test/java/no/nav/fo/veilarbregistrering/registrering/bruker/FormidlingsgruppeTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/registrering/bruker/FormidlingsgruppeTest.java
@@ -1,6 +1,6 @@
 package no.nav.fo.veilarbregistrering.registrering.bruker;
 
-import no.nav.fo.veilarbregistrering.oppfolging.Formidlingsgruppe;
+import no.nav.fo.veilarbregistrering.arbeidssoker.Formidlingsgruppe;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/src/test/java/no/nav/fo/veilarbregistrering/registrering/bruker/RegistreringTypeTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/registrering/bruker/RegistreringTypeTest.java
@@ -1,6 +1,6 @@
 package no.nav.fo.veilarbregistrering.registrering.bruker;
 
-import no.nav.fo.veilarbregistrering.oppfolging.Formidlingsgruppe;
+import no.nav.fo.veilarbregistrering.arbeidssoker.Formidlingsgruppe;
 import no.nav.fo.veilarbregistrering.oppfolging.Oppfolgingsstatus;
 import no.nav.fo.veilarbregistrering.oppfolging.Rettighetsgruppe;
 import no.nav.fo.veilarbregistrering.oppfolging.Servicegruppe;

--- a/src/test/java/no/nav/fo/veilarbregistrering/registrering/resources/StartRegistreringStatusDtoMapperTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/registrering/resources/StartRegistreringStatusDtoMapperTest.java
@@ -1,7 +1,7 @@
 package no.nav.fo.veilarbregistrering.registrering.resources;
 
 import no.nav.fo.veilarbregistrering.bruker.GeografiskTilknytning;
-import no.nav.fo.veilarbregistrering.oppfolging.Formidlingsgruppe;
+import no.nav.fo.veilarbregistrering.arbeidssoker.Formidlingsgruppe;
 import no.nav.fo.veilarbregistrering.oppfolging.Oppfolgingsstatus;
 import no.nav.fo.veilarbregistrering.oppfolging.Rettighetsgruppe;
 import no.nav.fo.veilarbregistrering.oppfolging.Servicegruppe;


### PR DESCRIPTION
Formidlingsgruppe bør bo i `arbeidssoker`-pakken fremfor oppfolging. Selv om vi også henter verdien fra oppfolging, så bør vi i større grad basere oss på egne data.

Med synken via Kafka, vil vi ha de samme dataene lokalt, og bør da ikke trenge å snakke med Oppfolging for å få denne informasjonen. Da gir det også mening å samle det der.