### PR TITLE
Henter flere arbeidssokerperioder for liste av fnr i en spørring

### DIFF
--- a/src/main/java/no/nav/fo/veilarbregistrering/arbeidssoker/ArbeidssokerRepository.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/arbeidssoker/ArbeidssokerRepository.java
@@ -3,6 +3,8 @@ package no.nav.fo.veilarbregistrering.arbeidssoker;
 import no.nav.fo.veilarbregistrering.bruker.Bruker;
 import no.nav.fo.veilarbregistrering.bruker.Foedselsnummer;
 
+import java.util.List;
+
 public interface ArbeidssokerRepository {
 
     long lagre(EndretFormidlingsgruppeCommand arenaFormidlingsgruppeEvent);
@@ -10,4 +12,6 @@ public interface ArbeidssokerRepository {
     Arbeidssokerperioder finnFormidlingsgrupper(Foedselsnummer foedselsnummer);
 
     Arbeidssokerperioder finnFormidlingsgrupper(Bruker bruker);
+
+    Arbeidssokerperioder finnFormidlingsgrupper(List<Foedselsnummer> foedselsnummer);
 }

--- a/src/main/java/no/nav/fo/veilarbregistrering/db/arbeidssoker/ArbeidssokerRepositoryImpl.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/db/arbeidssoker/ArbeidssokerRepositoryImpl.java
@@ -8,20 +8,27 @@ import no.nav.fo.veilarbregistrering.bruker.Bruker;
 import no.nav.fo.veilarbregistrering.bruker.Foedselsnummer;
 import no.nav.sbl.sql.SqlUtils;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.stream.Collectors;
 
+import static java.util.stream.Collectors.toList;
 import static no.nav.fo.veilarbregistrering.db.arbeidssoker.ArbeidssokerperioderMapper.map;
 
 public class ArbeidssokerRepositoryImpl implements ArbeidssokerRepository {
 
     private final JdbcTemplate jdbcTemplate;
+    private final NamedParameterJdbcTemplate namedParameterJdbcTemplate;
 
     public ArbeidssokerRepositoryImpl(JdbcTemplate jdbcTemplate) {
         this.jdbcTemplate = jdbcTemplate;
+        this.namedParameterJdbcTemplate = new NamedParameterJdbcTemplate(jdbcTemplate);
     }
 
     @Override
@@ -53,29 +60,46 @@ public class ArbeidssokerRepositoryImpl implements ArbeidssokerRepository {
     }
 
     @Override
+    public Arbeidssokerperioder finnFormidlingsgrupper(Bruker bruker) {
+        Arbeidssokerperioder arbeidssokerperioder = finnFormidlingsgrupper(bruker.getGjeldendeFoedselsnummer());
+
+        List<Arbeidssokerperioder> historiskeArbeidssokerperioder = bruker.getHistoriskeFoedselsnummer().stream()
+                .map(this::finnFormidlingsgrupper)
+                .collect(toList());
+
+        return arbeidssokerperioder.slaaSammenMed(historiskeArbeidssokerperioder);
+    }
+
+    @Override
     public Arbeidssokerperioder finnFormidlingsgrupper(Foedselsnummer foedselsnummer) {
         String sql = "SELECT * FROM FORMIDLINGSGRUPPE WHERE FOEDSELSNUMMER = ?";
 
         List<ArbeidssokerperiodeRaaData> arbeidssokerperioder = jdbcTemplate.query(
                 sql,
-                new Object[]{foedselsnummer.stringValue()},
-                (rs, row) -> new ArbeidssokerperiodeRaaData(
-                        rs.getString("FORMIDLINGSGRUPPE"),
-                        rs.getTimestamp("FORMIDLINGSGRUPPE_ENDRET")
-                )
+                new Object[]{foedselsnummer.stringValue()}, new ArbeidssokerperiodeRaaDataRowMapper()
         );
 
         return map(arbeidssokerperioder);
     }
 
     @Override
-    public Arbeidssokerperioder finnFormidlingsgrupper(Bruker bruker) {
-        Arbeidssokerperioder arbeidssokerperioder = finnFormidlingsgrupper(bruker.getGjeldendeFoedselsnummer());
+    public Arbeidssokerperioder finnFormidlingsgrupper(List<Foedselsnummer> foedselsnummer) {
+        String sql = "SELECT * FROM FORMIDLINGSGRUPPE WHERE FOEDSELSNUMMER IN (:foedselsnummer)";
 
-        List<Arbeidssokerperioder> historiskeArbeidssokerperioder = bruker.getHistoriskeFoedselsnummer().stream()
-                .map(this::finnFormidlingsgrupper)
-                .collect(Collectors.toList());
+        MapSqlParameterSource parameters = new MapSqlParameterSource();
+        parameters.addValue("foedselsnummer", foedselsnummer.stream().map(f -> f.stringValue()).collect(toList()));
 
-        return arbeidssokerperioder.slaaSammenMed(historiskeArbeidssokerperioder);
+        List<ArbeidssokerperiodeRaaData> raaData = namedParameterJdbcTemplate.query(sql, parameters, new ArbeidssokerperiodeRaaDataRowMapper());
+        return map(raaData);
+    }
+
+    private class ArbeidssokerperiodeRaaDataRowMapper implements RowMapper<ArbeidssokerperiodeRaaData> {
+
+        @Override
+        public ArbeidssokerperiodeRaaData mapRow(ResultSet rs, int i) throws SQLException {
+            return new ArbeidssokerperiodeRaaData(
+                    rs.getString("FORMIDLINGSGRUPPE"),
+                    rs.getTimestamp("FORMIDLINGSGRUPPE_ENDRET"));
+        }
     }
 }

--- a/src/test/java/no/nav/fo/veilarbregistrering/arbeidssoker/ArbeidssokerServiceTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/arbeidssoker/ArbeidssokerServiceTest.java
@@ -196,6 +196,11 @@ public class ArbeidssokerServiceTest {
 
             return map.get(bruker);
         }
+
+        @Override
+        public Arbeidssokerperioder finnFormidlingsgrupper(List<Foedselsnummer> foedselsnummer) {
+            return null;
+        }
     }
 
     private static class StubFormidlingsgruppeGateway implements FormidlingsgruppeGateway {

--- a/src/test/java/no/nav/fo/veilarbregistrering/db/arbeidssoker/ArbeidssokerRepositoryDbIntegrationTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/db/arbeidssoker/ArbeidssokerRepositoryDbIntegrationTest.java
@@ -1,12 +1,8 @@
 package no.nav.fo.veilarbregistrering.db.arbeidssoker;
 
-import no.nav.fo.veilarbregistrering.arbeidssoker.ArbeidssokerRepository;
-import no.nav.fo.veilarbregistrering.arbeidssoker.Arbeidssokerperioder;
-import no.nav.fo.veilarbregistrering.arbeidssoker.EndretFormidlingsgruppeCommand;
-import no.nav.fo.veilarbregistrering.arbeidssoker.Operation;
+import no.nav.fo.veilarbregistrering.arbeidssoker.*;
 import no.nav.fo.veilarbregistrering.bruker.Foedselsnummer;
 import no.nav.fo.veilarbregistrering.db.DbIntegrasjonsTest;
-import no.nav.fo.veilarbregistrering.arbeidssoker.Formidlingsgruppe;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -15,12 +11,15 @@ import javax.inject.Inject;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
+import static java.util.Arrays.asList;
 import static no.nav.veilarbregistrering.db.DatabaseTestContext.setupInMemoryDatabaseContext;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ArbeidssokerRepositoryDbIntegrationTest extends DbIntegrasjonsTest {
 
     private static final Foedselsnummer FOEDSELSNUMMER = Foedselsnummer.of("01234567890");
+    private static final Foedselsnummer FOEDSELSNUMMER_2 = Foedselsnummer.of("01234567892");
+    private static final Foedselsnummer FOEDSELSNUMMER_3 = Foedselsnummer.of("01234567895");
 
     @Inject
     private JdbcTemplate jdbcTemplate;
@@ -35,10 +34,37 @@ public class ArbeidssokerRepositoryDbIntegrationTest extends DbIntegrasjonsTest 
 
     @Test
     public void skal_lagre_formidlingsgruppeEvent() {
-        EndretFormidlingsgruppeCommand command = new EndretFormidlingsgruppeCommand() {
+        EndretFormidlingsgruppeCommand command = endretFormdlingsgruppe(FOEDSELSNUMMER, LocalDateTime.now().minusSeconds(20));
+
+        long id = arbeidssokerRepository.lagre(command);
+        assertThat(id).isNotNull();
+
+        Arbeidssokerperioder arbeidssokerperiodes = arbeidssokerRepository.finnFormidlingsgrupper(FOEDSELSNUMMER);
+        assertThat(arbeidssokerperiodes.asList()).hasSize(1);
+    }
+
+    @Test
+    public void skal_hente_alle_periodene_for_en_persons_identer() {
+        EndretFormidlingsgruppeCommand command = endretFormdlingsgruppe(FOEDSELSNUMMER, LocalDateTime.now().minusDays(10));
+        arbeidssokerRepository.lagre(command);
+
+        EndretFormidlingsgruppeCommand command2 = endretFormdlingsgruppe(FOEDSELSNUMMER_2, LocalDateTime.now().minusDays(50));
+        arbeidssokerRepository.lagre(command2);
+
+        EndretFormidlingsgruppeCommand command3 = endretFormdlingsgruppe(FOEDSELSNUMMER_3, LocalDateTime.now().minusSeconds(20));
+        arbeidssokerRepository.lagre(command3);
+
+        Arbeidssokerperioder arbeidssokerperiodes = arbeidssokerRepository.finnFormidlingsgrupper(
+                asList(FOEDSELSNUMMER, FOEDSELSNUMMER_2, FOEDSELSNUMMER_3));
+        assertThat(arbeidssokerperiodes.asList()).hasSize(3);
+    }
+
+
+    private EndretFormidlingsgruppeCommand endretFormdlingsgruppe(Foedselsnummer foedselsnummer, LocalDateTime tidspunkt) {
+        return new EndretFormidlingsgruppeCommand() {
             @Override
             public Optional<Foedselsnummer> getFoedselsnummer() {
-                return Optional.of(FOEDSELSNUMMER);
+                return Optional.of(foedselsnummer);
             }
 
             @Override
@@ -58,7 +84,7 @@ public class ArbeidssokerRepositoryDbIntegrationTest extends DbIntegrasjonsTest 
 
             @Override
             public LocalDateTime getFormidlingsgruppeEndret() {
-                return LocalDateTime.now().minusSeconds(20);
+                return tidspunkt;
             }
 
             @Override
@@ -71,12 +97,6 @@ public class ArbeidssokerRepositoryDbIntegrationTest extends DbIntegrasjonsTest 
                 return Optional.empty();
             }
         };
-
-        long id = arbeidssokerRepository.lagre(command);
-        assertThat(id).isNotNull();
-
-        Arbeidssokerperioder arbeidssokerperiodes = arbeidssokerRepository.finnFormidlingsgrupper(FOEDSELSNUMMER);
-        assertThat(arbeidssokerperiodes.asList()).hasSize(1);
     }
 
 }


### PR DESCRIPTION
Legger til funksjonalitet for å hente arbeidssokerperioder / formidlingsgrupper for flere fnr i samme spørring.
I første omgang er ikke denne tatt i bruk, men vil erstatte tilsvarende funksjonalitet i neste iterasjon.