### PR TITLE
Kommenterer ut PubliseringAvHistorikk

### DIFF
--- a/src/main/java/no/nav/fo/veilarbregistrering/kafka/ArbeidssokerRegistrertKafkaProducer.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/kafka/ArbeidssokerRegistrertKafkaProducer.java
@@ -8,9 +8,6 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.header.internals.RecordHeader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.slf4j.MDC;
-
-import java.nio.charset.StandardCharsets;
 
 import static no.nav.fo.veilarbregistrering.kafka.ArbeidssokerRegistrertMapper.map;
 import static no.nav.fo.veilarbregistrering.log.CallId.getCorrelationIdAsBytes;

--- a/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/PubliseringAvHistorikkTask.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/PubliseringAvHistorikkTask.java
@@ -8,10 +8,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
-import java.util.concurrent.Executors;
-
-import static java.util.concurrent.TimeUnit.MINUTES;
-
 public class PubliseringAvHistorikkTask implements Runnable {
 
     private static final Logger LOG = LoggerFactory.getLogger(PubliseringAvHistorikkTask.class);
@@ -32,10 +28,10 @@ public class PubliseringAvHistorikkTask implements Runnable {
 
         /*
         Kan taes inn ved behov for å kjøre ny batch
-         */
+
         Executors.newSingleThreadScheduledExecutor()
                 .schedule(this, 5, MINUTES);
-
+         */
     }
 
     @Override


### PR DESCRIPTION
Vi trenger ingen tråd som skal starte etter hver deploy for å publisere historiske data til Kafka. Denne kan enables ved behov.