### PR TITLE
Flytter beregning av registreringstype

### DIFF
--- a/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/BrukerRegistreringService.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/BrukerRegistreringService.java
@@ -255,9 +255,7 @@ public class BrukerRegistreringService {
             sykeforloepMetaData = sykemeldingService.hentSykmeldtInfoData(fnr);
         }
 
-        RegistreringType registreringType = beregnRegistreringType(oppfolgingsstatus, sykeforloepMetaData);
-
-        return new BrukersTilstand(oppfolgingsstatus, sykeforloepMetaData, registreringType);
+        return new BrukersTilstand(oppfolgingsstatus, sykeforloepMetaData);
     }
 
     public List<AktiveringTilstand> finnAktiveringTilstandMed(Status status) {

--- a/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/BrukersTilstand.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/BrukersTilstand.java
@@ -20,10 +20,10 @@ public class BrukersTilstand implements HasMetrics {
     private final RegistreringType registreringType;
     private final Oppfolgingsstatus oppfolgingStatusData;
 
-    public BrukersTilstand(Oppfolgingsstatus Oppfolgingsstatus, SykmeldtInfoData sykmeldtInfoData, RegistreringType registreringType) {
+    public BrukersTilstand(Oppfolgingsstatus Oppfolgingsstatus, SykmeldtInfoData sykmeldtInfoData) {
         this.oppfolgingStatusData = Oppfolgingsstatus;
         this.sykmeldtInfoData = sykmeldtInfoData;
-        this.registreringType = registreringType;
+        this.registreringType = beregnRegistreringType(Oppfolgingsstatus, sykmeldtInfoData);;
     }
 
     public boolean kanReaktiveres() {

--- a/src/test/java/no/nav/fo/veilarbregistrering/registrering/resources/StartRegistreringStatusDtoMapperTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/registrering/resources/StartRegistreringStatusDtoMapperTest.java
@@ -28,7 +28,7 @@ public class StartRegistreringStatusDtoMapperTest {
                 null,
                 null);
         SykmeldtInfoData sykmeldtInfoData = new SykmeldtInfoData(null, false);
-        BrukersTilstand brukersTilstand = new BrukersTilstand(oppfolgingsstatus, sykmeldtInfoData, ORDINAER_REGISTRERING);
+        BrukersTilstand brukersTilstand = new BrukersTilstand(oppfolgingsstatus, sykmeldtInfoData);
 
         StartRegistreringStatusDto dto = StartRegistreringStatusDtoMapper.map(
                 brukersTilstand,
@@ -53,14 +53,14 @@ public class StartRegistreringStatusDtoMapperTest {
     @Test
     public void map_skal_håndtere_verdi_i_alle_felter() {
         Oppfolgingsstatus oppfolgingsstatus = new Oppfolgingsstatus(
-                true,
-                true,
+                false,
+                false,
                 true,
                 Formidlingsgruppe.of("IARBS"),
                 Servicegruppe.of("SERV"),
                 Rettighetsgruppe.of("AAP"));
         SykmeldtInfoData sykmeldtInfoData = new SykmeldtInfoData("01122019", true);
-        BrukersTilstand brukersTilstand = new BrukersTilstand(oppfolgingsstatus, sykmeldtInfoData, SYKMELDT_REGISTRERING);
+        BrukersTilstand brukersTilstand = new BrukersTilstand(oppfolgingsstatus, sykmeldtInfoData);
 
         StartRegistreringStatusDto dto = StartRegistreringStatusDtoMapper.map(
                 brukersTilstand,
@@ -73,7 +73,7 @@ public class StartRegistreringStatusDtoMapperTest {
         softAssertions.assertThat(dto.getGeografiskTilknytning()).isEqualTo("030109");
         softAssertions.assertThat(dto.getJobbetSeksAvTolvSisteManeder()).isTrue();
         softAssertions.assertThat(dto.isErSykmeldtMedArbeidsgiver()).isTrue();
-        softAssertions.assertThat(dto.isUnderOppfolging()).isTrue();
+        softAssertions.assertThat(dto.isUnderOppfolging()).isFalse();
         softAssertions.assertThat(dto.getFormidlingsgruppe()).isEqualTo("IARBS");
         softAssertions.assertThat(dto.getMaksDato()).isEqualTo("01122019");
         softAssertions.assertThat(dto.getRettighetsgruppe()).isEqualTo("AAP");
@@ -92,7 +92,7 @@ public class StartRegistreringStatusDtoMapperTest {
                 Servicegruppe.of("SERV"),
                 Rettighetsgruppe.of("AAP"));
         SykmeldtInfoData sykmeldtInfoData = new SykmeldtInfoData("01122019", true);
-        BrukersTilstand brukersTilstand = new BrukersTilstand(oppfolgingsstatus, sykmeldtInfoData, SYKMELDT_REGISTRERING);
+        BrukersTilstand brukersTilstand = new BrukersTilstand(oppfolgingsstatus, sykmeldtInfoData);
 
         StartRegistreringStatusDto dto = StartRegistreringStatusDtoMapper.map(
                 brukersTilstand,


### PR DESCRIPTION
Flytter beregning av registreringstype til BrukerTilstand, da denne ikke trengs å utledes på utsiden, for deretter å sendes inn. Den kan heller utledes på innsiden, med verdiene som allerede er gitt.