### PR TITLE
Fjerner bruk av toggle som ikke har vært endret på 1 år

### DIFF
--- a/src/main/java/no/nav/fo/veilarbregistrering/config/PepConfig.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/config/PepConfig.java
@@ -4,7 +4,6 @@ import no.nav.apiapp.security.veilarbabac.VeilarbAbacPepClient;
 import no.nav.common.oidc.SystemUserTokenProvider;
 import no.nav.sbl.dialogarena.common.abac.pep.Pep;
 import no.nav.sbl.dialogarena.common.abac.pep.context.AbacContext;
-import no.nav.sbl.featuretoggle.unleash.UnleashService;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -19,8 +18,6 @@ public class PepConfig {
     SystemUserTokenProvider systemUserTokenProvider;
 
     @Inject
-    UnleashService unleashService;
-
     @Bean
     public VeilarbAbacPepClient pepClient(Pep pep) {
 
@@ -28,9 +25,9 @@ public class PepConfig {
                 .medPep(pep)
                 .medResourceTypePerson()
                 .medSystemUserTokenProvider(()->systemUserTokenProvider.getSystemUserAccessToken())
-                .brukAktoerId(()->unleashService.isEnabled("veilarbregistrering.veilarbabac.aktor"))
-                .sammenlikneTilgang(()->unleashService.isEnabled("veilarbregistrering.veilarbabac.sammenlikn"))
-                .foretrekkVeilarbAbacResultat(()->unleashService.isEnabled("veilarbregistrering.veilarbabac.foretrekk_veilarbabac"))
+                .brukAktoerId(()->false)
+                .sammenlikneTilgang(()->false)
+                .foretrekkVeilarbAbacResultat(()->false)
                 .bygg();
     }
 

--- a/src/main/java/no/nav/fo/veilarbregistrering/config/PepConfig.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/config/PepConfig.java
@@ -25,9 +25,6 @@ public class PepConfig {
                 .medPep(pep)
                 .medResourceTypePerson()
                 .medSystemUserTokenProvider(()->systemUserTokenProvider.getSystemUserAccessToken())
-                .brukAktoerId(()->false)
-                .sammenlikneTilgang(()->false)
-                .foretrekkVeilarbAbacResultat(()->false)
                 .bygg();
     }
 


### PR DESCRIPTION
Toggle for å bygge opp veilarbabac-klient som ikke har vært endret siden juni 2019. Sletter disse, så vi får færre toggles å bry oss om.