### PR TITLE
Flytter manuell registrering inn i sykmeldt registrering service

### DIFF
--- a/src/main/java/no/nav/fo/veilarbregistrering/config/ServiceBeansConfig.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/config/ServiceBeansConfig.java
@@ -97,11 +97,13 @@ public class ServiceBeansConfig {
     SykmeldtRegistreringService sykmeldtRegistreringService(
             BrukerTilstandService arbeidssokerService,
             OppfolgingGateway oppfolgingGateway,
-            BrukerRegistreringRepository brukerRegistreringRepository) {
+            BrukerRegistreringRepository brukerRegistreringRepository,
+            ManuellRegistreringRepository manuellRegistreringRepository) {
         return new SykmeldtRegistreringService(
                 arbeidssokerService,
                 oppfolgingGateway,
-                brukerRegistreringRepository);
+                brukerRegistreringRepository,
+                manuellRegistreringRepository);
     }
 
     @Bean
@@ -111,14 +113,16 @@ public class ServiceBeansConfig {
             OppfolgingGateway oppfolgingGateway,
             ProfileringService profileringService,
             RegistreringTilstandRepository registreringTilstandRepository,
-            BrukerTilstandService brukerTilstandService, ManuellRegistreringRepository manuellRegistreringRepository) {
+            BrukerTilstandService brukerTilstandService,
+            ManuellRegistreringRepository manuellRegistreringRepository) {
         return new BrukerRegistreringService(
                 brukerRegistreringRepository,
                 profileringRepository,
                 oppfolgingGateway,
                 profileringService,
                 registreringTilstandRepository,
-                brukerTilstandService, manuellRegistreringRepository);
+                brukerTilstandService,
+                manuellRegistreringRepository);
     }
 
     @Bean
