### PR TITLE
Skrur av sammenligning resultat fra SOAP vs. Rest

### DIFF
--- a/src/main/java/no/nav/fo/veilarbregistrering/registrering/manuell/ManuellRegistreringService.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/registrering/manuell/ManuellRegistreringService.java
@@ -56,15 +56,13 @@ public class ManuellRegistreringService {
             return null;
         }
 
-        Optional<NavEnhet> enhet = finnEnhet(Enhetnr.of(registrering.getVeilederEnhetId()));
-
+        Optional<NavEnhet> enhet;
         if (norg2ViaRest()) {
-            try {
-                Optional<NavEnhet> navEnhet = finnEnhetViaRest(Enhetnr.of(registrering.getVeilederEnhetId()));
-                LOG.info(String.format("Lik NAV-enhet: %s", enhet.equals(navEnhet) ? "Ja" : "Nei"));
-            } catch (RuntimeException e) {
-                LOG.error("Sammenligning av NavEnhet feilet. Har ingen betydning", e);
-            }
+            LOG.info("Henter NavEnhet via Rest");
+            enhet = finnEnhetViaRest(Enhetnr.of(registrering.getVeilederEnhetId()));
+        } else {
+            LOG.info("Henter NavEnhet via SOAP");
+            enhet = finnEnhet(Enhetnr.of(registrering.getVeilederEnhetId()));
         }
 
         return new Veileder()


### PR DESCRIPTION
Ifm. at vi skriver oss bort fra SOAP mot Norg2, har vi nå kjørt noen dager med begge kallene og sammenlignet svaret. Etter 3-4 dager, så er det 100% match, så da fjerner vi sammenligningen og bruker toggle for å enkelt skru mellom tjenestene slik at vi har fallback til SOAP ved behov.

Hvis det funker som ønsket, så fjerner vi også toggle med SOAP-integrasjonen.