### PR TITLE
Toggle for bruk av Norg2 via Rest

### DIFF
--- a/src/main/java/no/nav/fo/veilarbregistrering/config/ServiceBeansConfig.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/config/ServiceBeansConfig.java
@@ -163,11 +163,13 @@ public class ServiceBeansConfig {
     ManuellRegistreringService manuellRegistreringService(
             ManuellRegistreringRepository manuellRegistreringRepository,
             HentEnheterGateway hentEnheterGateway,
-            Norg2Gateway norg2Gateway) {
+            Norg2Gateway norg2Gateway,
+            UnleashService unleashService) {
         return new ManuellRegistreringService(
                 manuellRegistreringRepository,
                 hentEnheterGateway,
-                norg2Gateway);
+                norg2Gateway,
+                unleashService);
     }
 
     @Bean

--- a/src/main/java/no/nav/fo/veilarbregistrering/registrering/manuell/ManuellRegistreringService.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/registrering/manuell/ManuellRegistreringService.java
@@ -5,6 +5,7 @@ import no.nav.fo.veilarbregistrering.orgenhet.HentEnheterGateway;
 import no.nav.fo.veilarbregistrering.orgenhet.NavEnhet;
 import no.nav.fo.veilarbregistrering.orgenhet.Norg2Gateway;
 import no.nav.fo.veilarbregistrering.registrering.BrukerRegistreringType;
+import no.nav.sbl.featuretoggle.unleash.UnleashService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -18,14 +19,17 @@ public class ManuellRegistreringService {
     private final ManuellRegistreringRepository manuellRegistreringRepository;
     private final HentEnheterGateway hentEnheterGateway;
     private final Norg2Gateway norg2Gateway;
+    private final UnleashService unleashService;
 
     public ManuellRegistreringService(
             ManuellRegistreringRepository manuellRegistreringRepository,
             HentEnheterGateway hentEnheterGateway,
-            Norg2Gateway norg2Gateway) {
+            Norg2Gateway norg2Gateway,
+            UnleashService unleashService) {
         this.manuellRegistreringRepository = manuellRegistreringRepository;
         this.hentEnheterGateway = hentEnheterGateway;
         this.norg2Gateway = norg2Gateway;
+        this.unleashService = unleashService;
     }
 
     public void lagreManuellRegistrering(
@@ -54,9 +58,22 @@ public class ManuellRegistreringService {
 
         Optional<NavEnhet> enhet = finnEnhet(Enhetnr.of(registrering.getVeilederEnhetId()));
 
+        if (norg2ViaRest()) {
+            try {
+                Optional<NavEnhet> navEnhet = finnEnhetViaRest(Enhetnr.of(registrering.getVeilederEnhetId()));
+                LOG.info(String.format("Lik nav-enhet: %s, SOAP: %s, Rest: %s", enhet.equals(navEnhet) ? "Ja" : "Nei", enhet, navEnhet));
+            } catch (RuntimeException e) {
+                LOG.error("Sammenligning av NavEnhet feilet. Har ingen betydning", e);
+            }
+        }
+
         return new Veileder()
                 .setEnhet(enhet.orElse(null))
                 .setIdent(registrering.getVeilederIdent());
+    }
+
+    private boolean norg2ViaRest() {
+        return unleashService.isEnabled("veilarbregistrering.registrering.norg2viaRest");
     }
 
     Optional<NavEnhet> finnEnhet(Enhetnr enhetId) {

--- a/src/test/java/no/nav/fo/veilarbregistrering/registrering/manuell/ManuellRegistreringServiceTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/registrering/manuell/ManuellRegistreringServiceTest.java
@@ -4,6 +4,7 @@ import no.nav.fo.veilarbregistrering.orgenhet.Enhetnr;
 import no.nav.fo.veilarbregistrering.orgenhet.HentEnheterGateway;
 import no.nav.fo.veilarbregistrering.orgenhet.NavEnhet;
 import no.nav.fo.veilarbregistrering.orgenhet.adapter.HentEnheterGatewayImpl;
+import no.nav.sbl.featuretoggle.unleash.UnleashService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -12,6 +13,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -23,7 +25,9 @@ class ManuellRegistreringServiceTest {
     public void setup(){
         ManuellRegistreringRepository manuellRegistreringRepository = mock(ManuellRegistreringRepository.class);
         HentEnheterGateway hentEnheterGateway = mock(HentEnheterGatewayImpl.class);
-        manuellRegistreringService = new ManuellRegistreringService(manuellRegistreringRepository, hentEnheterGateway, null);
+        UnleashService unleashService = mock(UnleashService.class);
+        when(unleashService.isEnabled(any())).thenReturn(true);
+        manuellRegistreringService = new ManuellRegistreringService(manuellRegistreringRepository, hentEnheterGateway, null, unleashService);
 
         List<NavEnhet> enheter = Arrays.asList(
                 new NavEnhet(Enhetnr.of("1234"), "TEST1"),


### PR DESCRIPTION
Legger til toggle for å kunne sammenligne svar fra Norg2 via SOAP og Rest. Hvis Rest-tjenesten fungerer, og svarene er like, vil vi kunne bytte til Rest, og fjerne SOAP-integrasjonen.