### PR TITLE
Trekker ut hentBrukerTilstand i egen service

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -109,7 +109,7 @@ jobs:
       env:
         APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
         CLUSTER: prod-fss
-        DRY_RUN: false
+        DRY_RUN: true
         RESOURCE: nais/nais.yaml
         VARS: nais/vars-p.yaml
 

--- a/src/main/java/no/nav/fo/veilarbregistrering/config/ServiceBeansConfig.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/config/ServiceBeansConfig.java
@@ -62,29 +62,35 @@ public class ServiceBeansConfig {
     }
 
     @Bean
+    HentBrukerTilstandService hentBrukerTilstandService(
+            OppfolgingGateway oppfolgingGateway,
+            SykemeldingService sykemeldingService) {
+        return new HentBrukerTilstandService(oppfolgingGateway, sykemeldingService);
+    }
+
+    @Bean
     BrukerRegistreringService registrerBrukerService(
             BrukerRegistreringRepository brukerRegistreringRepository,
             ProfileringRepository profileringRepository,
             OppfolgingGateway oppfolgingGateway,
             PersonGateway personGateway,
-            SykemeldingService sykemeldingService,
             ArbeidsforholdGateway arbeidsforholdGateway,
             ProfileringService profileringService,
             ArbeidssokerRegistrertProducer arbeidssokerRegistrertProducer,
             ArbeidssokerProfilertProducer arbeidssokerProfilertProducer,
-            AktiveringTilstandRepository aktiveringTilstandRepository
-    ) {
+            AktiveringTilstandRepository aktiveringTilstandRepository,
+            HentBrukerTilstandService hentBrukerTilstandService) {
         return new BrukerRegistreringService(
                 brukerRegistreringRepository,
                 profileringRepository,
                 oppfolgingGateway,
                 personGateway,
-                sykemeldingService,
                 arbeidsforholdGateway,
                 profileringService,
                 arbeidssokerRegistrertProducer,
                 arbeidssokerProfilertProducer,
-                aktiveringTilstandRepository);
+                aktiveringTilstandRepository,
+                hentBrukerTilstandService);
     }
 
     @Bean

--- a/src/main/java/no/nav/fo/veilarbregistrering/config/ServiceBeansConfig.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/config/ServiceBeansConfig.java
@@ -62,10 +62,10 @@ public class ServiceBeansConfig {
     }
 
     @Bean
