### PR TITLE
Router GK for Oslo, Bergen, Stavanger og Trondheim -> Intern brukerst…

### DIFF
--- a/src/main/java/no/nav/fo/veilarbregistrering/bruker/GeografiskTilknytning.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/bruker/GeografiskTilknytning.java
@@ -3,7 +3,11 @@ package no.nav.fo.veilarbregistrering.bruker;
 import no.nav.fo.veilarbregistrering.metrics.Metric;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
+
+import static no.nav.fo.veilarbregistrering.bruker.GeografiskTilknytning.ByMedBydeler.byMedBydelerAsKode;
 
 /**
  * Geografisk tilknytning kan være 1 av 3:
@@ -67,7 +71,6 @@ public class GeografiskTilknytning implements Metric {
         } else if (bydelOslo()) {
             fieldName = "bydelOslo" + BydelOslo.of(geografisktilknytning).name();
         } else {
-            fieldName = "ukjentVerdi";
             throw new IllegalArgumentException("Geografisk tilknytning har ukjent format: " + geografisktilknytning);
         }
 
@@ -90,7 +93,34 @@ public class GeografiskTilknytning implements Metric {
         return geografisktilknytning.length() == 6 && !BydelOslo.contains(geografisktilknytning);
     }
 
-    private enum BydelOslo {
+    public boolean byMedBydeler() {
+        return byMedBydelerAsKode().contains(geografisktilknytning);
+    }
+
+    enum ByMedBydeler {
+        Oslo("0301"),
+        Stavanger("1103"),
+        Bergen("4601"),
+        Trondheim("5001");
+
+        private final String kode;
+
+        ByMedBydeler(String kode) {
+            this.kode = kode;
+        }
+
+        static List<String> byMedBydelerAsKode() {
+            return Arrays.stream(values())
+                    .map(by -> by.kode)
+                    .collect(Collectors.toList());
+        }
+
+        String kode() {
+            return kode;
+        }
+    }
+
+    enum BydelOslo {
 
         GamleOslo("030101", "Gamle Oslo"),
         Grunerlokka("030102", "Grünerløkka"),
@@ -111,22 +141,26 @@ public class GeografiskTilknytning implements Metric {
         Marka("030117", "Marka");
 
         private final String kode;
-        private final String verdi;
+        private final String navn;
 
-        BydelOslo(String kode, String verdi) {
+        BydelOslo(String kode, String navn) {
             this.kode = kode;
-            this.verdi = verdi;
+            this.navn = navn;
         }
 
-        String verdi() {
-            return verdi;
+        String kode() {
+            return kode;
+        }
+
+        String navn() {
+            return navn;
         }
 
         private static BydelOslo of(String geografisktilknytning) {
             return Arrays.stream(BydelOslo.values())
                     .filter(bydelOslo -> bydelOslo.kode.equals(geografisktilknytning))
                     .findFirst()
-                    .orElseThrow(() -> new IllegalStateException(geografisktilknytning + " er ikke en kjent verdi for noen bydel i Oslo."));
+                    .orElseThrow(() -> new IllegalStateException(geografisktilknytning + " er ikke en kjent kode for noen bydel i Oslo."));
         }
 
         private static boolean contains(String geografisktilknytning) {

--- a/src/main/java/no/nav/fo/veilarbregistrering/oppgave/OppgaveRouter.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/oppgave/OppgaveRouter.java
@@ -69,6 +69,12 @@ public class OppgaveRouter {
 
             GeografiskTilknytning gk = geografiskTilknytning.get();
 
+            if (gk.byMedBydeler()) {
+                LOG.info("Fant {} som er en by med bydeler -> sender oppgave til intern brukerstøtte", gk);
+                reportTags(OPPGAVE_ROUTING_EVENT, GeografiskTilknytning_ByMedBydel_Funnet);
+                return Optional.of(Enhetsnr.internBrukerstotte());
+            }
+
             if (!gk.utland()) {
                 LOG.info("Fant {} -> overlater til oppgave-api å route selv", gk);
                 reportTags(OPPGAVE_ROUTING_EVENT, GeografiskTilknytning_Funnet);

--- a/src/main/java/no/nav/fo/veilarbregistrering/oppgave/RoutingStep.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/oppgave/RoutingStep.java
@@ -6,6 +6,7 @@ public enum  RoutingStep implements Metric {
 
     GeografiskTilknytning_Feilet,
     GeografiskTilknytning_Funnet,
+    GeografiskTilknytning_ByMedBydel_Funnet,
     GeografiskTilknytning_Utland,
     Enhetsnummer_Feilet,
     SisteArbeidsforhold_IkkeFunnet,

--- a/src/test/java/no/nav/fo/veilarbregistrering/bruker/GeografiskTilknytningTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/bruker/GeografiskTilknytningTest.java
@@ -1,18 +1,16 @@
 package no.nav.fo.veilarbregistrering.bruker;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class GeografiskTilknytningTest {
 
     @Test
     public void geografiskTilknytning_kan_ikke_vaere_null() {
-        try {
-            GeografiskTilknytning.of(null);
-        } catch (NullPointerException e) {
-            assertThat(e.getMessage()).isEqualTo("Geografisk tilknytning kan ikke være null. Bruk <code>ofNullable</code> hvis du er usikker.");
-        }
+        NullPointerException nullPointerException = assertThrows(NullPointerException.class, () -> GeografiskTilknytning.of(null));
+        assertThat(nullPointerException.getMessage()).isEqualTo("Geografisk tilknytning kan ikke være null. Bruk <code>ofNullable</code> hvis du er usikker.");
     }
 
     @Test
@@ -37,10 +35,38 @@ public class GeografiskTilknytningTest {
 
     @Test
     public void exception_skal_kastes_hvis_geografiskTilknytning_er_ukjent() {
-        try {
-            GeografiskTilknytning.of("12").value();
-        } catch (IllegalArgumentException e) {
-            assertThat(e.getMessage()).isEqualTo("Geografisk tilknytning har ukjent format: 12");
-        }
+        IllegalArgumentException illegalArgumentException = assertThrows(IllegalArgumentException.class, () -> GeografiskTilknytning.of("12").value());
+        assertThat(illegalArgumentException.getMessage()).isEqualTo("Geografisk tilknytning har ukjent format: 12");
     }
+
+    @Test
+    public void bydel_bjerke_i_oslo_er_ikke_by_med_bydel() {
+        GeografiskTilknytning bjerke = GeografiskTilknytning.of(GeografiskTilknytning.BydelOslo.Bjerke.kode());
+        assertThat(bjerke.byMedBydeler()).isFalse();
+    }
+
+    @Test
+    public void oslo_er_by_med_bydeler() {
+        GeografiskTilknytning oslo = GeografiskTilknytning.of(GeografiskTilknytning.ByMedBydeler.Oslo.kode());
+        assertThat(oslo.byMedBydeler()).isTrue();
+    }
+
+    @Test
+    public void stavanger_er_by_med_bydeler() {
+        GeografiskTilknytning oslo = GeografiskTilknytning.of(GeografiskTilknytning.ByMedBydeler.Stavanger.kode());
+        assertThat(oslo.byMedBydeler()).isTrue();
+    }
+
+    @Test
+    public void bergen_er_by_med_bydeler() {
+        GeografiskTilknytning oslo = GeografiskTilknytning.of(GeografiskTilknytning.ByMedBydeler.Bergen.kode());
+        assertThat(oslo.byMedBydeler()).isTrue();
+    }
+
+    @Test
+    public void trondheim_er_by_med_bydeler() {
+        GeografiskTilknytning oslo = GeografiskTilknytning.of(GeografiskTilknytning.ByMedBydeler.Trondheim.kode());
+        assertThat(oslo.byMedBydeler()).isTrue();
+    }
+
 }

--- a/src/test/java/no/nav/fo/veilarbregistrering/oppgave/OppgaveRouterTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/oppgave/OppgaveRouterTest.java
@@ -97,6 +97,20 @@ public class OppgaveRouterTest {
     }
 
     @Test
+    public void geografisk_tilknytning_med_by_med_bydel_skal_gi_intern_brukerstotte() {
+        ArbeidsforholdGateway arbeidsforholdGateway = fnr -> flereArbeidsforholdTilfeldigSortert();
+        EnhetGateway enhetGateway = organisasjonsnummer -> Optional.empty();
+        Norg2Gateway norg2Gateway = kommunenummer -> Optional.empty();
+        PersonGateway personGateway = foedselsnummer -> Optional.of(GeografiskTilknytning.of("0301"));
+
+        OppgaveRouter oppgaveRouter = new OppgaveRouter(arbeidsforholdGateway, enhetGateway, norg2Gateway, personGateway);
+
+        Optional<Enhetsnr> enhetsnr = oppgaveRouter.hentEnhetsnummerFor(BRUKER, UTVANDRET);
+
+        assertThat(enhetsnr).hasValue(Enhetsnr.internBrukerstotte());
+    }
+
+    @Test
     public void geografisk_tilknytning_med_unntak_av_landkode_skal_gi_empty_enhetsnummer() {
         ArbeidsforholdGateway arbeidsforholdGateway = fnr -> flereArbeidsforholdTilfeldigSortert();
         EnhetGateway enhetGateway = organisasjonsnummer -> Optional.empty();


### PR DESCRIPTION
…øtte

Vi har fått et case i produksjon, hvor vi ser at vi får tilbake Geografisk tilknytning som tilsvarer Oslo, men ikke en bydel i Oslo.Vi har da tidligere latt Oppgave API route disse oppgavene selv, men ser at de ender opp med å route til NAV-utland som ikke ønsker disse sakene. Vi legger derfor til støtte for å route GK = Oslo, Bergen, Stavanger eller Trondheim til Intern brukerstøtte inntil vi har en bedre løsning.

Melder samtidig fra om tilfellet til de som sitter med Oppgave API og register for GK-verdier.