@@ -138,7 +142,6 @@ public class ServiceBeansConfig {
     RegistreringResource registreringResource(
             VeilarbAbacPepClient pepClient,
             UserService userService,
-            ManuellRegistreringService manuellRegistreringService,
             BrukerRegistreringService brukerRegistreringService,
             HentRegistreringService hentRegistreringService,
             UnleashService unleashService,
@@ -148,7 +151,6 @@ public class ServiceBeansConfig {
         return new RegistreringResource(
                 pepClient,
                 userService,
-                manuellRegistreringService,
                 brukerRegistreringService,
                 hentRegistreringService,
                 unleashService,

--- a/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/BrukerRegistreringService.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/BrukerRegistreringService.java
@@ -113,7 +113,6 @@ public class BrukerRegistreringService {
                 .setVeilederEnhetId(veileder.getEnhetsId());
 
         manuellRegistreringRepository.lagreManuellRegistrering(manuellRegistrering);
-
     }
 
     @Transactional

--- a/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/resources/RegistreringResource.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/resources/RegistreringResource.java
@@ -8,7 +8,6 @@ import no.nav.fo.veilarbregistrering.bruker.AutentiseringUtils;
 import no.nav.fo.veilarbregistrering.bruker.Bruker;
 import no.nav.fo.veilarbregistrering.bruker.UserService;
 import no.nav.fo.veilarbregistrering.registrering.bruker.*;
-import no.nav.fo.veilarbregistrering.registrering.manuell.ManuellRegistreringService;
 import no.nav.sbl.featuretoggle.unleash.UnleashService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -18,15 +17,14 @@ import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
-
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
 
 import static no.nav.fo.veilarbregistrering.bruker.BrukerAdapter.map;
-import static no.nav.fo.veilarbregistrering.metrics.Metrics.Event.*;
+import static no.nav.fo.veilarbregistrering.metrics.Metrics.Event.MANUELL_REAKTIVERING_EVENT;
+import static no.nav.fo.veilarbregistrering.metrics.Metrics.Event.SYKMELDT_BESVARELSE_EVENT;
 import static no.nav.fo.veilarbregistrering.metrics.Metrics.reportFields;
-import static no.nav.fo.veilarbregistrering.registrering.BrukerRegistreringType.SYKMELDT;
 import static no.nav.fo.veilarbregistrering.registrering.bruker.resources.StartRegistreringStatusMetrikker.rapporterRegistreringsstatus;
 
 @Component
@@ -42,7 +40,6 @@ public class RegistreringResource {
     private final SykmeldtRegistreringService sykmeldtRegistreringService;
     private final HentRegistreringService hentRegistreringService;
     private final UserService userService;
-    private final ManuellRegistreringService manuellRegistreringService;
     private final VeilarbAbacPepClient pepClient;
     private final StartRegistreringStatusService startRegistreringStatusService;
     private final InaktivBrukerService inaktivBrukerService;
@@ -50,7 +47,6 @@ public class RegistreringResource {
     public RegistreringResource(
             VeilarbAbacPepClient pepClient,
             UserService userService,
-            ManuellRegistreringService manuellRegistreringService,
             BrukerRegistreringService brukerRegistreringService,
             HentRegistreringService hentRegistreringService,
             UnleashService unleashService,
@@ -59,7 +55,6 @@ public class RegistreringResource {
             InaktivBrukerService inaktivBrukerService) {
         this.pepClient = pepClient;
         this.userService = userService;
-        this.manuellRegistreringService = manuellRegistreringService;
         this.brukerRegistreringService = brukerRegistreringService;
         this.hentRegistreringService = hentRegistreringService;
         this.unleashService = unleashService;
@@ -93,16 +88,9 @@ public class RegistreringResource {
 
         pepClient.sjekkSkrivetilgangTilBruker(map(bruker));
 
-        NavVeileder veileder = null;
-        OrdinaerBrukerRegistrering registrering;
-        if (AutentiseringUtils.erVeileder()) {
-            veileder = new NavVeileder(
-                    AutentiseringUtils.hentIdent()
-                            .orElseThrow(() -> new RuntimeException("Fant ikke ident")),
-                    userService.getEnhetIdFromUrlOrThrow()
-            );
-        }
+        NavVeileder veileder = navVeileder();
 
+        OrdinaerBrukerRegistrering registrering;
         if (skalSplitteRegistreringOgOverforing()) {
             registrering = splittRegistreringOgOverforing(ordinaerBrukerRegistrering, bruker, veileder);
         } else {
@@ -201,24 +189,24 @@ public class RegistreringResource {
         final Bruker bruker = userService.finnBrukerGjennomPdl();
         pepClient.sjekkSkrivetilgangTilBruker(map(bruker));
 
-        if (AutentiseringUtils.erVeileder()) {
+        NavVeileder veileder = navVeileder();
 
-            final String enhetId = userService.getEnhetIdFromUrlOrThrow();
-            final String veilederIdent = AutentiseringUtils.hentIdent()
-                    .orElseThrow(() -> new RuntimeException("Fant ikke ident"));
-
-            long id = sykmeldtRegistreringService.registrerSykmeldt(sykmeldtRegistrering, bruker);
-            manuellRegistreringService.lagreManuellRegistrering(veilederIdent, enhetId, id, SYKMELDT);
-
-            reportFields(MANUELL_REGISTRERING_EVENT, SYKMELDT);
-
-        } else {
-            sykmeldtRegistreringService.registrerSykmeldt(sykmeldtRegistrering, bruker);
-        }
+        sykmeldtRegistreringService.registrerSykmeldt(sykmeldtRegistrering, bruker, veileder);
 
         reportFields(SYKMELDT_BESVARELSE_EVENT,
                 sykmeldtRegistrering.getBesvarelse().getUtdanning(),
                 sykmeldtRegistrering.getBesvarelse().getFremtidigSituasjon());
+    }
+
+    private NavVeileder navVeileder() {
+        if (!AutentiseringUtils.erVeileder()) {
+            return null;
+        }
+
+        return new NavVeileder(
+                AutentiseringUtils.hentIdent()
+                        .orElseThrow(() -> new RuntimeException("Fant ikke ident")),
+                userService.getEnhetIdFromUrlOrThrow());
     }
 
     private boolean tjenesteErNede() {

--- a/src/main/java/no/nav/fo/veilarbregistrering/registrering/manuell/ManuellRegistreringService.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/registrering/manuell/ManuellRegistreringService.java
@@ -24,21 +24,6 @@ public class ManuellRegistreringService {
         this.norg2Gateway = norg2Gateway;
     }
 
-    public void lagreManuellRegistrering(
-            String veilederIdent,
-            String veilederEnhetId,
-            long registreringId,
-            BrukerRegistreringType brukerRegistreringType){
-
-        final ManuellRegistrering manuellRegistrering = new ManuellRegistrering()
-                .setRegistreringId(registreringId)
-                .setBrukerRegistreringType(brukerRegistreringType)
-                .setVeilederIdent(veilederIdent)
-                .setVeilederEnhetId(veilederEnhetId);
-
-        manuellRegistreringRepository.lagreManuellRegistrering(manuellRegistrering);
-    }
-
     public Veileder hentManuellRegistreringVeileder(long registreringId, BrukerRegistreringType brukerRegistreringType) {
         ManuellRegistrering registrering = manuellRegistreringRepository
                 .hentManuellRegistrering(registreringId, brukerRegistreringType);

--- a/src/test/java/no/nav/fo/veilarbregistrering/registrering/bruker/SykmeldtRegistreringServiceTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/registrering/bruker/SykmeldtRegistreringServiceTest.java
@@ -7,6 +7,7 @@ import no.nav.fo.veilarbregistrering.bruker.Foedselsnummer;
 import no.nav.fo.veilarbregistrering.oppfolging.adapter.OppfolgingClient;
 import no.nav.fo.veilarbregistrering.oppfolging.adapter.OppfolgingGatewayImpl;
 import no.nav.fo.veilarbregistrering.oppfolging.adapter.OppfolgingStatusData;
+import no.nav.fo.veilarbregistrering.registrering.manuell.ManuellRegistreringRepository;
 import no.nav.fo.veilarbregistrering.sykemelding.SykemeldingService;
 import no.nav.fo.veilarbregistrering.sykemelding.adapter.InfotrygdData;
 import no.nav.fo.veilarbregistrering.sykemelding.adapter.SykemeldingGatewayImpl;
@@ -37,6 +38,7 @@ public class SykmeldtRegistreringServiceTest {
         sykeforloepMetadataClient = mock(SykmeldtInfoClient.class);
 
         OppfolgingGatewayImpl oppfolgingGateway = new OppfolgingGatewayImpl(oppfolgingClient);
+        ManuellRegistreringRepository manuellRegistreringRepository = mock(ManuellRegistreringRepository.class);
 
         sykmeldtRegistreringService =
                 new SykmeldtRegistreringService(
@@ -44,7 +46,8 @@ public class SykmeldtRegistreringServiceTest {
                                 oppfolgingGateway,
                                 new SykemeldingService(new SykemeldingGatewayImpl(sykeforloepMetadataClient))),
                         oppfolgingGateway,
-                        brukerRegistreringRepository);
+                        brukerRegistreringRepository,
+                        manuellRegistreringRepository);
     }
 
     @Test
@@ -52,14 +55,14 @@ public class SykmeldtRegistreringServiceTest {
         mockSykmeldtBrukerOver39uker();
         mockSykmeldtMedArbeidsgiver();
         SykmeldtRegistrering sykmeldtRegistrering = new SykmeldtRegistrering().setBesvarelse(null);
-        assertThrows(RuntimeException.class, () -> sykmeldtRegistreringService.registrerSykmeldt(sykmeldtRegistrering, BRUKER_INTERN));
+        assertThrows(RuntimeException.class, () -> sykmeldtRegistreringService.registrerSykmeldt(sykmeldtRegistrering, BRUKER_INTERN, null));
     }
 
     @Test
     void skalIkkeRegistrereSykmeldtSomIkkeOppfyllerKrav() {
         mockSykmeldtMedArbeidsgiver();
         SykmeldtRegistrering sykmeldtRegistrering = SykmeldtRegistreringTestdataBuilder.gyldigSykmeldtRegistrering();
-        assertThrows(RuntimeException.class, () -> sykmeldtRegistreringService.registrerSykmeldt(sykmeldtRegistrering, BRUKER_INTERN));
+        assertThrows(RuntimeException.class, () -> sykmeldtRegistreringService.registrerSykmeldt(sykmeldtRegistrering, BRUKER_INTERN, null));
     }
 
     private void mockSykmeldtBrukerOver39uker() {

--- a/src/test/java/no/nav/fo/veilarbregistrering/registrering/bruker/resources/RegistreringResourceTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/registrering/bruker/resources/RegistreringResourceTest.java
@@ -46,7 +46,6 @@ public class RegistreringResourceTest {
         registreringResource = new RegistreringResource(
                 pepClient,
                 userService,
-                manuellRegistreringService,
                 brukerRegistreringService,
                 hentRegistreringService,
                 unleashService,

--- a/src/test/java/no/nav/fo/veilarbregistrering/sykemelding/adapter/SykmeldtInfoClientTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/sykemelding/adapter/SykmeldtInfoClientTest.java
@@ -11,6 +11,7 @@ import no.nav.fo.veilarbregistrering.registrering.bruker.BrukerRegistreringRepos
 import no.nav.fo.veilarbregistrering.registrering.bruker.BrukerTilstandService;
 import no.nav.fo.veilarbregistrering.registrering.bruker.SykmeldtRegistrering;
 import no.nav.fo.veilarbregistrering.registrering.bruker.SykmeldtRegistreringService;
+import no.nav.fo.veilarbregistrering.registrering.manuell.ManuellRegistreringRepository;
 import no.nav.fo.veilarbregistrering.sykemelding.SykemeldingService;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -54,6 +55,7 @@ class SykmeldtInfoClientTest {
         sykeforloepMetadataClient = buildSykeForloepClient();
 
         OppfolgingGatewayImpl oppfolgingGateway = new OppfolgingGatewayImpl(oppfolgingClient);
+        ManuellRegistreringRepository manuellRegistreringRepository = mock(ManuellRegistreringRepository.class);
 
         sykmeldtRegistreringService =
                 new SykmeldtRegistreringService(
@@ -61,7 +63,8 @@ class SykmeldtInfoClientTest {
                                 oppfolgingGateway,
                                 new SykemeldingService(new SykemeldingGatewayImpl(sykeforloepMetadataClient))),
                         oppfolgingGateway,
-                        brukerRegistreringRepository);
+                        brukerRegistreringRepository,
+                        manuellRegistreringRepository);
     }
 
     private SykmeldtInfoClient buildSykeForloepClient() {
@@ -83,7 +86,7 @@ class SykmeldtInfoClientTest {
         mockSykmeldtOver39u();
         SykmeldtRegistrering sykmeldtRegistrering = gyldigSykmeldtRegistrering();
         mockServer.when(request().withMethod("POST").withPath("/oppfolging/aktiverSykmeldt")).respond(response().withStatusCode(204));
-        sykmeldtRegistreringService.registrerSykmeldt(sykmeldtRegistrering, BRUKER);
+        sykmeldtRegistreringService.registrerSykmeldt(sykmeldtRegistrering, BRUKER, null);
     }
 
     /*
@@ -107,7 +110,7 @@ class SykmeldtInfoClientTest {
                         .withPath("/oppfolging/aktiverSykmeldt"))
                 .respond(response()
                         .withStatusCode(502));
-        assertThrows(RuntimeException.class, () -> sykmeldtRegistreringService.registrerSykmeldt(sykmeldtRegistrering, BRUKER));
+        assertThrows(RuntimeException.class, () -> sykmeldtRegistreringService.registrerSykmeldt(sykmeldtRegistrering, BRUKER, null));
     }
 
     private void mockSykmeldtOver39u() {


### PR DESCRIPTION
Gjør dette for at det skal bli likt som ordinær registrering service, og for at vi på sikt kan a) kvitte oss med ManuellRegistreringService og b) skille mer på ordniær registrering og sykmeldt registrering.