-    HentBrukerTilstandService hentBrukerTilstandService(
+    BrukerTilstandService brukerTilstandService(
             OppfolgingGateway oppfolgingGateway,
             SykemeldingService sykemeldingService) {
-        return new HentBrukerTilstandService(oppfolgingGateway, sykemeldingService);
+        return new BrukerTilstandService(oppfolgingGateway, sykemeldingService);
     }
 
     @Bean
@@ -79,7 +79,7 @@ public class ServiceBeansConfig {
             ArbeidssokerRegistrertProducer arbeidssokerRegistrertProducer,
             ArbeidssokerProfilertProducer arbeidssokerProfilertProducer,
             AktiveringTilstandRepository aktiveringTilstandRepository,
-            HentBrukerTilstandService hentBrukerTilstandService) {
+            BrukerTilstandService brukerTilstandService) {
         return new BrukerRegistreringService(
                 brukerRegistreringRepository,
                 profileringRepository,
@@ -90,7 +90,7 @@ public class ServiceBeansConfig {
                 arbeidssokerRegistrertProducer,
                 arbeidssokerProfilertProducer,
                 aktiveringTilstandRepository,
-                hentBrukerTilstandService);
+                brukerTilstandService);
     }
 
     @Bean

--- a/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/BrukerRegistreringService.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/BrukerRegistreringService.java
@@ -42,7 +42,7 @@ public class BrukerRegistreringService {
     private final ProfileringService profileringService;
     private final ArbeidssokerProfilertProducer arbeidssokerProfilertProducer;
     private final AktiveringTilstandRepository aktiveringTilstandRepository;
-    private final HentBrukerTilstandService hentBrukerTilstandService;
+    private final BrukerTilstandService brukerTilstandService;
 
     public BrukerRegistreringService(BrukerRegistreringRepository brukerRegistreringRepository,
                                      ProfileringRepository profileringRepository,
@@ -53,7 +53,7 @@ public class BrukerRegistreringService {
                                      ArbeidssokerRegistrertProducer arbeidssokerRegistrertProducer,
                                      ArbeidssokerProfilertProducer arbeidssokerProfilertProducer,
                                      AktiveringTilstandRepository aktiveringTilstandRepository,
-                                     HentBrukerTilstandService hentBrukerTilstandService) {
+                                     BrukerTilstandService brukerTilstandService) {
         this.brukerRegistreringRepository = brukerRegistreringRepository;
         this.profileringRepository = profileringRepository;
         this.personGateway = personGateway;
@@ -63,12 +63,12 @@ public class BrukerRegistreringService {
         this.arbeidssokerRegistrertProducer = arbeidssokerRegistrertProducer;
         this.arbeidssokerProfilertProducer = arbeidssokerProfilertProducer;
         this.aktiveringTilstandRepository = aktiveringTilstandRepository;
-        this.hentBrukerTilstandService = hentBrukerTilstandService;
+        this.brukerTilstandService = brukerTilstandService;
     }
 
     @Transactional
     public void reaktiverBruker(Bruker bruker) {
-        BrukersTilstand brukersTilstand = hentBrukerTilstandService.hentBrukersTilstand(bruker.getGjeldendeFoedselsnummer());
+        BrukersTilstand brukersTilstand = brukerTilstandService.hentBrukersTilstand(bruker.getGjeldendeFoedselsnummer());
         if (!brukersTilstand.kanReaktiveres()) {
             throw new RuntimeException("Bruker kan ikke reaktiveres.");
         }
@@ -112,7 +112,7 @@ public class BrukerRegistreringService {
     }
 
     private void validerBrukerRegistrering(OrdinaerBrukerRegistrering ordinaerBrukerRegistrering, Bruker bruker) {
-        BrukersTilstand brukersTilstand = hentBrukerTilstandService.hentBrukersTilstand(bruker.getGjeldendeFoedselsnummer());
+        BrukersTilstand brukersTilstand = brukerTilstandService.hentBrukersTilstand(bruker.getGjeldendeFoedselsnummer());
 
         if (brukersTilstand.isUnderOppfolging()) {
             throw new RuntimeException("Bruker allerede under oppfølging.");
@@ -132,7 +132,7 @@ public class BrukerRegistreringService {
     }
 
     public StartRegistreringStatusDto hentStartRegistreringStatus(Bruker bruker) {
-        BrukersTilstand brukersTilstand = hentBrukerTilstandService.hentBrukersTilstand(bruker.getGjeldendeFoedselsnummer());
+        BrukersTilstand brukersTilstand = brukerTilstandService.hentBrukersTilstand(bruker.getGjeldendeFoedselsnummer());
 
         Optional<GeografiskTilknytning> muligGeografiskTilknytning = hentGeografiskTilknytning(bruker);
 
@@ -191,7 +191,7 @@ public class BrukerRegistreringService {
         ofNullable(sykmeldtRegistrering.getBesvarelse())
                 .orElseThrow(() -> new RuntimeException("Besvarelse for sykmeldt ugyldig."));
 
-        BrukersTilstand brukersTilstand = hentBrukerTilstandService.hentBrukersTilstand(bruker.getGjeldendeFoedselsnummer());
+        BrukersTilstand brukersTilstand = brukerTilstandService.hentBrukersTilstand(bruker.getGjeldendeFoedselsnummer());
 
         if (brukersTilstand.ikkeErSykemeldtRegistrering()) {
             throw new RuntimeException("Bruker kan ikke registreres.");

--- a/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/BrukerTilstandService.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/BrukerTilstandService.java
@@ -6,12 +6,12 @@ import no.nav.fo.veilarbregistrering.oppfolging.Oppfolgingsstatus;
 import no.nav.fo.veilarbregistrering.sykemelding.SykemeldingService;
 import no.nav.fo.veilarbregistrering.sykemelding.SykmeldtInfoData;
 
-public class HentBrukerTilstandService {
+public class BrukerTilstandService {
 
     private final OppfolgingGateway oppfolgingGateway;
     private final SykemeldingService sykemeldingService;
 
-    public HentBrukerTilstandService(OppfolgingGateway oppfolgingGateway, SykemeldingService sykemeldingService) {
+    public BrukerTilstandService(OppfolgingGateway oppfolgingGateway, SykemeldingService sykemeldingService) {
         this.oppfolgingGateway = oppfolgingGateway;
         this.sykemeldingService = sykemeldingService;
     }

--- a/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/HentBrukerTilstandService.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/HentBrukerTilstandService.java
@@ -1,0 +1,30 @@
+package no.nav.fo.veilarbregistrering.registrering.bruker;
+
+import no.nav.fo.veilarbregistrering.bruker.Foedselsnummer;
+import no.nav.fo.veilarbregistrering.oppfolging.OppfolgingGateway;
+import no.nav.fo.veilarbregistrering.oppfolging.Oppfolgingsstatus;
+import no.nav.fo.veilarbregistrering.sykemelding.SykemeldingService;
+import no.nav.fo.veilarbregistrering.sykemelding.SykmeldtInfoData;
+
+public class HentBrukerTilstandService {
+
+    private final OppfolgingGateway oppfolgingGateway;
+    private final SykemeldingService sykemeldingService;
+
+    public HentBrukerTilstandService(OppfolgingGateway oppfolgingGateway, SykemeldingService sykemeldingService) {
+        this.oppfolgingGateway = oppfolgingGateway;
+        this.sykemeldingService = sykemeldingService;
+    }
+
+    BrukersTilstand hentBrukersTilstand(Foedselsnummer fnr) {
+        Oppfolgingsstatus oppfolgingsstatus = oppfolgingGateway.hentOppfolgingsstatus(fnr);
+
+        SykmeldtInfoData sykeforloepMetaData = null;
+        boolean erSykmeldtMedArbeidsgiver = oppfolgingsstatus.getErSykmeldtMedArbeidsgiver().orElse(false);
+        if (erSykmeldtMedArbeidsgiver) {
+            sykeforloepMetaData = sykemeldingService.hentSykmeldtInfoData(fnr);
+        }
+
+        return new BrukersTilstand(oppfolgingsstatus, sykeforloepMetaData);
+    }
+}

--- a/src/test/java/no/nav/fo/veilarbregistrering/oppfolging/adapter/OppfolgingClientTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/oppfolging/adapter/OppfolgingClientTest.java
@@ -81,12 +81,14 @@ class OppfolgingClientTest {
                         profileringRepository,
                         new OppfolgingGatewayImpl(oppfolgingClient),
                         personGateway,
-                        new SykemeldingService(new SykemeldingGatewayImpl(sykeforloepMetadataClient)),
                         arbeidsforholdGateway,
                         profileringService,
                         arbeidssokerRegistrertProducer,
                         arbeidssokerProfilertProducer,
-                        aktiveringTilstandRepository);
+                        aktiveringTilstandRepository,
+                        new HentBrukerTilstandService(
+                                new OppfolgingGatewayImpl(oppfolgingClient),
+                                new SykemeldingService(new SykemeldingGatewayImpl(sykeforloepMetadataClient))));
 
         when(profileringService.profilerBruker(anyInt(), any(), any()))
                 .thenReturn(new Profilering()

--- a/src/test/java/no/nav/fo/veilarbregistrering/oppfolging/adapter/OppfolgingClientTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/oppfolging/adapter/OppfolgingClientTest.java
@@ -86,7 +86,7 @@ class OppfolgingClientTest {
                         arbeidssokerRegistrertProducer,
                         arbeidssokerProfilertProducer,
                         aktiveringTilstandRepository,
-                        new HentBrukerTilstandService(
+                        new BrukerTilstandService(
                                 new OppfolgingGatewayImpl(oppfolgingClient),
                                 new SykemeldingService(new SykemeldingGatewayImpl(sykeforloepMetadataClient))));
 

--- a/src/test/java/no/nav/fo/veilarbregistrering/registrering/bruker/BrukerRegistreringServiceTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/registrering/bruker/BrukerRegistreringServiceTest.java
@@ -61,18 +61,22 @@ public class BrukerRegistreringServiceTest {
         };
         aktiveringTilstandRepository = mock(AktiveringTilstandRepository.class);
 
+        OppfolgingGatewayImpl oppfolgingGateway = new OppfolgingGatewayImpl(oppfolgingClient);
+
         brukerRegistreringService =
                 new BrukerRegistreringService(
                         brukerRegistreringRepository,
                         profileringRepository,
-                        new OppfolgingGatewayImpl(oppfolgingClient),
+                        oppfolgingGateway,
                         personGateway,
-                        new SykemeldingService(new SykemeldingGatewayImpl(sykeforloepMetadataClient)),
                         arbeidsforholdGateway,
                         profileringService,
                         arbeidssokerRegistrertProducer,
                         arbeidssokerProfilertProducer,
-                        aktiveringTilstandRepository);
+                        aktiveringTilstandRepository,
+                        new HentBrukerTilstandService(
+                                oppfolgingGateway,
+                                new SykemeldingService(new SykemeldingGatewayImpl(sykeforloepMetadataClient))));
     }
 
     /*

--- a/src/test/java/no/nav/fo/veilarbregistrering/registrering/bruker/BrukerRegistreringServiceTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/registrering/bruker/BrukerRegistreringServiceTest.java
@@ -74,7 +74,7 @@ public class BrukerRegistreringServiceTest {
                         arbeidssokerRegistrertProducer,
                         arbeidssokerProfilertProducer,
                         aktiveringTilstandRepository,
-                        new HentBrukerTilstandService(
+                        new BrukerTilstandService(
                                 oppfolgingGateway,
                                 new SykemeldingService(new SykemeldingGatewayImpl(sykeforloepMetadataClient))));
     }

--- a/src/test/java/no/nav/fo/veilarbregistrering/sykemelding/adapter/SykmeldtInfoClientTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/sykemelding/adapter/SykmeldtInfoClientTest.java
@@ -66,18 +66,22 @@ class SykmeldtInfoClientTest {
         }; //Noop, vi trenger ikke kafka
         AktiveringTilstandRepository aktiveringTilstandRepository = mock(AktiveringTilstandRepository.class);
 
+        OppfolgingGatewayImpl oppfolgingGateway = new OppfolgingGatewayImpl(oppfolgingClient);
+
         brukerRegistreringService =
                 new BrukerRegistreringService(
                         brukerRegistreringRepository,
                         profileringRepository,
-                        new OppfolgingGatewayImpl(oppfolgingClient),
+                        oppfolgingGateway,
                         personGateway,
-                        new SykemeldingService(new SykemeldingGatewayImpl(sykeforloepMetadataClient)),
                         arbeidsforholdGateway,
                         profileringService,
                         arbeidssokerRegistrertProducer,
                         arbeidssokerProfileringProducer,
-                        aktiveringTilstandRepository);
+                        aktiveringTilstandRepository,
+                        new HentBrukerTilstandService(
+                                oppfolgingGateway,
+                                new SykemeldingService(new SykemeldingGatewayImpl(sykeforloepMetadataClient))));
     }
 
     private SykmeldtInfoClient buildSykeForloepClient() {

--- a/src/test/java/no/nav/fo/veilarbregistrering/sykemelding/adapter/SykmeldtInfoClientTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/sykemelding/adapter/SykmeldtInfoClientTest.java
@@ -79,7 +79,7 @@ class SykmeldtInfoClientTest {
                         arbeidssokerRegistrertProducer,
                         arbeidssokerProfileringProducer,
                         aktiveringTilstandRepository,
-                        new HentBrukerTilstandService(
+                        new BrukerTilstandService(
                                 oppfolgingGateway,
                                 new SykemeldingService(new SykemeldingGatewayImpl(sykeforloepMetadataClient))));
     }

--- a/src/test/java/no/nav/veilarbregistrering/integrasjonstest/BrukerRegistreringServiceIntegrationTest.java
+++ b/src/test/java/no/nav/veilarbregistrering/integrasjonstest/BrukerRegistreringServiceIntegrationTest.java
@@ -164,8 +164,8 @@ class BrukerRegistreringServiceIntegrationTest {
         }
 
         @Bean
-        public HentBrukerTilstandService hentBrukerTilstandService(OppfolgingGateway oppfolgingGateway, SykemeldingService sykemeldingService) {
-            return new HentBrukerTilstandService(oppfolgingGateway, sykemeldingService);
+        public BrukerTilstandService hentBrukerTilstandService(OppfolgingGateway oppfolgingGateway, SykemeldingService sykemeldingService) {
+            return new BrukerTilstandService(oppfolgingGateway, sykemeldingService);
         }
 
         @Bean
@@ -179,7 +179,7 @@ class BrukerRegistreringServiceIntegrationTest {
                 ArbeidssokerRegistrertProducer arbeidssokerRegistrertProducer,
                 ArbeidssokerProfilertProducer arbeidssokerProfilertProducer,
                 AktiveringTilstandRepository aktiveringTilstandRepository,
-                HentBrukerTilstandService hentBrukerTilstandService) {
+                BrukerTilstandService brukerTilstandService) {
 
             return new BrukerRegistreringService(
                     brukerRegistreringRepository,
@@ -191,7 +191,7 @@ class BrukerRegistreringServiceIntegrationTest {
                     arbeidssokerRegistrertProducer,
                     arbeidssokerProfilertProducer,
                     aktiveringTilstandRepository,
-                    hentBrukerTilstandService);
+                    brukerTilstandService);
         }
 
         @Bean


### PR DESCRIPTION
Trekker ut hentBrukerTilstand til egen service. Dette er en funskjon som brukes på tvers av de fleste andre metodene. For at de andre funksjonene skal kunne skilles fra hverandre, er det en fordel å gjøre dette først. Da blir neste steg lettere.