### PR TITLE
Trekker ut hentRegistrering til egen service

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -109,7 +109,7 @@ jobs:
       env:
         APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
         CLUSTER: prod-fss
-        DRY_RUN: false
+        DRY_RUN: true
         RESOURCE: nais/nais.yaml
         VARS: nais/vars-p.yaml
 

--- a/src/main/java/no/nav/fo/veilarbregistrering/config/ServiceBeansConfig.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/config/ServiceBeansConfig.java
@@ -30,6 +30,7 @@ import no.nav.fo.veilarbregistrering.registrering.manuell.ManuellRegistreringSer
 import no.nav.fo.veilarbregistrering.registrering.resources.InternalRegistreringStatusServlet;
 import no.nav.fo.veilarbregistrering.registrering.resources.InternalRegistreringStatusoversiktServlet;
 import no.nav.fo.veilarbregistrering.registrering.resources.RegistreringResource;
+import no.nav.fo.veilarbregistrering.registrering.scheduler.PubliseringAvHistorikkTask;
 import no.nav.fo.veilarbregistrering.sykemelding.SykemeldingGateway;
 import no.nav.fo.veilarbregistrering.sykemelding.SykemeldingService;
 import no.nav.fo.veilarbregistrering.sykemelding.resources.SykemeldingResource;
@@ -50,6 +51,17 @@ public class ServiceBeansConfig {
     }
 
     @Bean
