### PR TITLE
Renamer StartRegistreringUtils -> ProfileringService

### DIFF
--- a/src/main/java/no/nav/fo/veilarbregistrering/config/ServiceBeansConfig.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/config/ServiceBeansConfig.java
@@ -23,7 +23,7 @@ import no.nav.fo.veilarbregistrering.oppgave.*;
 import no.nav.fo.veilarbregistrering.oppgave.resources.OppgaveResource;
 import no.nav.fo.veilarbregistrering.orgenhet.Norg2Gateway;
 import no.nav.fo.veilarbregistrering.profilering.ProfileringRepository;
-import no.nav.fo.veilarbregistrering.profilering.StartRegistreringUtils;
+import no.nav.fo.veilarbregistrering.profilering.ProfileringService;
 import no.nav.fo.veilarbregistrering.registrering.bruker.*;
 import no.nav.fo.veilarbregistrering.registrering.manuell.ManuellRegistreringRepository;
 import no.nav.fo.veilarbregistrering.registrering.manuell.ManuellRegistreringService;
@@ -69,7 +69,7 @@ public class ServiceBeansConfig {
             PersonGateway personGateway,
             SykemeldingService sykemeldingService,
             ArbeidsforholdGateway arbeidsforholdGateway,
-            StartRegistreringUtils startRegistreringUtils,
+            ProfileringService profileringService,
             ArbeidssokerRegistrertProducer arbeidssokerRegistrertProducer,
             ArbeidssokerProfilertProducer arbeidssokerProfilertProducer,
             AktiveringTilstandRepository aktiveringTilstandRepository
@@ -81,7 +81,7 @@ public class ServiceBeansConfig {
                 personGateway,
                 sykemeldingService,
                 arbeidsforholdGateway,
-                startRegistreringUtils,
+                profileringService,
                 arbeidssokerRegistrertProducer,
                 arbeidssokerProfilertProducer,
                 aktiveringTilstandRepository);
@@ -258,8 +258,8 @@ public class ServiceBeansConfig {
     }
 
     @Bean
-    StartRegistreringUtils startRegistreringUtils() {
-        return new StartRegistreringUtils();
+    ProfileringService profileringService() {
+        return new ProfileringService();
     }
 
     @Bean

--- a/src/main/java/no/nav/fo/veilarbregistrering/profilering/ProfileringService.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/profilering/ProfileringService.java
@@ -6,9 +6,8 @@ import no.nav.fo.veilarbregistrering.besvarelse.Besvarelse;
 import java.time.LocalDate;
 import java.util.function.Supplier;
 
-public class StartRegistreringUtils {
+public class ProfileringService {
 
-    //FIXME: Burde kunne være static
     public Profilering profilerBruker(
             int alder,
             Supplier<FlereArbeidsforhold> arbeidsforholdSupplier,

--- a/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/BrukerRegistreringService.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/BrukerRegistreringService.java
@@ -10,7 +10,7 @@ import no.nav.fo.veilarbregistrering.oppfolging.OppfolgingGateway;
 import no.nav.fo.veilarbregistrering.oppfolging.Oppfolgingsstatus;
 import no.nav.fo.veilarbregistrering.profilering.Profilering;
 import no.nav.fo.veilarbregistrering.profilering.ProfileringRepository;
-import no.nav.fo.veilarbregistrering.profilering.StartRegistreringUtils;
+import no.nav.fo.veilarbregistrering.profilering.ProfileringService;
 import no.nav.fo.veilarbregistrering.registrering.resources.RegistreringTilstandDto;
 import no.nav.fo.veilarbregistrering.registrering.resources.StartRegistreringStatusDto;
 import no.nav.fo.veilarbregistrering.sykemelding.SykemeldingService;
@@ -43,7 +43,7 @@ public class BrukerRegistreringService {
     private final ArbeidssokerRegistrertProducer arbeidssokerRegistrertProducer;
     private final OppfolgingGateway oppfolgingGateway;
     private final ArbeidsforholdGateway arbeidsforholdGateway;
-    private final StartRegistreringUtils startRegistreringUtils;
+    private final ProfileringService profileringService;
     private final ArbeidssokerProfilertProducer arbeidssokerProfilertProducer;
     private final AktiveringTilstandRepository aktiveringTilstandRepository;
 
@@ -53,7 +53,7 @@ public class BrukerRegistreringService {
                                      PersonGateway personGateway,
                                      SykemeldingService sykemeldingService,
                                      ArbeidsforholdGateway arbeidsforholdGateway,
-                                     StartRegistreringUtils startRegistreringUtils,
+                                     ProfileringService profileringService,
                                      ArbeidssokerRegistrertProducer arbeidssokerRegistrertProducer,
                                      ArbeidssokerProfilertProducer arbeidssokerProfilertProducer,
                                      AktiveringTilstandRepository aktiveringTilstandRepository) {
@@ -63,7 +63,7 @@ public class BrukerRegistreringService {
         this.oppfolgingGateway = oppfolgingGateway;
         this.sykemeldingService = sykemeldingService;
         this.arbeidsforholdGateway = arbeidsforholdGateway;
-        this.startRegistreringUtils = startRegistreringUtils;
+        this.profileringService = profileringService;
         this.arbeidssokerRegistrertProducer = arbeidssokerRegistrertProducer;
         this.arbeidssokerProfilertProducer = arbeidssokerProfilertProducer;
         this.aktiveringTilstandRepository = aktiveringTilstandRepository;
@@ -183,7 +183,7 @@ public class BrukerRegistreringService {
     }
 
     private Profilering profilerBrukerTilInnsatsgruppe(Foedselsnummer fnr, Besvarelse besvarelse) {
-        return startRegistreringUtils.profilerBruker(
+        return profileringService.profilerBruker(
                 fnr.alder(now()),
                 () -> arbeidsforholdGateway.hentArbeidsforhold(fnr),
                 now(), besvarelse);

--- a/src/test/java/no/nav/fo/veilarbregistrering/oppfolging/adapter/OppfolgingClientTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/oppfolging/adapter/OppfolgingClientTest.java
@@ -11,7 +11,7 @@ import no.nav.fo.veilarbregistrering.config.GammelSystemUserTokenProvider;
 import no.nav.fo.veilarbregistrering.profilering.Innsatsgruppe;
 import no.nav.fo.veilarbregistrering.profilering.Profilering;
 import no.nav.fo.veilarbregistrering.profilering.ProfileringRepository;
-import no.nav.fo.veilarbregistrering.profilering.StartRegistreringUtils;
+import no.nav.fo.veilarbregistrering.profilering.ProfileringService;
 import no.nav.fo.veilarbregistrering.registrering.bruker.*;
 import no.nav.fo.veilarbregistrering.sykemelding.SykemeldingService;
 import no.nav.fo.veilarbregistrering.sykemelding.adapter.SykemeldingGatewayImpl;
@@ -50,7 +50,7 @@ class OppfolgingClientTest {
     private BrukerRegistreringService brukerRegistreringService;
     private OppfolgingClient oppfolgingClient;
     private ArbeidsforholdGateway arbeidsforholdGateway;
-    private StartRegistreringUtils startRegistreringUtils;
+    private ProfileringService profileringService;
     private ClientAndServer mockServer;
 
     @AfterEach
@@ -68,7 +68,7 @@ class OppfolgingClientTest {
         ProfileringRepository profileringRepository = mock(ProfileringRepository.class);
         arbeidsforholdGateway = mock(ArbeidsforholdGateway.class);
         SykmeldtInfoClient sykeforloepMetadataClient = mock(SykmeldtInfoClient.class);
-        startRegistreringUtils = mock(StartRegistreringUtils.class);
+        profileringService = mock(ProfileringService.class);
         ArbeidssokerRegistrertProducer arbeidssokerRegistrertProducer = (event) -> {
         };
         ArbeidssokerProfilertProducer arbeidssokerProfilertProducer = (aktorId, innsatsgruppe, profilertDato) -> {
@@ -83,12 +83,12 @@ class OppfolgingClientTest {
                         personGateway,
                         new SykemeldingService(new SykemeldingGatewayImpl(sykeforloepMetadataClient)),
                         arbeidsforholdGateway,
-                        startRegistreringUtils,
+                        profileringService,
                         arbeidssokerRegistrertProducer,
                         arbeidssokerProfilertProducer,
                         aktiveringTilstandRepository);
 
-        when(startRegistreringUtils.profilerBruker(anyInt(), any(), any(), any()))
+        when(profileringService.profilerBruker(anyInt(), any(), any(), any()))
                 .thenReturn(new Profilering()
                         .setInnsatsgruppe(Innsatsgruppe.STANDARD_INNSATS)
                         .setAlder(50)
@@ -133,7 +133,7 @@ class OppfolgingClientTest {
     @Test
     public void testAtRegistreringGirOKDersomBrukerIkkeHarOppfolgingsflaggOgIkkeSkalReaktiveres() {
         when(brukerRegistreringRepository.lagre(any(), any())).thenReturn(new OrdinaerBrukerRegistrering());
-        when(startRegistreringUtils.profilerBruker(anyInt(), any(), any(), any())).thenReturn(lagProfilering());
+        when(profileringService.profilerBruker(anyInt(), any(), any(), any())).thenReturn(lagProfilering());
         mockServer.when(request().withMethod("GET").withPath("/oppfolging"))
                 .respond(response().withBody(settOppfolgingOgReaktivering(false, false), MediaType.JSON_UTF_8).withStatusCode(200));
         mockServer.when(request().withMethod("POST").withPath("/oppfolging/aktiverbruker")).respond(response().withStatusCode(204).withBody(okRegistreringBody(), MediaType.JSON_UTF_8));

--- a/src/test/java/no/nav/fo/veilarbregistrering/profilering/ProfileringServiceTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/profilering/ProfileringServiceTest.java
@@ -17,9 +17,9 @@ import static java.time.LocalDate.now;
 import static no.nav.fo.veilarbregistrering.profilering.Innsatsgruppe.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-class StartRegistreringUtilsTest {
+class ProfileringServiceTest {
 
-    private StartRegistreringUtils startRegistreringUtils = new StartRegistreringUtils();
+    private ProfileringService profileringService = new ProfileringService();
 
     @Test
     void testProfilering() {
@@ -83,7 +83,7 @@ class StartRegistreringUtilsTest {
             LocalDate dagensDato, Besvarelse besvarelse
     ) {
 
-        Innsatsgruppe innsatsgruppe = startRegistreringUtils.profilerBruker(
+        Innsatsgruppe innsatsgruppe = profileringService.profilerBruker(
                 alder,
                 arbeidsforholdSupplier,
                 dagensDato, besvarelse
@@ -110,7 +110,7 @@ class StartRegistreringUtilsTest {
 
     @Test
     void testIKVALBesvarelseMellom30Og59Aar() {
-        Innsatsgruppe innsatsgruppe = new StartRegistreringUtils().profilerBruker(
+        Innsatsgruppe innsatsgruppe = new ProfileringService().profilerBruker(
                 35,
                 () -> getArbeidsforholdList(true),
                 now(),
@@ -121,7 +121,7 @@ class StartRegistreringUtilsTest {
 
     @Test
     void testBFORMBesvarelseOver59Aar() {
-        Innsatsgruppe innsatsgruppe = new StartRegistreringUtils().profilerBruker(
+        Innsatsgruppe innsatsgruppe = new ProfileringService().profilerBruker(
                 60,
                 () -> getArbeidsforholdList(true),
                 now(),
@@ -132,7 +132,7 @@ class StartRegistreringUtilsTest {
 
     @Test
     void testBKARTBesvarelse() {
-        Innsatsgruppe innsatsgruppe = new StartRegistreringUtils().profilerBruker(
+        Innsatsgruppe innsatsgruppe = new ProfileringService().profilerBruker(
                 40,
                 () -> getArbeidsforholdList(true),
                 now(),

--- a/src/test/java/no/nav/fo/veilarbregistrering/registrering/bruker/BrukerRegistreringServiceTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/registrering/bruker/BrukerRegistreringServiceTest.java
@@ -9,7 +9,7 @@ import no.nav.fo.veilarbregistrering.oppfolging.adapter.OppfolgingClient;
 import no.nav.fo.veilarbregistrering.oppfolging.adapter.OppfolgingGatewayImpl;
 import no.nav.fo.veilarbregistrering.oppfolging.adapter.OppfolgingStatusData;
 import no.nav.fo.veilarbregistrering.profilering.ProfileringRepository;
-import no.nav.fo.veilarbregistrering.profilering.StartRegistreringUtils;
+import no.nav.fo.veilarbregistrering.profilering.ProfileringService;
 import no.nav.fo.veilarbregistrering.registrering.resources.RegistreringTilstandDto;
 import no.nav.fo.veilarbregistrering.registrering.resources.StartRegistreringStatusDto;
 import no.nav.fo.veilarbregistrering.sykemelding.SykemeldingService;
@@ -54,7 +54,7 @@ public class BrukerRegistreringServiceTest {
         personGateway = mock(PersonGateway.class);
         sykeforloepMetadataClient = mock(SykmeldtInfoClient.class);
         arbeidsforholdGateway = mock(ArbeidsforholdGateway.class);
-        StartRegistreringUtils startRegistreringUtils = new StartRegistreringUtils();
+        ProfileringService profileringService = new ProfileringService();
         ArbeidssokerRegistrertProducer arbeidssokerRegistrertProducer = (event) -> {
         }; //NoOp siden vi ikke ønsker å teste Kafka her
         ArbeidssokerProfilertProducer arbeidssokerProfilertProducer = (aktorId, innsatsgruppe, profilertDato) -> {
@@ -69,7 +69,7 @@ public class BrukerRegistreringServiceTest {
                         personGateway,
                         new SykemeldingService(new SykemeldingGatewayImpl(sykeforloepMetadataClient)),
                         arbeidsforholdGateway,
-                        startRegistreringUtils,
+                        profileringService,
                         arbeidssokerRegistrertProducer,
                         arbeidssokerProfilertProducer,
                         aktiveringTilstandRepository);

--- a/src/test/java/no/nav/fo/veilarbregistrering/sykemelding/adapter/SykmeldtInfoClientTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/sykemelding/adapter/SykmeldtInfoClientTest.java
@@ -10,7 +10,7 @@ import no.nav.fo.veilarbregistrering.bruker.PersonGateway;
 import no.nav.fo.veilarbregistrering.oppfolging.adapter.OppfolgingClient;
 import no.nav.fo.veilarbregistrering.oppfolging.adapter.OppfolgingGatewayImpl;
 import no.nav.fo.veilarbregistrering.profilering.ProfileringRepository;
-import no.nav.fo.veilarbregistrering.profilering.StartRegistreringUtils;
+import no.nav.fo.veilarbregistrering.profilering.ProfileringService;
 import no.nav.fo.veilarbregistrering.registrering.bruker.*;
 import no.nav.fo.veilarbregistrering.registrering.resources.StartRegistreringStatusDto;
 import no.nav.fo.veilarbregistrering.sykemelding.SykemeldingService;
@@ -59,7 +59,7 @@ class SykmeldtInfoClientTest {
         ProfileringRepository profileringRepository = mock(ProfileringRepository.class);
         ArbeidsforholdGateway arbeidsforholdGateway = mock(ArbeidsforholdGateway.class);
         sykeforloepMetadataClient = buildSykeForloepClient();
-        StartRegistreringUtils startRegistreringUtils = mock(StartRegistreringUtils.class);
+        ProfileringService profileringService = mock(ProfileringService.class);
         ArbeidssokerRegistrertProducer arbeidssokerRegistrertProducer = (event) -> {
         }; //Noop, vi trenger ikke kafka
         ArbeidssokerProfilertProducer arbeidssokerProfileringProducer = (aktorId, innsatsgruppe, profilertDato) -> {
@@ -74,7 +74,7 @@ class SykmeldtInfoClientTest {
                         personGateway,
                         new SykemeldingService(new SykemeldingGatewayImpl(sykeforloepMetadataClient)),
                         arbeidsforholdGateway,
-                        startRegistreringUtils,
+                        profileringService,
                         arbeidssokerRegistrertProducer,
                         arbeidssokerProfileringProducer,
                         aktiveringTilstandRepository);

--- a/src/test/java/no/nav/veilarbregistrering/integrasjonstest/BrukerRegistreringServiceIntegrationTest.java
+++ b/src/test/java/no/nav/veilarbregistrering/integrasjonstest/BrukerRegistreringServiceIntegrationTest.java
@@ -16,7 +16,7 @@ import no.nav.fo.veilarbregistrering.oppfolging.adapter.OppfolgingClient;
 import no.nav.fo.veilarbregistrering.oppfolging.adapter.OppfolgingGatewayImpl;
 import no.nav.fo.veilarbregistrering.oppfolging.adapter.OppfolgingStatusData;
 import no.nav.fo.veilarbregistrering.profilering.ProfileringRepository;
-import no.nav.fo.veilarbregistrering.profilering.StartRegistreringUtils;
+import no.nav.fo.veilarbregistrering.profilering.ProfileringService;
 import no.nav.fo.veilarbregistrering.registrering.bruker.*;
 import no.nav.fo.veilarbregistrering.sykemelding.SykemeldingService;
 import no.nav.fo.veilarbregistrering.sykemelding.adapter.SykemeldingGatewayImpl;
@@ -46,7 +46,7 @@ class BrukerRegistreringServiceIntegrationTest {
     private static BrukerRegistreringService brukerRegistreringService;
     private static OppfolgingClient oppfolgingClient;
     private static BrukerRegistreringRepository brukerRegistreringRepository;
-    private static StartRegistreringUtils startRegistreringUtils;
+    private static ProfileringService profileringService;
 
     private static final Foedselsnummer ident = Foedselsnummer.of("10108000398"); //Aremark fiktivt fnr.";
     private static final Bruker BRUKER = Bruker.of(ident, AktorId.of("AKTØRID"));
@@ -68,7 +68,7 @@ class BrukerRegistreringServiceIntegrationTest {
         brukerRegistreringRepository = context.getBean(BrukerRegistreringRepositoryImpl.class);
         brukerRegistreringService = context.getBean(BrukerRegistreringService.class);
         oppfolgingClient = context.getBean(OppfolgingClient.class);
-        startRegistreringUtils = context.getBean(StartRegistreringUtils.class);
+        profileringService = context.getBean(ProfileringService.class);
     }
 
     @AfterEach
@@ -101,7 +101,7 @@ class BrukerRegistreringServiceIntegrationTest {
 
     private void cofigureMocks() {
         when(oppfolgingClient.hentOppfolgingsstatus(any())).thenReturn(new OppfolgingStatusData().withUnderOppfolging(false).withKanReaktiveres(false));
-        when(startRegistreringUtils.profilerBruker(anyInt(), any(), any(), any())).thenReturn(lagProfilering());
+        when(profileringService.profilerBruker(anyInt(), any(), any(), any())).thenReturn(lagProfilering());
     }
 
     @Configuration
@@ -142,8 +142,8 @@ class BrukerRegistreringServiceIntegrationTest {
         }
 
         @Bean
-        public StartRegistreringUtils startRegistreringUtils() {
-            return mock(StartRegistreringUtils.class);
+        public ProfileringService startRegistreringUtils() {
+            return mock(ProfileringService.class);
         }
 
         @Bean
@@ -154,7 +154,7 @@ class BrukerRegistreringServiceIntegrationTest {
                 PersonGateway personGateway,
                 SykmeldtInfoClient sykeforloepMetadataClient,
                 ArbeidsforholdGateway arbeidsforholdGateway,
-                StartRegistreringUtils startRegistreringUtils,
+                ProfileringService profileringService,
                 ArbeidssokerRegistrertProducer arbeidssokerRegistrertProducer,
                 ArbeidssokerProfilertProducer arbeidssokerProfilertProducer,
                 AktiveringTilstandRepository aktiveringTilstandRepository) {
@@ -166,7 +166,7 @@ class BrukerRegistreringServiceIntegrationTest {
                     personGateway,
                     new SykemeldingService(new SykemeldingGatewayImpl(sykeforloepMetadataClient)),
                     arbeidsforholdGateway,
-                    startRegistreringUtils,
+                    profileringService,
                     arbeidssokerRegistrertProducer,
                     arbeidssokerProfilertProducer,
                     aktiveringTilstandRepository);


### PR DESCRIPTION
Planen er å gi denne større ansvar, slik at mer logikk kan flyttes ut fra BrukerRegistreringService. Dette for å kunne innramme Profilering bedre, og gjøre testingen enklere.