### PR TITLE
Adressebeskyttelse

### DIFF
--- a/src/main/java/no/nav/fo/veilarbregistrering/bruker/AdressebeskyttelseGradering.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/bruker/AdressebeskyttelseGradering.java
@@ -1,0 +1,15 @@
+package no.nav.fo.veilarbregistrering.bruker;
+
+public enum AdressebeskyttelseGradering {
+    STRENGT_FORTROLIG_UTLAND, // Tilsvarer paragraf 19 i Bisys (henvisning til Forvaltningslovens §19)
+    STRENGT_FORTROLIG, // Tidligere spesregkode kode 6 fra TPS
+    FORTROLIG, // Tidligere spesregkode kode 7 fra TPS
+
+    UGRADERT, // Kode vi kan få fra Folkeregisteret, men brukscaset er ukjent.
+
+    UKJENT;
+
+    public boolean erGradert() {
+        return this != UGRADERT && this != UKJENT;
+    }
+}

--- a/src/main/java/no/nav/fo/veilarbregistrering/bruker/Person.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/bruker/Person.java
@@ -9,26 +9,30 @@ public class Person {
     private final Telefonnummer telefonnummer;
     private final Foedselsdato foedselsdato;
     private final GeografiskTilknytning geografiskTilknytning;
+    private final AdressebeskyttelseGradering adressebeskyttelseGradering;
 
     public static Person of(
             Opphold opphold,
             Statsborgerskap statsborgerskap,
             Telefonnummer telefonnummer,
             Foedselsdato foedselsdato,
-            GeografiskTilknytning geografiskTilknytning) {
-        return new Person(opphold, statsborgerskap, telefonnummer, foedselsdato, geografiskTilknytning);
+            GeografiskTilknytning geografiskTilknytning,
+            AdressebeskyttelseGradering adressebeskyttelseGradering) {
+        return new Person(opphold, statsborgerskap, telefonnummer, foedselsdato, geografiskTilknytning, adressebeskyttelseGradering);
     }
 
     private Person(Opphold opphold,
                    Statsborgerskap statsborgerskap,
                    Telefonnummer telefonnummer,
                    Foedselsdato foedselsdato,
-                   GeografiskTilknytning geografiskTilknytning) {
+                   GeografiskTilknytning geografiskTilknytning,
+                   AdressebeskyttelseGradering adressebeskyttelseGradering) {
         this.opphold = opphold;
         this.statsborgerskap = statsborgerskap;
         this.telefonnummer = telefonnummer;
         this.foedselsdato = foedselsdato;
         this.geografiskTilknytning = geografiskTilknytning;
+        this.adressebeskyttelseGradering = adressebeskyttelseGradering;
     }
 
     public Opphold getOpphold() {
@@ -49,6 +53,14 @@ public class Person {
 
     public Optional<GeografiskTilknytning> getGeografiskTilknytning() {
         return Optional.ofNullable(geografiskTilknytning);
+    }
+
+    public AdressebeskyttelseGradering getAdressebeskyttelseGradering() {
+        return adressebeskyttelseGradering;
+    }
+
+    public boolean harAdressebeskyttelse() {
+        return adressebeskyttelseGradering != null && adressebeskyttelseGradering.erGradert();
     }
 
     @Override

--- a/src/main/java/no/nav/fo/veilarbregistrering/bruker/pdl/PdlOppslagMapper.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/bruker/pdl/PdlOppslagMapper.java
@@ -29,7 +29,10 @@ class PdlOppslagMapper {
                 pdlPerson.getSistePdlFoedsel()
                         .map(PdlOppslagMapper::map)
                         .orElse(null),
-                map(pdlPerson.getGeografiskTilknytning()));
+                map(pdlPerson.getGeografiskTilknytning()),
+                pdlPerson.strengesteAdressebeskyttelse()
+                        .map(PdlOppslagMapper::map)
+                        .orElse(AdressebeskyttelseGradering.UKJENT));
     }
 
     private static Foedselsdato map(PdlFoedsel pdlFoedsel) {
@@ -93,5 +96,12 @@ class PdlOppslagMapper {
             LOG.warn(String.format("Mapping av geografisk tilknytning %s fra PDL feilet", geografiskTilknytning), e);
         }
         return null;
+    }
+
+    protected static AdressebeskyttelseGradering map(PdlAdressebeskyttelse adressebeskyttelse) {
+        if (adressebeskyttelse == null || adressebeskyttelse.getGradering() == null) {
+            return AdressebeskyttelseGradering.UKJENT;
+        }
+        return AdressebeskyttelseGradering.valueOf(adressebeskyttelse.getGradering().name());
     }
 }

