### PR TITLE
Legger til Jira-lenke i oppgavetekst

### DIFF
--- a/src/main/java/no/nav/fo/veilarbregistrering/oppgave/Oppgave.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/oppgave/Oppgave.java
@@ -17,7 +17,9 @@ public class Oppgave {
                 OppgaveType.OPPHOLDSTILLATELSE,
                 "Brukeren får ikke registrert seg som arbeidssøker pga. manglende oppholdstillatelse i Arena, " +
                         "og har selv opprettet denne oppgaven. " +
-                        "Ring bruker og følg midlertidig rutine på navet om løsning for registreringen av arbeids- og oppholdstillatelse."
+                        "Ring bruker og følg midlertidig rutine på navet om løsning for registreringen av arbeids- og oppholdstillatelse. " +
+                        "\n\nHar oppgaven havnet i feil oppgaveliste? Da ønsker vi som har utviklet løsningen tilbakemelding på dette. " +
+                        "Meld sak her: https://jira.adeo.no/plugins/servlet/desk/portal/541/create/3384. Takk!"
         );
         beskrivelser.put(
                 OppgaveType.UTVANDRET,

--- a/src/test/java/no/nav/fo/veilarbregistrering/oppgave/adapter/OppgaveGatewayTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/oppgave/adapter/OppgaveGatewayTest.java
@@ -74,7 +74,8 @@ class OppgaveGatewayTest {
                                 "\"beskrivelse\":\"" +
                                 "Brukeren får ikke registrert seg som arbeidssøker pga. manglende oppholdstillatelse i Arena, " +
                                 "og har selv opprettet denne oppgaven. " +
-                                "Ring bruker og følg midlertidig rutine på navet om løsning for registreringen av arbeids- og oppholdstillatelse.\"," +
+                                "Ring bruker og følg midlertidig rutine på navet om løsning for registreringen av arbeids- og oppholdstillatelse. " +
+                                "\\n\\nHar oppgaven havnet i feil oppgaveliste? Da ønsker vi som har utviklet løsningen tilbakemelding på dette. Meld sak her: https://jira.adeo.no/plugins/servlet/desk/portal/541/create/3384. Takk!\"," +
                                 "\"tema\":\"OPP\"," +
                                 "\"oppgavetype\":\"KONT_BRUK\"," +
                                 "\"fristFerdigstillelse\":\"" +


### PR DESCRIPTION
Ved å legge til Jira-referanse i oppgaveteksten, gjør vi det lettere for veiledere og andre til å melde feil direkte tilbake til teamet. Da blir det enkelt for de, og vi får nyttig feedback.