### PR TITLE
Spør på alle identer til en person mot DB

### DIFF
--- a/src/main/java/no/nav/fo/veilarbregistrering/arbeidssoker/resources/ArbeidssokerResource.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/arbeidssoker/resources/ArbeidssokerResource.java
@@ -62,7 +62,7 @@ public class ArbeidssokerResource implements ArbeidssokerApi {
         pepClient.sjekkLesetilgangTilBruker(BrukerAdapter.map(bruker));
 
         Arbeidssokerperioder arbeidssokerperiodes = arbeidssokerService.hentArbeidssokerperioder(
-                bruker.getGjeldendeFoedselsnummer(), Periode.gyldigPeriode(fraOgMed, tilOgMed));
+                bruker, Periode.gyldigPeriode(fraOgMed, tilOgMed));
 
         LOG.info(String.format("Ferdig med henting av arbeidssokerperioder - fant %s perioder", arbeidssokerperiodes.asList().size()));
 

--- a/src/main/java/no/nav/fo/veilarbregistrering/arbeidssoker/resources/InternalArbeidssokerServlet.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/arbeidssoker/resources/InternalArbeidssokerServlet.java
@@ -42,7 +42,7 @@ public class InternalArbeidssokerServlet extends HttpServlet {
                 .orElseThrow(() -> new BadRequestException("Fnr eller aktørid må spesifiseres"));
 
         Arbeidssokerperioder arbeidssokerperiodes = arbeidssokerService.hentArbeidssokerperioder(
-                bruker.getGjeldendeFoedselsnummer(), Periode.gyldigPeriode(fraOgMed, tilOgMed));
+                bruker, Periode.gyldigPeriode(fraOgMed, tilOgMed));
 
         ArbeidssokerperioderDto dto = map(arbeidssokerperiodes.eldsteFoerst());
 

--- a/src/main/java/no/nav/fo/veilarbregistrering/db/arbeidssoker/ArbeidssokerRepositoryImpl.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/db/arbeidssoker/ArbeidssokerRepositoryImpl.java
@@ -88,6 +88,8 @@ public class ArbeidssokerRepositoryImpl implements ArbeidssokerRepository {
         public ArbeidssokerperiodeRaaData mapRow(ResultSet rs, int i) throws SQLException {
             return new ArbeidssokerperiodeRaaData(
                     rs.getString("FORMIDLINGSGRUPPE"),
+                    rs.getInt("PERSON_ID"),
+                    rs.getString("PERSON_ID_STATUS"),
                     rs.getTimestamp("FORMIDLINGSGRUPPE_ENDRET"));
         }
     }