--- a/src/main/java/no/nav/fo/veilarbregistrering/bruker/pdl/hentPerson/PdlAdressebeskyttelse.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/bruker/pdl/hentPerson/PdlAdressebeskyttelse.java
@@ -1,6 +1,6 @@
 package no.nav.fo.veilarbregistrering.bruker.pdl.hentPerson;
 
-public class PdlAdressebeskyttelse {
+public class PdlAdressebeskyttelse implements Comparable<PdlAdressebeskyttelse> {
 
     private PdlGradering gradering;
 
@@ -19,7 +19,8 @@ public class PdlAdressebeskyttelse {
         this.gradering = gradering;
     }
 
-    public boolean erGradert() {
-        return gradering != null && gradering != PdlGradering.UGRADERT;
+    @Override
+    public int compareTo(PdlAdressebeskyttelse other) {
+        return other.gradering.getNiva() - this.gradering.getNiva();
     }
 }

--- a/src/main/java/no/nav/fo/veilarbregistrering/bruker/pdl/hentPerson/PdlAdressebeskyttelse.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/bruker/pdl/hentPerson/PdlAdressebeskyttelse.java
@@ -7,11 +7,19 @@ public class PdlAdressebeskyttelse {
     public PdlAdressebeskyttelse() {
     }
 
+    public PdlAdressebeskyttelse(PdlGradering gradering) {
+        this.gradering = gradering;
+    }
+
     public PdlGradering getGradering() {
         return gradering;
     }
 
     public void setGradering(PdlGradering gradering) {
         this.gradering = gradering;
+    }
+
+    public boolean erGradert() {
+        return gradering != null && gradering != PdlGradering.UGRADERT;
     }
 }

--- a/src/main/java/no/nav/fo/veilarbregistrering/bruker/pdl/hentPerson/PdlAdressebeskyttelse.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/bruker/pdl/hentPerson/PdlAdressebeskyttelse.java
@@ -1,0 +1,17 @@
+package no.nav.fo.veilarbregistrering.bruker.pdl.hentPerson;
+
+public class PdlAdressebeskyttelse {
+
+    private PdlGradering gradering;
+
+    public PdlAdressebeskyttelse() {
+    }
+
+    public PdlGradering getGradering() {
+        return gradering;
+    }
+
+    public void setGradering(PdlGradering gradering) {
+        this.gradering = gradering;
+    }
+}

--- a/src/main/java/no/nav/fo/veilarbregistrering/bruker/pdl/hentPerson/PdlGradering.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/bruker/pdl/hentPerson/PdlGradering.java
@@ -1,0 +1,9 @@
+package no.nav.fo.veilarbregistrering.bruker.pdl.hentPerson;
+
+public enum PdlGradering {
+    STRENGT_FORTROLIG_UTLAND, // Tilsvarer paragraf 19 i Bisys (henvisning til Forvaltningslovens §19)
+    STRENGT_FORTROLIG, // Tidligere spesregkode kode 6 fra TPS
+    FORTROLIG, // Tidligere spesregkode kode 7 fra TPS
+
+    UGRADERT
+}

--- a/src/main/java/no/nav/fo/veilarbregistrering/bruker/pdl/hentPerson/PdlGradering.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/bruker/pdl/hentPerson/PdlGradering.java
@@ -1,9 +1,19 @@
 package no.nav.fo.veilarbregistrering.bruker.pdl.hentPerson;
 
 public enum PdlGradering {
-    STRENGT_FORTROLIG_UTLAND, // Tilsvarer paragraf 19 i Bisys (henvisning til Forvaltningslovens §19)
-    STRENGT_FORTROLIG, // Tidligere spesregkode kode 6 fra TPS
-    FORTROLIG, // Tidligere spesregkode kode 7 fra TPS
+    STRENGT_FORTROLIG_UTLAND(3), // Tilsvarer paragraf 19 i Bisys (henvisning til Forvaltningslovens §19)
+    STRENGT_FORTROLIG(2), // Tidligere spesregkode kode 6 fra TPS
+    FORTROLIG(1), // Tidligere spesregkode kode 7 fra TPS
 
-    UGRADERT
+    UGRADERT(0);
+
+    private final int niva;
+
+    PdlGradering(int niva) {
+        this.niva = niva;
+    }
+
+    protected int getNiva() {
+        return niva;
+    }
 }

--- a/src/main/java/no/nav/fo/veilarbregistrering/bruker/pdl/hentPerson/PdlPerson.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/bruker/pdl/hentPerson/PdlPerson.java
@@ -9,6 +9,7 @@ public class PdlPerson {
     private List<PdlTelefonnummer> telefonnummer;
     private List<PdlFoedsel> foedsel;
     private PdlGeografiskTilknytning geografiskTilknytning;
+    private List<PdlAdressebeskyttelse> adressebeskyttelse;
 
     public PdlPerson() {
     }
@@ -81,5 +82,13 @@ public class PdlPerson {
 
     public void setGeografiskTilknytning(PdlGeografiskTilknytning geografiskTilknytning) {
         this.geografiskTilknytning = geografiskTilknytning;
+    }
+
+    public List<PdlAdressebeskyttelse> getAdressebeskyttelse() {
+        return adressebeskyttelse;
+    }
+
+    public void setAdressebeskyttelse(List<PdlAdressebeskyttelse> adressebeskyttelse) {
+        this.adressebeskyttelse = adressebeskyttelse;
     }
 }

--- a/src/main/java/no/nav/fo/veilarbregistrering/bruker/pdl/hentPerson/PdlPerson.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/bruker/pdl/hentPerson/PdlPerson.java
@@ -68,13 +68,6 @@ public class PdlPerson {
         return Optional.of(this.foedsel.get(this.foedsel.size() - 1));
     }
 
-    public boolean harAdressebeskyttelse() {
-        if (this.adressebeskyttelse == null || this.adressebeskyttelse.isEmpty()) {
-            return false;
-        }
-        return this.adressebeskyttelse.stream().anyMatch(PdlAdressebeskyttelse::erGradert);
-    }
-
     public List<PdlFoedsel> getFoedsel() {
         return this.foedsel;
     }
@@ -89,6 +82,16 @@ public class PdlPerson {
 
     public void setGeografiskTilknytning(PdlGeografiskTilknytning geografiskTilknytning) {
         this.geografiskTilknytning = geografiskTilknytning;
+    }
+
+    public Optional<PdlAdressebeskyttelse> strengesteAdressebeskyttelse() {
+        if (adressebeskyttelse == null || adressebeskyttelse.isEmpty()) {
+            return Optional.empty();
+        }
+
+        return adressebeskyttelse.stream()
+                .sorted()
+                .findFirst();
     }
 
     public List<PdlAdressebeskyttelse> getAdressebeskyttelse() {

--- a/src/main/java/no/nav/fo/veilarbregistrering/bruker/pdl/hentPerson/PdlPerson.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/bruker/pdl/hentPerson/PdlPerson.java
@@ -68,6 +68,13 @@ public class PdlPerson {
         return Optional.of(this.foedsel.get(this.foedsel.size() - 1));
     }
 
+    public boolean harAdressebeskyttelse() {
+        if (this.adressebeskyttelse == null || this.adressebeskyttelse.isEmpty()) {
+            return false;
+        }
+        return this.adressebeskyttelse.stream().anyMatch(PdlAdressebeskyttelse::erGradert);
+    }
+
     public List<PdlFoedsel> getFoedsel() {
         return this.foedsel;
     }

--- a/src/main/java/no/nav/fo/veilarbregistrering/config/ServiceBeansConfig.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/config/ServiceBeansConfig.java
@@ -160,8 +160,9 @@ public class ServiceBeansConfig {
             EnhetGateway enhetGateway,
             Norg2Gateway norg2Gateway,
             PersonGateway personGateway,
-            UnleashService unleashService) {
-        return new OppgaveRouter(arbeidsforholdGateway, enhetGateway, norg2Gateway, personGateway, unleashService);
+            UnleashService unleashService,
+            PdlOppslagGateway pdlOppslagGateway) {
+        return new OppgaveRouter(arbeidsforholdGateway, enhetGateway, norg2Gateway, personGateway, unleashService, pdlOppslagGateway);
     }
 
     @Bean

--- a/src/main/resources/pdl/hentPerson.graphql
+++ b/src/main/resources/pdl/hentPerson.graphql
@@ -23,6 +23,9 @@ query($ident: ID!, $oppholdHistorikk: Boolean!){
         gtKommune,
         gtBydel,
         gtLand
+    },
+    adressebeskyttelse {
+        gradering
     }
   }
 }

--- a/src/test/java/no/nav/fo/veilarbregistrering/bruker/PersonTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/bruker/PersonTest.java
@@ -1,0 +1,24 @@
+package no.nav.fo.veilarbregistrering.bruker;
+
+import org.junit.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class PersonTest {
+
+    @Test
+    public void harAdressebeskyttelse() {
+        assertFalse(personMedAdressebeskyttelseGradering(null).harAdressebeskyttelse());
+        assertFalse(personMedAdressebeskyttelseGradering(AdressebeskyttelseGradering.UKJENT).harAdressebeskyttelse());
+        assertFalse(personMedAdressebeskyttelseGradering(AdressebeskyttelseGradering.UGRADERT).harAdressebeskyttelse());
+
+        assertTrue(personMedAdressebeskyttelseGradering(AdressebeskyttelseGradering.FORTROLIG).harAdressebeskyttelse());
+        assertTrue(personMedAdressebeskyttelseGradering(AdressebeskyttelseGradering.STRENGT_FORTROLIG).harAdressebeskyttelse());
+        assertTrue(personMedAdressebeskyttelseGradering(AdressebeskyttelseGradering.STRENGT_FORTROLIG_UTLAND).harAdressebeskyttelse());
+    }
+
+    private Person personMedAdressebeskyttelseGradering(AdressebeskyttelseGradering gradering) {
+        return Person.of(null, null, null, null, null, gradering);
+    }
+
+}

--- a/src/test/java/no/nav/fo/veilarbregistrering/bruker/pdl/PdlOppslagMapperTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/bruker/pdl/PdlOppslagMapperTest.java
@@ -4,9 +4,7 @@ import no.nav.fo.veilarbregistrering.bruker.*;
 import no.nav.fo.veilarbregistrering.bruker.pdl.hentIdenter.PdlGruppe;
 import no.nav.fo.veilarbregistrering.bruker.pdl.hentIdenter.PdlIdent;
 import no.nav.fo.veilarbregistrering.bruker.pdl.hentIdenter.PdlIdenter;
-import no.nav.fo.veilarbregistrering.bruker.pdl.hentPerson.GtType;
-import no.nav.fo.veilarbregistrering.bruker.pdl.hentPerson.Oppholdstype;
-import no.nav.fo.veilarbregistrering.bruker.pdl.hentPerson.PdlPerson;
+import no.nav.fo.veilarbregistrering.bruker.pdl.hentPerson.*;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -79,6 +77,17 @@ public class PdlOppslagMapperTest {
         assertThat(identer.getIdenter().get(0).getIdent()).isEqualTo("12345678910");
         assertThat(identer.getIdenter().get(0).isHistorisk()).isEqualTo(false);
         assertThat(identer.getIdenter().get(0).getGruppe()).isEqualTo(Gruppe.FOLKEREGISTERIDENT);
+    }
+
+    @Test
+    public void skal_mappe_adressebeskyttelse() {
+        for (PdlGradering gradering : PdlGradering.values()) {
+            PdlAdressebeskyttelse pdlAdressebeskyttelse = new PdlAdressebeskyttelse(gradering);
+            AdressebeskyttelseGradering mappedGradering = PdlOppslagMapper.map(pdlAdressebeskyttelse);
+            assertThat(gradering.name()).isEqualTo(mappedGradering.name());
+        }
+
+        assertThat(PdlOppslagMapper.map((PdlAdressebeskyttelse) null)).isEqualTo(AdressebeskyttelseGradering.UKJENT);
     }
 
 }

--- a/src/test/java/no/nav/fo/veilarbregistrering/bruker/pdl/PdlPersonTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/bruker/pdl/PdlPersonTest.java
@@ -1,5 +1,7 @@
 package no.nav.fo.veilarbregistrering.bruker.pdl;
 
+import no.nav.fo.veilarbregistrering.bruker.pdl.hentPerson.PdlAdressebeskyttelse;
+import no.nav.fo.veilarbregistrering.bruker.pdl.hentPerson.PdlGradering;
 import no.nav.fo.veilarbregistrering.bruker.pdl.hentPerson.PdlPerson;
 import no.nav.fo.veilarbregistrering.bruker.pdl.hentPerson.PdlTelefonnummer;
 import org.junit.jupiter.api.Test;
@@ -7,8 +9,10 @@ import org.junit.jupiter.api.Test;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class PdlPersonTest {
 
@@ -29,5 +33,25 @@ public class PdlPersonTest {
 
         Optional<PdlTelefonnummer> pdlTelefonnummer = pdlPerson.hoyestPrioriterteTelefonnummer();
         assertThat(pdlTelefonnummer).hasValue(pdlTelefonnummer1);
+    }
+
+    @Test
+    public void harAdressebeskyttelse() {
+        assertFalse(personMedAdressebeskyttelse().harAdressebeskyttelse());
+        assertFalse(personMedAdressebeskyttelse(PdlGradering.UGRADERT).harAdressebeskyttelse());
+
+        assertTrue(personMedAdressebeskyttelse(PdlGradering.FORTROLIG).harAdressebeskyttelse());
+        assertTrue(personMedAdressebeskyttelse(PdlGradering.STRENGT_FORTROLIG).harAdressebeskyttelse());
+        assertTrue(personMedAdressebeskyttelse(PdlGradering.STRENGT_FORTROLIG_UTLAND).harAdressebeskyttelse());
+
+        assertTrue(personMedAdressebeskyttelse(PdlGradering.UGRADERT, PdlGradering.FORTROLIG).harAdressebeskyttelse());
+    }
+
+    private PdlPerson personMedAdressebeskyttelse(PdlGradering... graderinger) {
+        PdlPerson person = new PdlPerson();
+        person.setAdressebeskyttelse(Arrays.asList(graderinger).stream()
+                .map(PdlAdressebeskyttelse::new)
+                .collect(Collectors.toList()));
+        return person;
     }
 }

--- a/src/test/java/no/nav/fo/veilarbregistrering/bruker/pdl/PdlPersonTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/bruker/pdl/PdlPersonTest.java
@@ -36,15 +36,38 @@ public class PdlPersonTest {
     }
 
     @Test
-    public void harAdressebeskyttelse() {
-        assertFalse(personMedAdressebeskyttelse().harAdressebeskyttelse());
-        assertFalse(personMedAdressebeskyttelse(PdlGradering.UGRADERT).harAdressebeskyttelse());
+    public void strengesteAdressebeskyttelse_uten_eksplisitt_graderingsniva() {
+        assertThat(personMedAdressebeskyttelse().strengesteAdressebeskyttelse()).isEmpty();
+    }
 
-        assertTrue(personMedAdressebeskyttelse(PdlGradering.FORTROLIG).harAdressebeskyttelse());
-        assertTrue(personMedAdressebeskyttelse(PdlGradering.STRENGT_FORTROLIG).harAdressebeskyttelse());
-        assertTrue(personMedAdressebeskyttelse(PdlGradering.STRENGT_FORTROLIG_UTLAND).harAdressebeskyttelse());
+    @Test
+    public void strengesteAdressebeskyttelse_med_en_gradering() {
+        for (PdlGradering gradering: PdlGradering.values()) {
+            PdlPerson enkeltgradertPerson = personMedAdressebeskyttelse(gradering);
+            PdlGradering strengesteGradering = strengesteGraderingForPerson(enkeltgradertPerson);
 
-        assertTrue(personMedAdressebeskyttelse(PdlGradering.UGRADERT, PdlGradering.FORTROLIG).harAdressebeskyttelse());
+            assertThat(strengesteGradering).isEqualTo(gradering);
+        }
+    }
+
+    @Test
+    public void strengesteAdressebeskyttelse_med_flere_graderinger() {
+        assertThat(strengesteGraderingForPerson(
+                personMedAdressebeskyttelse(PdlGradering.UGRADERT, PdlGradering.FORTROLIG)
+        )).isEqualTo(PdlGradering.FORTROLIG);
+
+        assertThat(strengesteGraderingForPerson(
+                personMedAdressebeskyttelse(PdlGradering.STRENGT_FORTROLIG, PdlGradering.FORTROLIG)
+        )).isEqualTo(PdlGradering.STRENGT_FORTROLIG);
+
+        assertThat(strengesteGraderingForPerson(
+                personMedAdressebeskyttelse(PdlGradering.STRENGT_FORTROLIG, PdlGradering.STRENGT_FORTROLIG_UTLAND, PdlGradering.FORTROLIG)
+        )).isEqualTo(PdlGradering.STRENGT_FORTROLIG_UTLAND);
+    }
+
+    private PdlGradering strengesteGraderingForPerson(PdlPerson person) {
+        return person.strengesteAdressebeskyttelse()
+                .map(PdlAdressebeskyttelse::getGradering).orElse(null);
     }
 
     private PdlPerson personMedAdressebeskyttelse(PdlGradering... graderinger) {

--- a/src/test/java/no/nav/fo/veilarbregistrering/oppgave/OppgaveRouterTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/oppgave/OppgaveRouterTest.java
@@ -3,6 +3,10 @@ package no.nav.fo.veilarbregistrering.oppgave;
 import no.nav.fo.veilarbregistrering.arbeidsforhold.ArbeidsforholdGateway;
 import no.nav.fo.veilarbregistrering.arbeidsforhold.FlereArbeidsforhold;
 import no.nav.fo.veilarbregistrering.bruker.*;
+import no.nav.fo.veilarbregistrering.bruker.pdl.PdlOppslagMapperTest;
+import no.nav.fo.veilarbregistrering.bruker.pdl.hentPerson.PdlAdressebeskyttelse;
+import no.nav.fo.veilarbregistrering.bruker.pdl.hentPerson.PdlGradering;
+import no.nav.fo.veilarbregistrering.bruker.pdl.hentPerson.PdlPerson;
 import no.nav.fo.veilarbregistrering.enhet.EnhetGateway;
 import no.nav.fo.veilarbregistrering.enhet.Forretningsadresse;
 import no.nav.fo.veilarbregistrering.enhet.Kommunenummer;
@@ -39,8 +43,9 @@ public class OppgaveRouterTest {
         Norg2Gateway norg2Gateway = new StubNorg2Gateway();
         PersonGateway personGateway = foedselsnummer -> Optional.empty();
         UnleashService unleashService = mock(UnleashService.class);
+        PdlOppslagGateway pdlOppslagGateway = mock(PdlOppslagGateway.class);
 
-        OppgaveRouter oppgaveRouter = new OppgaveRouter(arbeidsforholdGateway, enhetGateway, norg2Gateway, personGateway, unleashService);
+        OppgaveRouter oppgaveRouter = new OppgaveRouter(arbeidsforholdGateway, enhetGateway, norg2Gateway, personGateway, unleashService, pdlOppslagGateway);
 
         Optional<Enhetnr> enhetsnr = oppgaveRouter.hentEnhetsnummerFor(BRUKER, UTVANDRET);
 
@@ -54,8 +59,9 @@ public class OppgaveRouterTest {
         Norg2Gateway norg2Gateway = new StubNorg2Gateway();
         PersonGateway personGateway = foedselsnummer -> Optional.empty();
         UnleashService unleashService = mock(UnleashService.class);
+        PdlOppslagGateway pdlOppslagGateway = mock(PdlOppslagGateway.class);
 
-        OppgaveRouter oppgaveRouter = new OppgaveRouter(arbeidsforholdGateway, enhetGateway, norg2Gateway, personGateway, unleashService);
+        OppgaveRouter oppgaveRouter = new OppgaveRouter(arbeidsforholdGateway, enhetGateway, norg2Gateway, personGateway, unleashService, pdlOppslagGateway);
 
         Optional<Enhetnr> enhetsnr = oppgaveRouter.hentEnhetsnummerFor(BRUKER, UTVANDRET);
 
@@ -76,8 +82,9 @@ public class OppgaveRouterTest {
         Norg2Gateway norg2Gateway = new StubNorg2Gateway();
         PersonGateway personGateway = foedselsnummer -> Optional.empty();
         UnleashService unleashService = mock(UnleashService.class);
+        PdlOppslagGateway pdlOppslagGateway = mock(PdlOppslagGateway.class);
 
-        OppgaveRouter oppgaveRouter = new OppgaveRouter(arbeidsforholdGateway, enhetGateway, norg2Gateway, personGateway, unleashService);
+        OppgaveRouter oppgaveRouter = new OppgaveRouter(arbeidsforholdGateway, enhetGateway, norg2Gateway, personGateway, unleashService, pdlOppslagGateway);
 
         Optional<Enhetnr> enhetsnr = oppgaveRouter.hentEnhetsnummerFor(BRUKER, UTVANDRET);
 
@@ -98,8 +105,9 @@ public class OppgaveRouterTest {
         Norg2Gateway norg2Gateway = new StubNorg2Gateway();
         PersonGateway personGateway = foedselsnummer -> Optional.empty();
         UnleashService unleashService = mock(UnleashService.class);
+        PdlOppslagGateway pdlOppslagGateway = mock(PdlOppslagGateway.class);
 
-        OppgaveRouter oppgaveRouter = new OppgaveRouter(arbeidsforholdGateway, enhetGateway, norg2Gateway, personGateway, unleashService);
+        OppgaveRouter oppgaveRouter = new OppgaveRouter(arbeidsforholdGateway, enhetGateway, norg2Gateway, personGateway, unleashService, pdlOppslagGateway);
 
         Optional<Enhetnr> enhetsnr = oppgaveRouter.hentEnhetsnummerFor(BRUKER, UTVANDRET);
 
@@ -113,8 +121,9 @@ public class OppgaveRouterTest {
         Norg2Gateway norg2Gateway = new StubNorg2Gateway();
         PersonGateway personGateway = foedselsnummer -> Optional.of(GeografiskTilknytning.of("0301"));
         UnleashService unleashService = mock(UnleashService.class);
+        PdlOppslagGateway pdlOppslagGateway = mock(PdlOppslagGateway.class);
 
-        OppgaveRouter oppgaveRouter = new OppgaveRouter(arbeidsforholdGateway, enhetGateway, norg2Gateway, personGateway, unleashService);
+        OppgaveRouter oppgaveRouter = new OppgaveRouter(arbeidsforholdGateway, enhetGateway, norg2Gateway, personGateway, unleashService, pdlOppslagGateway);
 
         Optional<Enhetnr> enhetsnr = oppgaveRouter.hentEnhetsnummerFor(BRUKER, UTVANDRET);
 
@@ -128,8 +137,9 @@ public class OppgaveRouterTest {
         Norg2Gateway norg2Gateway = new StubNorg2Gateway();
         PersonGateway personGateway = foedselsnummer -> Optional.of(GeografiskTilknytning.of("030106"));
         UnleashService unleashService = mock(UnleashService.class);
+        PdlOppslagGateway pdlOppslagGateway = mock(PdlOppslagGateway.class);
 
-        OppgaveRouter oppgaveRouter = new OppgaveRouter(arbeidsforholdGateway, enhetGateway, norg2Gateway, personGateway, unleashService);
+        OppgaveRouter oppgaveRouter = new OppgaveRouter(arbeidsforholdGateway, enhetGateway, norg2Gateway, personGateway, unleashService, pdlOppslagGateway);
 
         Optional<Enhetnr> enhetsnr = oppgaveRouter.hentEnhetsnummerFor(BRUKER, UTVANDRET);
 
@@ -150,8 +160,9 @@ public class OppgaveRouterTest {
         Norg2Gateway norg2Gateway = new StubNorg2Gateway();
         PersonGateway personGateway = foedselsnummer -> Optional.of(GeografiskTilknytning.of("DNK"));
         UnleashService unleashService = mock(UnleashService.class);
+        PdlOppslagGateway pdlOppslagGateway = mock(PdlOppslagGateway.class);
 
-        OppgaveRouter oppgaveRouter = new OppgaveRouter(arbeidsforholdGateway, enhetGateway, norg2Gateway, personGateway, unleashService);
+        OppgaveRouter oppgaveRouter = new OppgaveRouter(arbeidsforholdGateway, enhetGateway, norg2Gateway, personGateway, unleashService, pdlOppslagGateway);
 
         Optional<Enhetnr> enhetsnr = oppgaveRouter.hentEnhetsnummerFor(BRUKER, UTVANDRET);
 
@@ -172,8 +183,9 @@ public class OppgaveRouterTest {
         Norg2Gateway norg2Gateway = new StubNorg2Gateway();
         PersonGateway personGateway = foedselsnummer -> Optional.of(GeografiskTilknytning.of("DNK"));
         UnleashService unleashService = mock(UnleashService.class);
+        PdlOppslagGateway pdlOppslagGateway = mock(PdlOppslagGateway.class);
 
-        OppgaveRouter oppgaveRouter = new OppgaveRouter(arbeidsforholdGateway, enhetGateway, norg2Gateway, personGateway, unleashService);
+        OppgaveRouter oppgaveRouter = new OppgaveRouter(arbeidsforholdGateway, enhetGateway, norg2Gateway, personGateway, unleashService, pdlOppslagGateway);
 
         Optional<Enhetnr> enhetsnr = oppgaveRouter.hentEnhetsnummerFor(BRUKER, UTVANDRET);
 
@@ -191,11 +203,10 @@ public class OppgaveRouterTest {
                 Arrays.asList(forretningsadresse), Collections.emptyList()));
         Norg2Gateway norg2Gateway = new StubNorg2Gateway();
         PersonGateway personGateway = foedselsnummer -> Optional.empty();
-
+        PdlOppslagGateway pdlOppslagGateway = mock(PdlOppslagGateway.class);
         UnleashService unleashService = mock(UnleashService.class);
-        when(unleashService.isEnabled("veilarbregistrering.utvidetEnhetsoppslagForAlleOppgavetyper")).thenReturn(false);
 
-        OppgaveRouter oppgaveRouter = new OppgaveRouter(arbeidsforholdGateway, enhetGateway, norg2Gateway, personGateway, unleashService);
+        OppgaveRouter oppgaveRouter = new OppgaveRouter(arbeidsforholdGateway, enhetGateway, norg2Gateway, personGateway, unleashService, pdlOppslagGateway);
 
         Optional<Enhetnr> enhetsnr = oppgaveRouter.hentEnhetsnummerFor(BRUKER, OPPHOLDSTILLATELSE);
         assertThat(enhetsnr).isEmpty();
@@ -211,14 +222,33 @@ public class OppgaveRouterTest {
                 Arrays.asList(forretningsadresse), Collections.emptyList()));
         Norg2Gateway norg2Gateway = new StubNorg2Gateway();
         PersonGateway personGateway = foedselsnummer -> Optional.empty();
+        PdlOppslagGateway pdlOppslagGateway = mock(PdlOppslagGateway.class);
+        UnleashService unleashService = unleashServiceMedFeatures("veilarbregistrering.utvidetEnhetsoppslagForAlleOppgavetyper");
 
-        UnleashService unleashService = mock(UnleashService.class);
-        when(unleashService.isEnabled("veilarbregistrering.utvidetEnhetsoppslagForAlleOppgavetyper")).thenReturn(true);
-
-        OppgaveRouter oppgaveRouter = new OppgaveRouter(arbeidsforholdGateway, enhetGateway, norg2Gateway, personGateway, unleashService);
+        OppgaveRouter oppgaveRouter = new OppgaveRouter(arbeidsforholdGateway, enhetGateway, norg2Gateway, personGateway, unleashService, pdlOppslagGateway);
 
         Optional<Enhetnr> enhetsnr = oppgaveRouter.hentEnhetsnummerFor(BRUKER, OPPHOLDSTILLATELSE);
         assertThat(enhetsnr).hasValue(Enhetnr.of("232"));
+    }
+
+    @Test
+    public void brukere_med_adressebeskyttelse_sendes_til_intern_brukerstotte() {
+        ArbeidsforholdGateway arbeidsforholdGateway = fnr -> flereArbeidsforholdTilfeldigSortert();
+        EnhetGateway enhetGateway = organisasjonsnummer -> Optional.empty();
+        Norg2Gateway norg2Gateway = new StubNorg2Gateway();
+        PersonGateway personGateway = foedselsnummer -> Optional.of(GeografiskTilknytning.of("030106"));
+        UnleashService unleashService = unleashServiceMedFeatures("veilarbregistrering.adressebeskyttelse");
+
+        PdlOppslagGateway pdlOppslagGateway = mock(PdlOppslagGateway.class);
+
+        Person person = Person.of(null, null, null, null, null, AdressebeskyttelseGradering.STRENGT_FORTROLIG);
+        when(pdlOppslagGateway.hentPerson(BRUKER.getAktorId())).thenReturn(Optional.of(person));
+
+        OppgaveRouter oppgaveRouter = new OppgaveRouter(arbeidsforholdGateway, enhetGateway, norg2Gateway, personGateway, unleashService, pdlOppslagGateway);
+
+        Optional<Enhetnr> enhetsnr = oppgaveRouter.hentEnhetsnummerFor(BRUKER, UTVANDRET);
+
+        assertThat(enhetsnr).hasValue(Enhetnr.internBrukerstotte());
     }
 
     class StubNorg2Gateway implements Norg2Gateway {
@@ -239,5 +269,13 @@ public class OppgaveRouterTest {
         public Map<Enhetnr, NavEnhet> hentAlleEnheter() {
             return null;
         }
+    }
+
+    private UnleashService unleashServiceMedFeatures(String... aktiverteFeatures) {
+        UnleashService unleashService = mock(UnleashService.class);
+        for (String aktivertFeature: aktiverteFeatures) {
+            when(unleashService.isEnabled(aktivertFeature)).thenReturn(true);
+        }
+        return unleashService;
     }
 }


### PR DESCRIPTION
Routing av brukere med adressebeskyttelse til intern brukerstøtte

Dette gjelder personer med flaggene FORTROLIG, STRENGT_FORTROLIG, og STRENGT_FORTROLIG_UTLAND i PDL.
Se https://navikt.github.io/pdl/#_adressebeskyttelse for mer info.

Foreløpig er dette skjult bak et feature-flagg i Unleash: "veilarbregistrering.adressebeskyttelse"