### PR TITLE
Innfører toggle for overforing uten cookie

### DIFF
--- a/src/main/java/no/nav/fo/veilarbregistrering/oppfolging/adapter/OppfolgingClient.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/oppfolging/adapter/OppfolgingClient.java
@@ -113,7 +113,7 @@ public class OppfolgingClient {
     }
 
     private Builder buildSystemAuthorizationRequestWithUrl(Client client, String url) {
-        if (asynkArenaOverforing()) {
+        if (overforingUtenCookie()) {
             LOG.info("Benytter SystemAuthorizationRequest uten cookie");
             return client.target(url)
                     .request()
@@ -126,6 +126,10 @@ public class OppfolgingClient {
                 .request()
                 .header(COOKIE, cookies)
                 .header("SystemAuthorization", this.gammelSystemUserTokenProvider.getToken());
+    }
+
+    private boolean overforingUtenCookie() {
+        return unleashService.isEnabled("veilarbregistrering.overforUtenCookie");
     }
 
     private boolean asynkArenaOverforing() {


### PR DESCRIPTION
Cookie som blir sendt med til veilarboppfolging blir ikke benyttet av veilarboppfolging. Vi tror derfor at vi kan droppe verdien. Da kan vi potensielt forenkle litt av logikken, og ikke måtte skille på asynk/synk her. For å raskt kunne endre tilbake, tar vi veien via toggle.