+    HentRegistreringService hentRegistreringService(
+            BrukerRegistreringRepository brukerRegistreringRepository,
+            ProfileringRepository profileringRepository,
+            ManuellRegistreringService manuellRegistreringService) {
+        return new HentRegistreringService(
+                brukerRegistreringRepository,
+                profileringRepository,
+                manuellRegistreringService);
+    }
+
+    @Bean
     BrukerRegistreringService registrerBrukerService(
             BrukerRegistreringRepository brukerRegistreringRepository,
             ProfileringRepository profileringRepository,
@@ -57,7 +69,6 @@ public class ServiceBeansConfig {
             PersonGateway personGateway,
             SykemeldingService sykemeldingService,
             ArbeidsforholdGateway arbeidsforholdGateway,
-            ManuellRegistreringService manuellRegistreringService,
             StartRegistreringUtils startRegistreringUtils,
             ArbeidssokerRegistrertProducer arbeidssokerRegistrertProducer,
             ArbeidssokerProfilertProducer arbeidssokerProfilertProducer,
@@ -70,7 +81,6 @@ public class ServiceBeansConfig {
                 personGateway,
                 sykemeldingService,
                 arbeidsforholdGateway,
-                manuellRegistreringService,
                 startRegistreringUtils,
                 arbeidssokerRegistrertProducer,
                 arbeidssokerProfilertProducer,
@@ -96,6 +106,7 @@ public class ServiceBeansConfig {
             UserService userService,
             ManuellRegistreringService manuellRegistreringService,
             BrukerRegistreringService brukerRegistreringService,
+            HentRegistreringService hentRegistreringService,
             UnleashService unleashService
     ) {
         return new RegistreringResource(
@@ -103,6 +114,7 @@ public class ServiceBeansConfig {
                 userService,
                 manuellRegistreringService,
                 brukerRegistreringService,
+                hentRegistreringService,
                 unleashService
         );
     }

--- a/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/BrukerRegistreringService.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/BrukerRegistreringService.java
@@ -11,8 +11,6 @@ import no.nav.fo.veilarbregistrering.oppfolging.Oppfolgingsstatus;
 import no.nav.fo.veilarbregistrering.profilering.Profilering;
 import no.nav.fo.veilarbregistrering.profilering.ProfileringRepository;
 import no.nav.fo.veilarbregistrering.profilering.StartRegistreringUtils;
-import no.nav.fo.veilarbregistrering.registrering.manuell.ManuellRegistreringService;
-import no.nav.fo.veilarbregistrering.registrering.manuell.Veileder;
 import no.nav.fo.veilarbregistrering.registrering.resources.RegistreringTilstandDto;
 import no.nav.fo.veilarbregistrering.registrering.resources.StartRegistreringStatusDto;
 import no.nav.fo.veilarbregistrering.sykemelding.SykemeldingService;
@@ -45,7 +43,6 @@ public class BrukerRegistreringService {
     private final ArbeidssokerRegistrertProducer arbeidssokerRegistrertProducer;
     private final OppfolgingGateway oppfolgingGateway;
     private final ArbeidsforholdGateway arbeidsforholdGateway;
-    private final ManuellRegistreringService manuellRegistreringService;
     private final StartRegistreringUtils startRegistreringUtils;
     private final ArbeidssokerProfilertProducer arbeidssokerProfilertProducer;
     private final AktiveringTilstandRepository aktiveringTilstandRepository;
@@ -56,7 +53,6 @@ public class BrukerRegistreringService {
                                      PersonGateway personGateway,
                                      SykemeldingService sykemeldingService,
                                      ArbeidsforholdGateway arbeidsforholdGateway,
-                                     ManuellRegistreringService manuellRegistreringService,
                                      StartRegistreringUtils startRegistreringUtils,
                                      ArbeidssokerRegistrertProducer arbeidssokerRegistrertProducer,
                                      ArbeidssokerProfilertProducer arbeidssokerProfilertProducer,
@@ -67,7 +63,6 @@ public class BrukerRegistreringService {
         this.oppfolgingGateway = oppfolgingGateway;
         this.sykemeldingService = sykemeldingService;
         this.arbeidsforholdGateway = arbeidsforholdGateway;
-        this.manuellRegistreringService = manuellRegistreringService;
         this.startRegistreringUtils = startRegistreringUtils;
         this.arbeidssokerRegistrertProducer = arbeidssokerRegistrertProducer;
         this.arbeidssokerProfilertProducer = arbeidssokerProfilertProducer;
@@ -192,39 +187,6 @@ public class BrukerRegistreringService {
                 fnr.alder(now()),
                 () -> arbeidsforholdGateway.hentArbeidsforhold(fnr),
                 now(), besvarelse);
-    }
-
-    public OrdinaerBrukerRegistrering hentOrdinaerBrukerRegistrering(Bruker bruker) {
-        OrdinaerBrukerRegistrering ordinaerBrukerRegistrering = brukerRegistreringRepository
-                .hentOrdinaerBrukerregistreringForAktorId(bruker.getAktorId());
-
-        if (ordinaerBrukerRegistrering == null) {
-            return null;
-        }
-
-        Profilering profilering = profileringRepository.hentProfileringForId(
-                ordinaerBrukerRegistrering.getId());
-        ordinaerBrukerRegistrering.setProfilering(profilering);
-
-        Veileder veileder = manuellRegistreringService.hentManuellRegistreringVeileder(
-                ordinaerBrukerRegistrering.getId(), ordinaerBrukerRegistrering.hentType());
-        ordinaerBrukerRegistrering.setManueltRegistrertAv(veileder);
-
-        return ordinaerBrukerRegistrering;
-    }
-
-    public SykmeldtRegistrering hentSykmeldtRegistrering(Bruker bruker) {
-        SykmeldtRegistrering sykmeldtBrukerRegistrering = brukerRegistreringRepository
-                .hentSykmeldtregistreringForAktorId(bruker.getAktorId());
-
-        if (sykmeldtBrukerRegistrering == null) {
-            return null;
-        }
-        Veileder veileder = manuellRegistreringService.hentManuellRegistreringVeileder(
-                sykmeldtBrukerRegistrering.getId(), sykmeldtBrukerRegistrering.hentType());
-        sykmeldtBrukerRegistrering.setManueltRegistrertAv(veileder);
-
-        return sykmeldtBrukerRegistrering;
     }
 
     @Transactional

--- a/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/HentRegistreringService.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/HentRegistreringService.java
@@ -1,0 +1,56 @@
+package no.nav.fo.veilarbregistrering.registrering.bruker;
+
+import no.nav.fo.veilarbregistrering.bruker.Bruker;
+import no.nav.fo.veilarbregistrering.profilering.Profilering;
+import no.nav.fo.veilarbregistrering.profilering.ProfileringRepository;
+import no.nav.fo.veilarbregistrering.registrering.manuell.ManuellRegistreringService;
+import no.nav.fo.veilarbregistrering.registrering.manuell.Veileder;
+
+public class HentRegistreringService {
+
+    private BrukerRegistreringRepository brukerRegistreringRepository;
+    private ProfileringRepository profileringRepository;
+    private ManuellRegistreringService manuellRegistreringService;
+
+    public HentRegistreringService(
+            BrukerRegistreringRepository brukerRegistreringRepository,
+            ProfileringRepository profileringRepository,
+            ManuellRegistreringService manuellRegistreringService) {
+        this.brukerRegistreringRepository = brukerRegistreringRepository;
+        this.profileringRepository = profileringRepository;
+        this.manuellRegistreringService = manuellRegistreringService;
+    }
+
+    public OrdinaerBrukerRegistrering hentOrdinaerBrukerRegistrering(Bruker bruker) {
+        OrdinaerBrukerRegistrering ordinaerBrukerRegistrering = brukerRegistreringRepository
+                .hentOrdinaerBrukerregistreringForAktorId(bruker.getAktorId());
+
+        if (ordinaerBrukerRegistrering == null) {
+            return null;
+        }
+
+        Profilering profilering = profileringRepository.hentProfileringForId(
+                ordinaerBrukerRegistrering.getId());
+        ordinaerBrukerRegistrering.setProfilering(profilering);
+
+        Veileder veileder = manuellRegistreringService.hentManuellRegistreringVeileder(
+                ordinaerBrukerRegistrering.getId(), ordinaerBrukerRegistrering.hentType());
+        ordinaerBrukerRegistrering.setManueltRegistrertAv(veileder);
+
+        return ordinaerBrukerRegistrering;
+    }
+
+    public SykmeldtRegistrering hentSykmeldtRegistrering(Bruker bruker) {
+        SykmeldtRegistrering sykmeldtBrukerRegistrering = brukerRegistreringRepository
+                .hentSykmeldtregistreringForAktorId(bruker.getAktorId());
+
+        if (sykmeldtBrukerRegistrering == null) {
+            return null;
+        }
+        Veileder veileder = manuellRegistreringService.hentManuellRegistreringVeileder(
+                sykmeldtBrukerRegistrering.getId(), sykmeldtBrukerRegistrering.hentType());
+        sykmeldtBrukerRegistrering.setManueltRegistrertAv(veileder);
+
+        return sykmeldtBrukerRegistrering;
+    }
+}

--- a/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/PubliseringAvEventsService.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/PubliseringAvEventsService.java
@@ -33,10 +33,10 @@ public class PubliseringAvEventsService {
     }
 
     @Transactional
-    public void utforPublisering() {
+    public void publiserEvents() {
         Optional<AktiveringTilstand> muligRegistreringTilstand = aktiveringTilstandRepository.finnNesteAktiveringTilstandForOverforing();
         if (!muligRegistreringTilstand.isPresent()) {
-            LOG.info("Ingen registreringer klare (status = MOTTATT) for overføring");
+            LOG.info("Ingen registreringer klare (status = OVERFOERT_ARENA_OK) for publisering av events");
             return;
         }
 

--- a/src/main/java/no/nav/fo/veilarbregistrering/registrering/resources/RegistreringResource.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/registrering/resources/RegistreringResource.java
@@ -40,6 +40,7 @@ public class RegistreringResource {
 
     private final UnleashService unleashService;
     private final BrukerRegistreringService brukerRegistreringService;
+    private final HentRegistreringService hentRegistreringService;
     private final UserService userService;
     private final ManuellRegistreringService manuellRegistreringService;
     private final VeilarbAbacPepClient pepClient;
@@ -49,12 +50,13 @@ public class RegistreringResource {
             UserService userService,
             ManuellRegistreringService manuellRegistreringService,
             BrukerRegistreringService brukerRegistreringService,
-            UnleashService unleashService
+            HentRegistreringService hentRegistreringService, UnleashService unleashService
     ) {
         this.pepClient = pepClient;
         this.userService = userService;
         this.manuellRegistreringService = manuellRegistreringService;
         this.brukerRegistreringService = brukerRegistreringService;
+        this.hentRegistreringService = hentRegistreringService;
         this.unleashService = unleashService;
     }
 
@@ -116,8 +118,8 @@ public class RegistreringResource {
 
         pepClient.sjekkLesetilgangTilBruker(map(bruker));
 
-        OrdinaerBrukerRegistrering ordinaerBrukerRegistrering = brukerRegistreringService.hentOrdinaerBrukerRegistrering(bruker);
-        SykmeldtRegistrering sykmeldtBrukerRegistrering = brukerRegistreringService.hentSykmeldtRegistrering(bruker);
+        OrdinaerBrukerRegistrering ordinaerBrukerRegistrering = hentRegistreringService.hentOrdinaerBrukerRegistrering(bruker);
+        SykmeldtRegistrering sykmeldtBrukerRegistrering = hentRegistreringService.hentSykmeldtRegistrering(bruker);
 
         BrukerRegistreringWrapper brukerRegistreringWrapper = BrukerRegistreringWrapperFactory.create(ordinaerBrukerRegistrering, sykmeldtBrukerRegistrering);
         if (brukerRegistreringWrapper == null) {

--- a/src/main/java/no/nav/fo/veilarbregistrering/registrering/scheduler/PubliseringAvHistorikkTask.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/registrering/scheduler/PubliseringAvHistorikkTask.java
@@ -1,6 +1,9 @@
-package no.nav.fo.veilarbregistrering.registrering.bruker;
+package no.nav.fo.veilarbregistrering.registrering.scheduler;
 
 import no.nav.common.leaderelection.LeaderElection;
+import no.nav.fo.veilarbregistrering.registrering.bruker.ArbeidssokerRegistrertInternalEvent;
+import no.nav.fo.veilarbregistrering.registrering.bruker.ArbeidssokerRegistrertProducer;
+import no.nav.fo.veilarbregistrering.registrering.bruker.BrukerRegistreringRepository;
 import no.nav.sbl.featuretoggle.unleash.UnleashService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/test/java/no/nav/fo/veilarbregistrering/oppfolging/adapter/OppfolgingClientTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/oppfolging/adapter/OppfolgingClientTest.java
@@ -3,14 +3,16 @@ package no.nav.fo.veilarbregistrering.oppfolging.adapter;
 import com.google.common.net.MediaType;
 import no.nav.common.oidc.SystemUserTokenProvider;
 import no.nav.fo.veilarbregistrering.arbeidsforhold.ArbeidsforholdGateway;
-import no.nav.fo.veilarbregistrering.bruker.*;
+import no.nav.fo.veilarbregistrering.bruker.AktorId;
+import no.nav.fo.veilarbregistrering.bruker.Bruker;
+import no.nav.fo.veilarbregistrering.bruker.Foedselsnummer;
+import no.nav.fo.veilarbregistrering.bruker.PersonGateway;
 import no.nav.fo.veilarbregistrering.config.GammelSystemUserTokenProvider;
 import no.nav.fo.veilarbregistrering.profilering.Innsatsgruppe;
 import no.nav.fo.veilarbregistrering.profilering.Profilering;
 import no.nav.fo.veilarbregistrering.profilering.ProfileringRepository;
 import no.nav.fo.veilarbregistrering.profilering.StartRegistreringUtils;
 import no.nav.fo.veilarbregistrering.registrering.bruker.*;
-import no.nav.fo.veilarbregistrering.registrering.manuell.ManuellRegistreringService;
 import no.nav.fo.veilarbregistrering.sykemelding.SykemeldingService;
 import no.nav.fo.veilarbregistrering.sykemelding.adapter.SykemeldingGatewayImpl;
 import no.nav.fo.veilarbregistrering.sykemelding.adapter.SykmeldtInfoClient;
@@ -67,7 +69,6 @@ class OppfolgingClientTest {
         arbeidsforholdGateway = mock(ArbeidsforholdGateway.class);
         SykmeldtInfoClient sykeforloepMetadataClient = mock(SykmeldtInfoClient.class);
         startRegistreringUtils = mock(StartRegistreringUtils.class);
-        ManuellRegistreringService manuellRegistreringService = mock(ManuellRegistreringService.class);
         ArbeidssokerRegistrertProducer arbeidssokerRegistrertProducer = (event) -> {
         };
         ArbeidssokerProfilertProducer arbeidssokerProfilertProducer = (aktorId, innsatsgruppe, profilertDato) -> {
@@ -82,7 +83,6 @@ class OppfolgingClientTest {
                         personGateway,
                         new SykemeldingService(new SykemeldingGatewayImpl(sykeforloepMetadataClient)),
                         arbeidsforholdGateway,
-                        manuellRegistreringService,
                         startRegistreringUtils,
                         arbeidssokerRegistrertProducer,
                         arbeidssokerProfilertProducer,

--- a/src/test/java/no/nav/fo/veilarbregistrering/registrering/bruker/BrukerRegistreringServiceTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/registrering/bruker/BrukerRegistreringServiceTest.java
@@ -10,7 +10,6 @@ import no.nav.fo.veilarbregistrering.oppfolging.adapter.OppfolgingGatewayImpl;
 import no.nav.fo.veilarbregistrering.oppfolging.adapter.OppfolgingStatusData;
 import no.nav.fo.veilarbregistrering.profilering.ProfileringRepository;
 import no.nav.fo.veilarbregistrering.profilering.StartRegistreringUtils;
-import no.nav.fo.veilarbregistrering.registrering.manuell.ManuellRegistreringService;
 import no.nav.fo.veilarbregistrering.registrering.resources.RegistreringTilstandDto;
 import no.nav.fo.veilarbregistrering.registrering.resources.StartRegistreringStatusDto;
 import no.nav.fo.veilarbregistrering.sykemelding.SykemeldingService;
@@ -51,7 +50,6 @@ public class BrukerRegistreringServiceTest {
     public void setup() {
         brukerRegistreringRepository = mock(BrukerRegistreringRepository.class);
         ProfileringRepository profileringRepository = mock(ProfileringRepository.class);
-        ManuellRegistreringService manuellRegistreringService = mock(ManuellRegistreringService.class);
         oppfolgingClient = mock(OppfolgingClient.class);
         personGateway = mock(PersonGateway.class);
         sykeforloepMetadataClient = mock(SykmeldtInfoClient.class);
@@ -71,7 +69,6 @@ public class BrukerRegistreringServiceTest {
                         personGateway,
                         new SykemeldingService(new SykemeldingGatewayImpl(sykeforloepMetadataClient)),
                         arbeidsforholdGateway,
-                        manuellRegistreringService,
                         startRegistreringUtils,
                         arbeidssokerRegistrertProducer,
                         arbeidssokerProfilertProducer,

--- a/src/test/java/no/nav/fo/veilarbregistrering/registrering/resources/RegistreringResourceTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/registrering/resources/RegistreringResourceTest.java
@@ -10,6 +10,7 @@ import no.nav.fo.veilarbregistrering.bruker.Bruker;
 import no.nav.fo.veilarbregistrering.bruker.Foedselsnummer;
 import no.nav.fo.veilarbregistrering.bruker.UserService;
 import no.nav.fo.veilarbregistrering.registrering.bruker.BrukerRegistreringService;
+import no.nav.fo.veilarbregistrering.registrering.bruker.HentRegistreringService;
 import no.nav.fo.veilarbregistrering.registrering.bruker.OrdinaerBrukerRegistrering;
 import no.nav.fo.veilarbregistrering.registrering.bruker.SykmeldtRegistrering;
 import no.nav.fo.veilarbregistrering.registrering.manuell.ManuellRegistreringService;
@@ -27,6 +28,7 @@ public class RegistreringResourceTest {
     private RegistreringResource registreringResource;
     private UserService userService;
     private BrukerRegistreringService brukerRegistreringService;
+    private HentRegistreringService hentRegistreringService;
 
     private static String IDENT = "10108000398"; //Aremark fiktivt fnr.";
 
@@ -36,6 +38,7 @@ public class RegistreringResourceTest {
         userService = mock(UserService.class);
         ManuellRegistreringService manuellRegistreringService = mock(ManuellRegistreringService.class);
         brukerRegistreringService = mock(BrukerRegistreringService.class);
+        hentRegistreringService = mock(HentRegistreringService.class);
         UnleashService unleashService = mock(UnleashService.class);
 
         registreringResource = new RegistreringResource(
@@ -43,6 +46,7 @@ public class RegistreringResourceTest {
                 userService,
                 manuellRegistreringService,
                 brukerRegistreringService,
+                hentRegistreringService,
                 unleashService
         );
     }
@@ -66,8 +70,8 @@ public class RegistreringResourceTest {
 
     @Test
     public void skalSjekkeTilgangTilBrukerVedHentingAvRegistrering() {
-        when(brukerRegistreringService.hentOrdinaerBrukerRegistrering(any(Bruker.class))).thenReturn(gyldigBrukerRegistrering());
-        when(brukerRegistreringService.hentSykmeldtRegistrering(any(Bruker.class))).thenReturn(null);
+        when(hentRegistreringService.hentOrdinaerBrukerRegistrering(any(Bruker.class))).thenReturn(gyldigBrukerRegistrering());
+        when(hentRegistreringService.hentSykmeldtRegistrering(any(Bruker.class))).thenReturn(null);
         when(userService.finnBrukerGjennomPdl()).thenReturn(Bruker.of(Foedselsnummer.of(IDENT), AktorId.of("1234")));
         registreringResource.hentRegistrering();
         verify(pepClient, times(1)).sjekkLesetilgangTilBruker(any());

--- a/src/test/java/no/nav/fo/veilarbregistrering/sykemelding/adapter/SykmeldtInfoClientTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/sykemelding/adapter/SykmeldtInfoClientTest.java
@@ -12,7 +12,6 @@ import no.nav.fo.veilarbregistrering.oppfolging.adapter.OppfolgingGatewayImpl;
 import no.nav.fo.veilarbregistrering.profilering.ProfileringRepository;
 import no.nav.fo.veilarbregistrering.profilering.StartRegistreringUtils;
 import no.nav.fo.veilarbregistrering.registrering.bruker.*;
-import no.nav.fo.veilarbregistrering.registrering.manuell.ManuellRegistreringService;
 import no.nav.fo.veilarbregistrering.registrering.resources.StartRegistreringStatusDto;
 import no.nav.fo.veilarbregistrering.sykemelding.SykemeldingService;
 import org.junit.jupiter.api.AfterEach;
@@ -61,7 +60,6 @@ class SykmeldtInfoClientTest {
         ArbeidsforholdGateway arbeidsforholdGateway = mock(ArbeidsforholdGateway.class);
         sykeforloepMetadataClient = buildSykeForloepClient();
         StartRegistreringUtils startRegistreringUtils = mock(StartRegistreringUtils.class);
-        ManuellRegistreringService manuellRegistreringService = mock(ManuellRegistreringService.class);
         ArbeidssokerRegistrertProducer arbeidssokerRegistrertProducer = (event) -> {
         }; //Noop, vi trenger ikke kafka
         ArbeidssokerProfilertProducer arbeidssokerProfileringProducer = (aktorId, innsatsgruppe, profilertDato) -> {
@@ -76,7 +74,6 @@ class SykmeldtInfoClientTest {
                         personGateway,
                         new SykemeldingService(new SykemeldingGatewayImpl(sykeforloepMetadataClient)),
                         arbeidsforholdGateway,
-                        manuellRegistreringService,
                         startRegistreringUtils,
                         arbeidssokerRegistrertProducer,
                         arbeidssokerProfileringProducer,

--- a/src/test/java/no/nav/veilarbregistrering/integrasjonstest/BrukerRegistreringServiceIntegrationTest.java
+++ b/src/test/java/no/nav/veilarbregistrering/integrasjonstest/BrukerRegistreringServiceIntegrationTest.java
@@ -18,7 +18,6 @@ import no.nav.fo.veilarbregistrering.oppfolging.adapter.OppfolgingStatusData;
 import no.nav.fo.veilarbregistrering.profilering.ProfileringRepository;
 import no.nav.fo.veilarbregistrering.profilering.StartRegistreringUtils;
 import no.nav.fo.veilarbregistrering.registrering.bruker.*;
-import no.nav.fo.veilarbregistrering.registrering.manuell.ManuellRegistreringService;
 import no.nav.fo.veilarbregistrering.sykemelding.SykemeldingService;
 import no.nav.fo.veilarbregistrering.sykemelding.adapter.SykemeldingGatewayImpl;
 import no.nav.fo.veilarbregistrering.sykemelding.adapter.SykmeldtInfoClient;
@@ -143,11 +142,6 @@ class BrukerRegistreringServiceIntegrationTest {
         }
 
         @Bean
-        public ManuellRegistreringService manuellRegistreringService() {
-            return mock(ManuellRegistreringService.class);
-        }
-
-        @Bean
         public StartRegistreringUtils startRegistreringUtils() {
             return mock(StartRegistreringUtils.class);
         }
@@ -160,7 +154,6 @@ class BrukerRegistreringServiceIntegrationTest {
                 PersonGateway personGateway,
                 SykmeldtInfoClient sykeforloepMetadataClient,
                 ArbeidsforholdGateway arbeidsforholdGateway,
-                ManuellRegistreringService manuellRegistreringService,
                 StartRegistreringUtils startRegistreringUtils,
                 ArbeidssokerRegistrertProducer arbeidssokerRegistrertProducer,
                 ArbeidssokerProfilertProducer arbeidssokerProfilertProducer,
@@ -173,7 +166,6 @@ class BrukerRegistreringServiceIntegrationTest {
                     personGateway,
                     new SykemeldingService(new SykemeldingGatewayImpl(sykeforloepMetadataClient)),
                     arbeidsforholdGateway,
-                    manuellRegistreringService,
                     startRegistreringUtils,
                     arbeidssokerRegistrertProducer,
                     arbeidssokerProfilertProducer,


### PR DESCRIPTION
I et forsøk på å redusere kompleksiteten og omfanget til BrukerRegistreringService, forsøker jeg å dele opp ut fra "feature". Starter derfor med hentRegistrering som er relativt frittstående.

Etterpå kan vi vurdere om vi ønsker å flytte logikk fra ManuellRegistreringService - hypotesen er at den ikke nødvendigvis har livets rett.