--- a/src/main/java/no/nav/fo/veilarbregistrering/db/arbeidssoker/ArbeidssokerperiodeRaaData.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/db/arbeidssoker/ArbeidssokerperiodeRaaData.java
@@ -6,10 +6,14 @@ import java.util.Comparator;
 class ArbeidssokerperiodeRaaData {
 
     private final String formidlingsgruppe;
+    private final int personId;
+    private final String personIdStatus;
     private final Timestamp formidlingsgruppeEndret;
 
-    ArbeidssokerperiodeRaaData(String formidlingsgruppe, Timestamp formidlingsgruppeEndret) {
+    public ArbeidssokerperiodeRaaData(String formidlingsgruppe, int personId, String personIdStatus, Timestamp formidlingsgruppeEndret) {
         this.formidlingsgruppe = formidlingsgruppe;
+        this.personId = personId;
+        this.personIdStatus = personIdStatus;
         this.formidlingsgruppeEndret = formidlingsgruppeEndret;
     }
 
@@ -19,6 +23,14 @@ class ArbeidssokerperiodeRaaData {
 
     String getFormidlingsgruppe() {
         return this.formidlingsgruppe;
+    }
+
+    int getPersonId() {
+        return personId;
+    }
+
+    String getPersonIdStatus() {
+        return personIdStatus;
     }
 
     static class NyesteFoerst implements Comparator<ArbeidssokerperiodeRaaData> {

--- a/src/test/java/no/nav/fo/veilarbregistrering/arbeidssoker/ArbeidssokerServiceTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/arbeidssoker/ArbeidssokerServiceTest.java
@@ -30,6 +30,12 @@ public class ArbeidssokerServiceTest {
             asList(FOEDSELSNUMMER_2, FOEDSELSNUMMER_1)
     );
 
+    private static final Bruker BRUKER_3 = Bruker.of(
+            FOEDSELSNUMMER_3,
+            AktorId.of("100002345678"),
+            Collections.emptyList()
+    );
+
     private ArbeidssokerService arbeidssokerService;
     private UnleashService unleashService;
 
@@ -50,7 +56,7 @@ public class ArbeidssokerServiceTest {
                 LocalDate.of(2020, 1, 2),
                 LocalDate.of(2020, 5, 1));
 
-        Arbeidssokerperioder arbeidssokerperiodes = arbeidssokerService.hentArbeidssokerperioder(FOEDSELSNUMMER_3, forespurtPeriode);
+        Arbeidssokerperioder arbeidssokerperiodes = arbeidssokerService.hentArbeidssokerperioder(BRUKER_3, forespurtPeriode);
 
         assertThat(arbeidssokerperiodes.eldsteFoerst()).containsExactly(
                 StubArbeidssokerRepository.ARBEIDSSOKERPERIODE_1,
@@ -65,7 +71,7 @@ public class ArbeidssokerServiceTest {
                 LocalDate.of(2019, 12, 1),
                 LocalDate.of(2020, 5, 1));
 
-        Arbeidssokerperioder arbeidssokerperiodes = arbeidssokerService.hentArbeidssokerperioder(FOEDSELSNUMMER_3, forespurtPeriode);
+        Arbeidssokerperioder arbeidssokerperiodes = arbeidssokerService.hentArbeidssokerperioder(BRUKER_3, forespurtPeriode);
 
         assertThat(arbeidssokerperiodes.eldsteFoerst()).containsExactly(
                 StubFormidlingsgruppeGateway.ARBEIDSSOKERPERIODE_0,
@@ -82,7 +88,7 @@ public class ArbeidssokerServiceTest {
                 LocalDate.of(2019, 11, 30)
         );
 
-        Arbeidssokerperioder arbeidssokerperiodes = arbeidssokerService.hentArbeidssokerperioder(FOEDSELSNUMMER_3, forespurtPeriode);
+        Arbeidssokerperioder arbeidssokerperiodes = arbeidssokerService.hentArbeidssokerperioder(BRUKER_3, forespurtPeriode);
 
         assertThat(arbeidssokerperiodes.asList()).isEmpty();
     }
@@ -94,7 +100,7 @@ public class ArbeidssokerServiceTest {
                 LocalDate.of(2019, 11, 30)
         );
 
-        Arbeidssokerperioder arbeidssokerperiodes = arbeidssokerService.hentArbeidssokerperioder(BRUKER_1, forespurtPeriode);
+        Arbeidssokerperioder arbeidssokerperiodes = arbeidssokerService.hentArbeidssokerperioderLocalCache(BRUKER_1, forespurtPeriode);
 
         assertThat(arbeidssokerperiodes.asList()).isEmpty();
     }

--- a/src/test/java/no/nav/fo/veilarbregistrering/db/arbeidssoker/ArbeidssokerperiodeMapperTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/db/arbeidssoker/ArbeidssokerperiodeMapperTest.java
@@ -17,9 +17,9 @@ public class ArbeidssokerperiodeMapperTest {
     @Test
     public void kun_siste_periode_kan_ha_blank_tildato() {
         List<ArbeidssokerperiodeRaaData> arbeidssokerperiodeRaaData = new ArrayList<>();
-        arbeidssokerperiodeRaaData.add(new ArbeidssokerperiodeRaaData("ARBS", Timestamp.valueOf(LocalDate.of(2020, 3, 19).atStartOfDay())));
-        arbeidssokerperiodeRaaData.add(new ArbeidssokerperiodeRaaData("ISERV", Timestamp.valueOf(LocalDate.of(2020, 4, 21).atStartOfDay())));
-        arbeidssokerperiodeRaaData.add(new ArbeidssokerperiodeRaaData("ISERV", Timestamp.valueOf(LocalDate.of(2020, 5, 30).atStartOfDay())));
+        arbeidssokerperiodeRaaData.add(new ArbeidssokerperiodeRaaData("ARBS", 4397692, "AKTIV", Timestamp.valueOf(LocalDate.of(2020, 3, 19).atStartOfDay())));
+        arbeidssokerperiodeRaaData.add(new ArbeidssokerperiodeRaaData("ISERV", 4397692, "AKTIV", Timestamp.valueOf(LocalDate.of(2020, 4, 21).atStartOfDay())));
+        arbeidssokerperiodeRaaData.add(new ArbeidssokerperiodeRaaData("ISERV", 4397692, "AKTIV", Timestamp.valueOf(LocalDate.of(2020, 5, 30).atStartOfDay())));
 
         Arbeidssokerperioder arbeidssokerperioder = map(arbeidssokerperiodeRaaData);
 
@@ -31,8 +31,8 @@ public class ArbeidssokerperiodeMapperTest {
     @Test
     public void foerste_periode_skal_ha_tildato_lik_dagen_foer_andre_periode_sin_fradato() {
         List<ArbeidssokerperiodeRaaData> arbeidssokerperiodeRaaData = new ArrayList<>();
-        arbeidssokerperiodeRaaData.add(new ArbeidssokerperiodeRaaData("ARBS", Timestamp.valueOf(LocalDate.of(2020, 3, 19).atStartOfDay())));
-        arbeidssokerperiodeRaaData.add(new ArbeidssokerperiodeRaaData("ISERV", Timestamp.valueOf(LocalDate.of(2020, 4, 21).atStartOfDay())));
+        arbeidssokerperiodeRaaData.add(new ArbeidssokerperiodeRaaData("ARBS", 4397692, "AKTIV", Timestamp.valueOf(LocalDate.of(2020, 3, 19).atStartOfDay())));
+        arbeidssokerperiodeRaaData.add(new ArbeidssokerperiodeRaaData("ISERV", 4397692, "AKTIV", Timestamp.valueOf(LocalDate.of(2020, 4, 21).atStartOfDay())));
 
         Arbeidssokerperioder arbeidssokerperioder = map(arbeidssokerperiodeRaaData);
 
@@ -44,9 +44,9 @@ public class ArbeidssokerperiodeMapperTest {
     @Test
     public void skal_populere_tildato_korrekt_selv_om_listen_kommer_usortert() {
         List<ArbeidssokerperiodeRaaData> arbeidssokerperiodeRaaData = new ArrayList<>();
-        arbeidssokerperiodeRaaData.add(new ArbeidssokerperiodeRaaData("ARBS", Timestamp.valueOf(LocalDate.of(2020, 5, 30).atStartOfDay())));
-        arbeidssokerperiodeRaaData.add(new ArbeidssokerperiodeRaaData("ARBS", Timestamp.valueOf(LocalDate.of(2020, 3, 19).atStartOfDay())));
-        arbeidssokerperiodeRaaData.add(new ArbeidssokerperiodeRaaData("ISERV", Timestamp.valueOf(LocalDate.of(2020, 4, 21).atStartOfDay())));
+        arbeidssokerperiodeRaaData.add(new ArbeidssokerperiodeRaaData("ARBS", 4397692, "AKTIV", Timestamp.valueOf(LocalDate.of(2020, 5, 30).atStartOfDay())));
+        arbeidssokerperiodeRaaData.add(new ArbeidssokerperiodeRaaData("ARBS", 4397692, "AKTIV", Timestamp.valueOf(LocalDate.of(2020, 3, 19).atStartOfDay())));
+        arbeidssokerperiodeRaaData.add(new ArbeidssokerperiodeRaaData("ISERV", 4397692, "AKTIV", Timestamp.valueOf(LocalDate.of(2020, 4, 21).atStartOfDay())));
 
         Arbeidssokerperioder arbeidssokerperioder = map(arbeidssokerperiodeRaaData);
 
@@ -77,9 +77,9 @@ public class ArbeidssokerperiodeMapperTest {
     public void skal_kun_beholde_siste_formidlingsgruppeendring_fra_samme_dag() {
         LocalDateTime now = LocalDateTime.now();
         List<ArbeidssokerperiodeRaaData> arbeidssokerperiodeRaaData = new ArrayList<>();
-        arbeidssokerperiodeRaaData.add(new ArbeidssokerperiodeRaaData("ISERV", Timestamp.valueOf(now)));
-        arbeidssokerperiodeRaaData.add(new ArbeidssokerperiodeRaaData("ARBS", Timestamp.valueOf(now.plusSeconds(2))));
-        arbeidssokerperiodeRaaData.add(new ArbeidssokerperiodeRaaData("IARBS", Timestamp.valueOf(now.plusSeconds(4))));
+        arbeidssokerperiodeRaaData.add(new ArbeidssokerperiodeRaaData("ISERV", 4397692, "AKTIV", Timestamp.valueOf(now)));
+        arbeidssokerperiodeRaaData.add(new ArbeidssokerperiodeRaaData("ARBS", 4397692, "AKTIV", Timestamp.valueOf(now.plusSeconds(2))));
+        arbeidssokerperiodeRaaData.add(new ArbeidssokerperiodeRaaData("IARBS", 4397692, "AKTIV", Timestamp.valueOf(now.plusSeconds(4))));
 
         Arbeidssokerperioder arbeidssokerperioder = map(arbeidssokerperiodeRaaData);
 
@@ -92,16 +92,16 @@ public class ArbeidssokerperiodeMapperTest {
     public void skal_kun_beholde_siste_formidlingsgruppeendring_fra_samme_dag_flere_dager() {
         LocalDateTime now = LocalDateTime.now();
         List<ArbeidssokerperiodeRaaData> arbeidssokerperiodeRaaData = new ArrayList<>();
-        arbeidssokerperiodeRaaData.add(new ArbeidssokerperiodeRaaData("ISERV", Timestamp.valueOf(now)));
-        arbeidssokerperiodeRaaData.add(new ArbeidssokerperiodeRaaData("ARBS", Timestamp.valueOf(now.plusSeconds(2))));
-        arbeidssokerperiodeRaaData.add(new ArbeidssokerperiodeRaaData("IARBS", Timestamp.valueOf(now.plusSeconds(4))));
+        arbeidssokerperiodeRaaData.add(new ArbeidssokerperiodeRaaData("ISERV", 4397692, "AKTIV", Timestamp.valueOf(now)));
+        arbeidssokerperiodeRaaData.add(new ArbeidssokerperiodeRaaData("ARBS", 4397692, "AKTIV", Timestamp.valueOf(now.plusSeconds(2))));
+        arbeidssokerperiodeRaaData.add(new ArbeidssokerperiodeRaaData("IARBS", 4397692, "AKTIV", Timestamp.valueOf(now.plusSeconds(4))));
 
-        arbeidssokerperiodeRaaData.add(new ArbeidssokerperiodeRaaData("ISERV", Timestamp.valueOf(now.plusDays(7))));
-        arbeidssokerperiodeRaaData.add(new ArbeidssokerperiodeRaaData("ARBS", Timestamp.valueOf(now.plusDays(7).plusSeconds(3))));
+        arbeidssokerperiodeRaaData.add(new ArbeidssokerperiodeRaaData("ISERV", 4397692, "AKTIV", Timestamp.valueOf(now.plusDays(7))));
+        arbeidssokerperiodeRaaData.add(new ArbeidssokerperiodeRaaData("ARBS", 4397692, "AKTIV", Timestamp.valueOf(now.plusDays(7).plusSeconds(3))));
 
-        arbeidssokerperiodeRaaData.add(new ArbeidssokerperiodeRaaData("ISERV", Timestamp.valueOf(now.plusDays(50))));
-        arbeidssokerperiodeRaaData.add(new ArbeidssokerperiodeRaaData("ARBS", Timestamp.valueOf(now.plusDays(50).plusSeconds(2))));
-        arbeidssokerperiodeRaaData.add(new ArbeidssokerperiodeRaaData("ISERV", Timestamp.valueOf(now.plusDays(50).plusSeconds(5))));
+        arbeidssokerperiodeRaaData.add(new ArbeidssokerperiodeRaaData("ISERV", 4397692, "AKTIV", Timestamp.valueOf(now.plusDays(50))));
+        arbeidssokerperiodeRaaData.add(new ArbeidssokerperiodeRaaData("ARBS", 4397692, "AKTIV", Timestamp.valueOf(now.plusDays(50).plusSeconds(2))));
+        arbeidssokerperiodeRaaData.add(new ArbeidssokerperiodeRaaData("ISERV", 4397692, "AKTIV", Timestamp.valueOf(now.plusDays(50).plusSeconds(5))));
 
         Arbeidssokerperioder arbeidssokerperioder = map(arbeidssokerperiodeRaaData);
 
@@ -112,5 +112,20 @@ public class ArbeidssokerperiodeMapperTest {
         assertThat(arbeidssokerperioder.asList().get(0).getPeriode().getFra()).isEqualTo(now.toLocalDate());
         assertThat(arbeidssokerperioder.asList().get(1).getPeriode().getFra()).isEqualTo(now.plusDays(7).toLocalDate());
         assertThat(arbeidssokerperioder.asList().get(2).getPeriode().getFra()).isEqualTo(now.plusDays(50).toLocalDate());
+    }
+
+    @Test
+    public void skal_flette_to_personer() {
+
+        List<ArbeidssokerperiodeRaaData> arbeidssokerperiodeRaaData = new ArrayList<>();
+        arbeidssokerperiodeRaaData.add(new ArbeidssokerperiodeRaaData("ISERV", 4397692, "AKTIV", Timestamp.valueOf(LocalDateTime.of(2019, 3, 6, 10, 10))));
+        arbeidssokerperiodeRaaData.add(new ArbeidssokerperiodeRaaData("ISERV", 4451554, "DUPLIKAT_TIL_BEH", Timestamp.valueOf(LocalDateTime.of(2019, 9, 11, 10, 10))));
+        arbeidssokerperiodeRaaData.add(new ArbeidssokerperiodeRaaData("ARBS", 4451554, "DUPLIKAT_TIL_BEH", Timestamp.valueOf(LocalDateTime.of(2019, 9, 11, 10, 10))));
+        arbeidssokerperiodeRaaData.add(new ArbeidssokerperiodeRaaData("ARBS", 4397692, "AKTIV", Timestamp.valueOf(LocalDateTime.of(2019, 12, 9, 10, 10))));
+        arbeidssokerperiodeRaaData.add(new ArbeidssokerperiodeRaaData("ISERV", 4451554, "DUPLIKAT_TIL_BEH", Timestamp.valueOf(LocalDateTime.of(2019, 12, 18, 10, 10))));
+
+        Arbeidssokerperioder arbeidssokerperioder = map(arbeidssokerperiodeRaaData);
+
+
     }
 }


### PR DESCRIPTION
Ifm. arbeidssokerperioder/formidlingsgruppe, spør vi nå mot databasen på alle identer en person har hatt, også historiske.
Men vi benytter fremdeles svaret fra ORDS-tjenesten - lokale data brukes kun til sammenligning.