### PR TITLE
Sletter tekniske ISERV-endringer

### DIFF
--- a/src/main/java/no/nav/fo/veilarbregistrering/db/arbeidssoker/ArbeidssokerperioderMapper.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/db/arbeidssoker/ArbeidssokerperioderMapper.java
@@ -6,9 +6,7 @@ import no.nav.fo.veilarbregistrering.arbeidssoker.Formidlingsgruppe;
 import no.nav.fo.veilarbregistrering.bruker.Periode;
 
 import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 import java.util.function.Function;
 
 import static java.util.stream.Collectors.toList;
@@ -24,6 +22,7 @@ class ArbeidssokerperioderMapper {
                                 .sorted(nyesteFoerst())
                                 .collect(toList()))
                         .map(beholdKunEndringerForAktiveIdenter)
+                        .map(slettTekniskeISERVEndringer)
                         .map(beholdKunSisteEndringPerDagIListen)
                         .map(populerTilDato)
                         .get()
@@ -36,6 +35,26 @@ class ArbeidssokerperioderMapper {
             (formidlingsgruppeendringer) -> formidlingsgruppeendringer.stream()
                     .filter(Formidlingsgruppeendring::erAktiv)
                     .collect(toList());
+
+    private static Function<List<Formidlingsgruppeendring>, List<Formidlingsgruppeendring>> slettTekniskeISERVEndringer =
+            (formidlingsgruppeendringer -> {
+
+                int j = 0;
+
+                while (j < formidlingsgruppeendringer.size() - 1) {
+                    if (formidlingsgruppeendringer.get(j).getFormidlingsgruppeEndret().equals(formidlingsgruppeendringer.get(j+1).getFormidlingsgruppeEndret())) {
+                        if (formidlingsgruppeendringer.get(j).erISERV() && formidlingsgruppeendringer.get(j+1).erARBS()) {
+                            formidlingsgruppeendringer.remove(j);
+                        } else if (formidlingsgruppeendringer.get(j).erARBS() && formidlingsgruppeendringer.get(j+1).erISERV()) {
+                            formidlingsgruppeendringer.remove(j+1);
+                        }
+                    } else {
+                        j++;
+                    }
+                }
+
+                return formidlingsgruppeendringer;
+            });
 
     private static Function<List<Formidlingsgruppeendring>, List<Arbeidssokerperiode>> beholdKunSisteEndringPerDagIListen =
             (formidlingsgruppeendringer) -> {

--- a/src/main/java/no/nav/fo/veilarbregistrering/db/arbeidssoker/Formidlingsgruppeendring.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/db/arbeidssoker/Formidlingsgruppeendring.java
@@ -26,6 +26,14 @@ class Formidlingsgruppeendring {
         return this.formidlingsgruppe;
     }
 
+    boolean erARBS() {
+        return Objects.equals(formidlingsgruppe, "ARBS");
+    }
+
+    boolean erISERV() {
+        return Objects.equals(formidlingsgruppe, "ISERV");
+    }
+
     int getPersonId() {
         return personId;
     }

--- a/src/test/java/no/nav/fo/veilarbregistrering/db/arbeidssoker/ArbeidssokerperiodeMapperTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/db/arbeidssoker/ArbeidssokerperiodeMapperTest.java
@@ -137,4 +137,46 @@ public class ArbeidssokerperiodeMapperTest {
                 arbsAktiv
         );
     }
+
+    @Test
+    public void skal_filtrere_bort_tekniske_ISERVendringer() {
+        List<Formidlingsgruppeendring> formidlingsgruppeendringer = new ArrayList<>();
+        formidlingsgruppeendringer.add(new Formidlingsgruppeendring("ARBS", 4685858, "AKTIV", Timestamp.valueOf(LocalDateTime.of(2020, 8, 14, 22, 7, 15))));
+        formidlingsgruppeendringer.add(new Formidlingsgruppeendring("ISERV", 4685858, "AKTIV", Timestamp.valueOf(LocalDateTime.of(2020, 8, 14, 22, 7, 15))));
+        formidlingsgruppeendringer.add(new Formidlingsgruppeendring("ISERV", 4685858, "AKTIV", Timestamp.valueOf(LocalDateTime.of(2020, 9, 9, 9, 9, 9))));
+        formidlingsgruppeendringer.add(new Formidlingsgruppeendring("ARBS", 4685858, "AKTIV", Timestamp.valueOf(LocalDateTime.of(2020, 9, 9, 9, 9, 9))));
+
+        Arbeidssokerperioder arbeidssokerperioder = map(formidlingsgruppeendringer);
+
+        Arbeidssokerperiode arbs1 = Arbeidssokerperiode.of(Formidlingsgruppe.of("ARBS"), Periode.of(LocalDate.of(2020, 8, 14), LocalDate.of(2020, 9, 8)));
+        Arbeidssokerperiode arbs2 = Arbeidssokerperiode.of(Formidlingsgruppe.of("ARBS"), Periode.of(LocalDate.of(2020, 9, 9), null));
+
+        assertThat(arbeidssokerperioder.asList()).containsExactly(
+                arbs1,
+                arbs2
+        );
+
+        formidlingsgruppeendringer = new ArrayList<>();
+        formidlingsgruppeendringer.add(new Formidlingsgruppeendring("ARBS", 4685858, "AKTIV", Timestamp.valueOf(LocalDateTime.of(2020, 8, 14, 22, 7, 15))));
+        formidlingsgruppeendringer.add(new Formidlingsgruppeendring("ISERV", 4685858, "AKTIV", Timestamp.valueOf(LocalDateTime.of(2020, 8, 14, 22, 7, 15))));
+
+        arbeidssokerperioder = map(formidlingsgruppeendringer);
+
+        arbs1 = Arbeidssokerperiode.of(Formidlingsgruppe.of("ARBS"), Periode.of(LocalDate.of(2020, 8, 14), null));
+
+        assertThat(arbeidssokerperioder.asList()).containsExactly(
+                arbs1
+        );
+
+        formidlingsgruppeendringer = new ArrayList<>();
+        formidlingsgruppeendringer.add(new Formidlingsgruppeendring("ARBS", 4685858, "AKTIV", Timestamp.valueOf(LocalDateTime.of(2020, 8, 14, 22, 7, 15))));
+
+        arbeidssokerperioder = map(formidlingsgruppeendringer);
+
+        arbs1 = Arbeidssokerperiode.of(Formidlingsgruppe.of("ARBS"), Periode.of(LocalDate.of(2020, 8, 14), null));
+
+        assertThat(arbeidssokerperioder.asList()).containsExactly(
+                arbs1
+        );
+    }
 }


### PR DESCRIPTION
Naar en saksbehandler oppretter en bruker i Arena og setter status til ARBS skjer foelgende i praksis:
1. Bruker faar status ISERV
2. Bruker faar status ARBS rett etterpaa (samme sekund)
Denne ekstra tekniske ISERV-statusen skaper problemer faar resten av logikken vaar. Derfor fjerner vi den.