### PR TITLE
Bruk av EnhetId fremfor String lekker ut i APIet

### DIFF
--- a/src/main/java/no/nav/fo/veilarbregistrering/orgenhet/NavEnhet.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/orgenhet/NavEnhet.java
@@ -10,6 +10,6 @@ import lombok.experimental.Accessors;
 @AllArgsConstructor
 @NoArgsConstructor
 public class NavEnhet {
-    Enhetnr id;
+    String id;
     String navn;
 }

--- a/src/main/java/no/nav/fo/veilarbregistrering/orgenhet/adapter/Norg2GatewayImpl.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/orgenhet/adapter/Norg2GatewayImpl.java
@@ -37,7 +37,7 @@ class Norg2GatewayImpl implements Norg2Gateway {
         List<RsEnhet> rsEnhets = norg2RestClient.hentAlleEnheter();
 
         return rsEnhets.stream()
-                .map(rs -> new NavEnhet(Enhetnr.of(rs.getEnhetNr()), rs.getNavn()))
-                .collect(toMap(NavEnhet::getId, navEnhet -> navEnhet));
+                .map(rs -> new NavEnhet(rs.getEnhetNr(), rs.getNavn()))
+                .collect(toMap(navEnhet -> Enhetnr.of(navEnhet.getId()), navEnhet -> navEnhet));
     }
 }

--- a/src/test/java/no/nav/fo/veilarbregistrering/registrering/manuell/ManuellRegistreringServiceTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/registrering/manuell/ManuellRegistreringServiceTest.java
@@ -27,15 +27,15 @@ class ManuellRegistreringServiceTest {
         manuellRegistreringService = new ManuellRegistreringService(manuellRegistreringRepository, norg2Gateway);
 
         Map<Enhetnr, NavEnhet> enheter = new HashMap();
-        enheter.put(Enhetnr.of("1234"), new NavEnhet(Enhetnr.of("1234"), "TEST1"));
-        enheter.put(Enhetnr.of("5678"), new NavEnhet(Enhetnr.of("5678"), "TEST2"));
+        enheter.put(Enhetnr.of("1234"), new NavEnhet("1234", "TEST1"));
+        enheter.put(Enhetnr.of("5678"), new NavEnhet("5678", "TEST2"));
 
         when(norg2Gateway.hentAlleEnheter()).thenReturn(enheter);
     }
     @Test
     public void skalFinneRiktigEnhet(){
         Optional<NavEnhet> enhet = manuellRegistreringService.finnEnhet(Enhetnr.of("1234"));
-        assertThat(enhet).hasValue(new NavEnhet(Enhetnr.of("1234"), "TEST1"));
+        assertThat(enhet).hasValue(new NavEnhet("1234", "TEST1"));
     }
 
     @Test


### PR DESCRIPTION
Fikser endring fra bruk av EnhetId fremfor String i NavEnhet. Ettersom dette objektet også blir benyttet i APIet vårt, og vi ikke har noen forskjell på internt og eksternt API så treffer dette konsumentene våre. Endrer derfor tilbake, også får vi fikse dette senere ved å dele opp modellen bedre.