### PR TITLE
STRENGT_FORTROLIG_UTLAND

### DIFF
--- a/src/main/java/no/nav/fo/veilarbregistrering/bruker/AdressebeskyttelseGradering.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/bruker/AdressebeskyttelseGradering.java
@@ -1,7 +1,17 @@
 package no.nav.fo.veilarbregistrering.bruker;
 
+import no.nav.fo.veilarbregistrering.orgenhet.Enhetnr;
+
+import java.util.Optional;
+
 public enum AdressebeskyttelseGradering {
-    STRENGT_FORTROLIG_UTLAND, // Tilsvarer paragraf 19 i Bisys (henvisning til Forvaltningslovens §19)
+    // Tilsvarer paragraf 19 i Bisys (henvisning til Forvaltningslovens §19)
+    // Koden finnes kun i PDL, og ikke i TPS.
+    // Routing skjer (foreløpig) basert på TPS, så vi må eksplisitt overstyre enhet.
+    // Eksplisitt routing-enhet kan fjernes når Oppgave-APIet går over til PDL.
+    STRENGT_FORTROLIG_UTLAND(Enhetnr.enhetForAdressebeskyttelse()),
+
+
     STRENGT_FORTROLIG, // Tidligere spesregkode kode 6 fra TPS
     FORTROLIG, // Tidligere spesregkode kode 7 fra TPS
 
@@ -9,7 +19,21 @@ public enum AdressebeskyttelseGradering {
 
     UKJENT;
 
+    private final Enhetnr eksplisittRoutingEnhet;
+
     public boolean erGradert() {
         return this != UGRADERT && this != UKJENT;
+    }
+
+    AdressebeskyttelseGradering() {
+        this(null);
+    }
+
+    AdressebeskyttelseGradering(Enhetnr eksplisittRoutingEnhet) {
+        this.eksplisittRoutingEnhet = eksplisittRoutingEnhet;
+    }
+
+    public Optional<Enhetnr> getEksplisittRoutingEnhet() {
+        return Optional.ofNullable(eksplisittRoutingEnhet);
     }
 }

--- a/src/main/java/no/nav/fo/veilarbregistrering/oppgave/OppgaveRouter.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/oppgave/OppgaveRouter.java
@@ -57,8 +57,9 @@ public class OppgaveRouter {
     }
 
     public Optional<Enhetnr> hentEnhetsnummerFor(Bruker bruker) {
-        if (harBrukerAdressebeskyttelse(bruker)) {
-            return Optional.empty();
+        AdressebeskyttelseGradering adressebeskyttelseGradering = hentAdressebeskyttelse(bruker);
+        if (adressebeskyttelseGradering.erGradert()) {
+            return adressebeskyttelseGradering.getEksplisittRoutingEnhet();
         }
 
         Optional<GeografiskTilknytning> geografiskTilknytning;
@@ -104,13 +105,15 @@ public class OppgaveRouter {
         }
     }
 
-    private boolean harBrukerAdressebeskyttelse(Bruker bruker) {
+    private AdressebeskyttelseGradering hentAdressebeskyttelse(Bruker bruker) {
         try {
             Optional<Person> person = pdlOppslagGateway.hentPerson(bruker.getAktorId());
-            return person.map(Person::harAdressebeskyttelse).orElse(false);
+            return person.map(Person::getAdressebeskyttelseGradering)
+                    .orElse(AdressebeskyttelseGradering.UKJENT);
+
         } catch (Exception e) {
             LOG.warn("Feil ved uthenting av adressebeskyttelse fra PDL", e);
-            return false;
+            return AdressebeskyttelseGradering.UKJENT;
         }
     }
 

--- a/src/main/java/no/nav/fo/veilarbregistrering/orgenhet/Enhetnr.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/orgenhet/Enhetnr.java
@@ -25,6 +25,11 @@ public class Enhetnr {
         return Enhetnr.of("2930");
     }
 
+    public static Enhetnr enhetForAdressebeskyttelse() {
+        // NAV Vikafossen håndterer brukere med adressebeskyttelse
+        return Enhetnr.of("2103");
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/src/test/kotlin/OppgaveRouterTest.kt
+++ b/src/test/kotlin/OppgaveRouterTest.kt
@@ -116,6 +116,12 @@ class OppgaveRouterTest {
         assertThat(enhetsnr).isEmpty
     }
 
+    @Test
+    fun `brukere med adressebeskyttelse STRENGT_FORTROLIG_UTLAND routes eksplisitt til spesialkontor`() {
+        val enhetsnr = hentEnhetsnummerForBrukerMedAdressebeskyttelse(AdressebeskyttelseGradering.STRENGT_FORTROLIG_UTLAND)
+        assertThat(enhetsnr).hasValue(Enhetnr.enhetForAdressebeskyttelse())
+    }
+
     fun hentEnhetsnummerForBrukerMedAdressebeskyttelse(adressebeskyttelseGradering: AdressebeskyttelseGradering): Optional<Enhetnr> {
         val personGateway = PersonGateway { Optional.of(GeografiskTilknytning.of("0301")) }
         val person = Person.of(null, null, adressebeskyttelseGradering)

--- a/src/test/kotlin/OppgaveRouterTest.kt
+++ b/src/test/kotlin/OppgaveRouterTest.kt
@@ -105,14 +105,24 @@ class OppgaveRouterTest {
     }
 
     @Test
-    fun `brukere med adressebeskyttelse overlates til oppgave api`() {
+    fun `brukere med adressebeskyttelse FORTROLIG (kode 6) overlates til oppgave api`() {
+        val enhetsnr = hentEnhetsnummerForBrukerMedAdressebeskyttelse(AdressebeskyttelseGradering.FORTROLIG)
+        assertThat(enhetsnr).isEmpty
+    }
+
+    @Test
+    fun `brukere med adressebeskyttelse STRENGT_FORTROLIG (kode 7) overlates til oppgave api`() {
+        val enhetsnr = hentEnhetsnummerForBrukerMedAdressebeskyttelse(AdressebeskyttelseGradering.STRENGT_FORTROLIG)
+        assertThat(enhetsnr).isEmpty
+    }
+
+    fun hentEnhetsnummerForBrukerMedAdressebeskyttelse(adressebeskyttelseGradering: AdressebeskyttelseGradering): Optional<Enhetnr> {
         val personGateway = PersonGateway { Optional.of(GeografiskTilknytning.of("0301")) }
-        val person = Person.of(null, null, AdressebeskyttelseGradering.STRENGT_FORTROLIG)
+        val person = Person.of(null, null, adressebeskyttelseGradering)
         val pdlOppslagGateway = StubPdlOppslagGateway(users = mapOf(BRUKER.aktorId to person))
         val oppgaveRouter = oppgaveRouter(personGateway = personGateway, pdlOppslagGateway = pdlOppslagGateway)
 
-        val enhetsnr = oppgaveRouter.hentEnhetsnummerFor(BRUKER)
-        assertThat(enhetsnr).isEmpty
+        return oppgaveRouter.hentEnhetsnummerFor(BRUKER)
     }
 
     private fun oppgaveRouter(


### PR DESCRIPTION
Oppgave-APIet håndterer i dag FORTROLIG (kode 6) og STRENGT_FORTROLIG (kode 7). Dette gjøres ved å sjekke graderingen i TPS.
STRENGT_FORTROLIG_UTLAND finnes ikke i TPS, men bare PDL. Oppgave-APIet har dermed (per nå) ingen måte å filtere på denne graderingen.

Som en midlertidig løsning, router vi eksplisitt brukere med STRENGT_FORTROLIG_UTLAND til kontoret som håndterer disse (NAV Vikafossen).