### PR TITLE
Fjerner toggle for pdl-integrasjon

### DIFF
--- a/src/main/java/no/nav/fo/veilarbregistrering/config/ServiceBeansConfig.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/config/ServiceBeansConfig.java
@@ -195,9 +195,8 @@ public class ServiceBeansConfig {
     ArbeidssokerResource arbeidssokerResource(
             ArbeidssokerService arbeidssokerService,
             UserService userService,
-            VeilarbAbacPepClient pepClient,
-            UnleashService unleashService) {
-        return new ArbeidssokerResource(arbeidssokerService, userService, pepClient, unleashService);
+            VeilarbAbacPepClient pepClient) {
+        return new ArbeidssokerResource(arbeidssokerService, userService, pepClient);
     }
 
     @Bean


### PR DESCRIPTION
Vi har nå testet ut integrasjonen mot PDL ifm. arbeidssøker, og ettersom den funker, fjerner vi muligheten for å bruke aktørregisteret her.