### PR TITLE
Oppdaterer Oppgave med lenke til rutinebeskrivelse

### DIFF
--- a/src/main/java/no/nav/fo/veilarbregistrering/oppgave/Oppgave.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/oppgave/Oppgave.java
@@ -16,8 +16,9 @@ public class Oppgave {
         beskrivelser.put(
                 OppgaveType.OPPHOLDSTILLATELSE,
                 "Brukeren får ikke registrert seg som arbeidssøker pga. manglende oppholdstillatelse i Arena, " +
-                        "og har selv opprettet denne oppgaven. " +
-                        "Ring bruker og følg midlertidig rutine på navet om løsning for registreringen av arbeids- og oppholdstillatelse. " +
+                        "og har selv opprettet denne oppgaven." +
+                        "\n\nFølg rutinen som er beskrevet for registreringen av arbeids- og oppholdstillatelse: " +
+                        "https://navno.sharepoint.com/sites/fag-og-ytelser-regelverk-og-rutiner/SitePages/Registrering-av-arbeids--og-oppholdstillatelse.aspx" +
                         "\n\nHar oppgaven havnet i feil oppgaveliste? Da ønsker vi som har utviklet løsningen tilbakemelding på dette. " +
                         "Meld sak her: https://jira.adeo.no/plugins/servlet/desk/portal/541/create/3384. Takk!"
         );
@@ -25,7 +26,7 @@ public class Oppgave {
                 OppgaveType.UTVANDRET,
                 "Brukeren får ikke registrert seg som arbeidssøker fordi bruker står som utvandret i TPS og ikke er befolket i Arena, " +
                         "og har selv opprettet denne oppgaven. " +
-                        "Ring bruker og følg vanlig rutine for slike tilfeller." +
+                        "\n\nRing bruker og følg vanlig rutine for slike tilfeller." +
                         "\n\nHar oppgaven havnet i feil oppgaveliste? Da ønsker vi som har utviklet løsningen tilbakemelding på dette. " +
                         "Meld sak her: https://jira.adeo.no/plugins/servlet/desk/portal/541/create/3384. Takk!"
         );

--- a/src/test/java/no/nav/fo/veilarbregistrering/oppgave/adapter/OppgaveGatewayTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/oppgave/adapter/OppgaveGatewayTest.java
@@ -73,8 +73,9 @@ class OppgaveGatewayTest {
                                 "\"aktoerId\":\"12e1e3\"," +
                                 "\"beskrivelse\":\"" +
                                 "Brukeren får ikke registrert seg som arbeidssøker pga. manglende oppholdstillatelse i Arena, " +
-                                "og har selv opprettet denne oppgaven. " +
-                                "Ring bruker og følg midlertidig rutine på navet om løsning for registreringen av arbeids- og oppholdstillatelse. " +
+                                "og har selv opprettet denne oppgaven." +
+                                "\\n\\nFølg rutinen som er beskrevet for registreringen av arbeids- og oppholdstillatelse: " +
+                                "https://navno.sharepoint.com/sites/fag-og-ytelser-regelverk-og-rutiner/SitePages/Registrering-av-arbeids--og-oppholdstillatelse.aspx" +
                                 "\\n\\nHar oppgaven havnet i feil oppgaveliste? Da ønsker vi som har utviklet løsningen tilbakemelding på dette. Meld sak her: https://jira.adeo.no/plugins/servlet/desk/portal/541/create/3384. Takk!\"," +
                                 "\"tema\":\"OPP\"," +
                                 "\"oppgavetype\":\"KONT_BRUK\"," +

--- a/src/test/java/no/nav/fo/veilarbregistrering/oppgave/adapter/OppgaveIntegrationTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/oppgave/adapter/OppgaveIntegrationTest.java
@@ -88,7 +88,7 @@ public class OppgaveIntegrationTest {
                                 "\"beskrivelse\":\"" +
                                 "Brukeren får ikke registrert seg som arbeidssøker fordi bruker står som utvandret i TPS og ikke er befolket i Arena, " +
                                 "og har selv opprettet denne oppgaven. " +
-                                "Ring bruker og følg vanlig rutine for slike tilfeller." +
+                                "\\n\\nRing bruker og følg vanlig rutine for slike tilfeller." +
                                 "\\n\\nHar oppgaven havnet i feil oppgaveliste? Da ønsker vi som har utviklet løsningen tilbakemelding på dette. " +
                                 "Meld sak her: https://jira.adeo.no/plugins/servlet/desk/portal/541/create/3384. Takk!\"," +
                                 "\"tema\":\"OPP\"," +


### PR DESCRIPTION
Etter tilbakemeldinger via JiraServiceDesk oppdaterer vi nå tekst med henvisning til gjeldende rutine. Gammel rutine, hvor bruker skulle ringes opp, er ikke lenger relevant.