### PR TITLE
Innfører toggle for å skru av maksdato-validering

### DIFF
--- a/src/main/java/no/nav/fo/veilarbregistrering/config/ServiceBeansConfig.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/config/ServiceBeansConfig.java
@@ -69,8 +69,9 @@ public class ServiceBeansConfig {
     @Bean
     BrukerTilstandService brukerTilstandService(
             OppfolgingGateway oppfolgingGateway,
-            SykemeldingService sykemeldingService) {
-        return new BrukerTilstandService(oppfolgingGateway, sykemeldingService);
+            SykemeldingService sykemeldingService,
+            UnleashService unleashService) {
+        return new BrukerTilstandService(oppfolgingGateway, sykemeldingService, unleashService);
     }
 
     @Bean

--- a/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/BrukerTilstandService.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/BrukerTilstandService.java
@@ -5,15 +5,21 @@ import no.nav.fo.veilarbregistrering.oppfolging.OppfolgingGateway;
 import no.nav.fo.veilarbregistrering.oppfolging.Oppfolgingsstatus;
 import no.nav.fo.veilarbregistrering.sykemelding.SykemeldingService;
 import no.nav.fo.veilarbregistrering.sykemelding.SykmeldtInfoData;
+import no.nav.sbl.featuretoggle.unleash.UnleashService;
 
 public class BrukerTilstandService {
 
     private final OppfolgingGateway oppfolgingGateway;
     private final SykemeldingService sykemeldingService;
+    private final UnleashService unleashService;
 
-    public BrukerTilstandService(OppfolgingGateway oppfolgingGateway, SykemeldingService sykemeldingService) {
+    public BrukerTilstandService(
+            OppfolgingGateway oppfolgingGateway,
+            SykemeldingService sykemeldingService,
+            UnleashService unleashService) {
         this.oppfolgingGateway = oppfolgingGateway;
         this.sykemeldingService = sykemeldingService;
+        this.unleashService = unleashService;
     }
 
     BrukersTilstand hentBrukersTilstand(Foedselsnummer fnr) {
@@ -25,6 +31,10 @@ public class BrukerTilstandService {
             sykeforloepMetaData = sykemeldingService.hentSykmeldtInfoData(fnr);
         }
 
-        return new BrukersTilstand(oppfolgingsstatus, sykeforloepMetaData);
+        return new BrukersTilstand(oppfolgingsstatus, sykeforloepMetaData, maksdatoToggletAv());
+    }
+
+    private boolean maksdatoToggletAv() {
+        return unleashService.isEnabled("veilarbregistrering.maksdatoToggletAv");
     }
 }

--- a/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/BrukersTilstand.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/BrukersTilstand.java
@@ -20,10 +20,13 @@ public class BrukersTilstand implements HasMetrics {
     private final RegistreringType registreringType;
     private final Oppfolgingsstatus oppfolgingStatusData;
 
-    public BrukersTilstand(Oppfolgingsstatus Oppfolgingsstatus, SykmeldtInfoData sykmeldtInfoData) {
+    public BrukersTilstand(
+            Oppfolgingsstatus Oppfolgingsstatus,
+            SykmeldtInfoData sykmeldtInfoData,
+            boolean maksdatoToggletAv) {
         this.oppfolgingStatusData = Oppfolgingsstatus;
         this.sykmeldtInfoData = sykmeldtInfoData;
-        this.registreringType = beregnRegistreringType(Oppfolgingsstatus, sykmeldtInfoData);
+        this.registreringType = beregnRegistreringType(Oppfolgingsstatus, sykmeldtInfoData, maksdatoToggletAv);
     }
 
     public boolean kanReaktiveres() {

--- a/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/RegistreringType.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/RegistreringType.java
@@ -7,7 +7,11 @@ import no.nav.fo.veilarbregistrering.sykemelding.SykmeldtInfoData;
 public enum RegistreringType implements Metric {
     REAKTIVERING, SPERRET, ALLEREDE_REGISTRERT, SYKMELDT_REGISTRERING, ORDINAER_REGISTRERING;
 
-    protected static RegistreringType beregnRegistreringType(Oppfolgingsstatus oppfolgingsstatus, SykmeldtInfoData sykeforloepMetaData) {
+    protected static RegistreringType beregnRegistreringType(
+            Oppfolgingsstatus oppfolgingsstatus,
+            SykmeldtInfoData sykeforloepMetaData,
+            boolean maksdatoToggletAv) {
+
         if (oppfolgingsstatus.isUnderOppfolging() && !oppfolgingsstatus.getKanReaktiveres().orElse(false)) {
             return ALLEREDE_REGISTRERT;
 
@@ -15,7 +19,9 @@ public enum RegistreringType implements Metric {
             return REAKTIVERING;
 
         } else if (oppfolgingsstatus.getErSykmeldtMedArbeidsgiver().orElse(false)) {
-            if (erSykmeldtMedArbeidsgiverOver39Uker(sykeforloepMetaData)) {
+            if (maksdatoToggletAv) {
+                return SYKMELDT_REGISTRERING;
+            } else if (erSykmeldtMedArbeidsgiverOver39Uker(sykeforloepMetaData)) {
                 return SYKMELDT_REGISTRERING;
             } else {
                 return SPERRET;

--- a/src/test/java/no/nav/fo/veilarbregistrering/oppfolging/adapter/OppfolgingClientTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/oppfolging/adapter/OppfolgingClientTest.java
@@ -58,12 +58,13 @@ class OppfolgingClientTest {
         BrukerRegistreringRepository brukerRegistreringRepository = mock(BrukerRegistreringRepository.class);
         SykmeldtInfoClient sykeforloepMetadataClient = mock(SykmeldtInfoClient.class);
         ProfileringService profileringService = mock(ProfileringService.class);
+        UnleashService unleashService = mock(UnleashService.class);
 
         OppfolgingGatewayImpl oppfolgingGateway = new OppfolgingGatewayImpl(oppfolgingClient);
 
         BrukerTilstandService brukerTilstandService = new BrukerTilstandService(
                 oppfolgingGateway,
-                new SykemeldingService(new SykemeldingGatewayImpl(sykeforloepMetadataClient)));
+                new SykemeldingService(new SykemeldingGatewayImpl(sykeforloepMetadataClient)), unleashService);
 
         inaktivBrukerService = new InaktivBrukerService(
                 brukerTilstandService,

--- a/src/test/java/no/nav/fo/veilarbregistrering/registrering/bruker/InaktivBrukerServiceTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/registrering/bruker/InaktivBrukerServiceTest.java
@@ -7,6 +7,7 @@ import no.nav.fo.veilarbregistrering.oppfolging.adapter.OppfolgingStatusData;
 import no.nav.fo.veilarbregistrering.sykemelding.SykemeldingService;
 import no.nav.fo.veilarbregistrering.sykemelding.adapter.SykemeldingGatewayImpl;
 import no.nav.fo.veilarbregistrering.sykemelding.adapter.SykmeldtInfoClient;
+import no.nav.sbl.featuretoggle.unleash.UnleashService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -33,6 +34,7 @@ public class InaktivBrukerServiceTest {
         oppfolgingClient = mock(OppfolgingClient.class);
         when(oppfolgingClient.reaktiverBruker(any())).thenReturn(AktiverBrukerResultat.Companion.ok());
         sykeforloepMetadataClient = mock(SykmeldtInfoClient.class);
+        UnleashService unleashService = mock(UnleashService.class);
 
         OppfolgingGatewayImpl oppfolgingGateway = new OppfolgingGatewayImpl(oppfolgingClient);
 
@@ -40,7 +42,7 @@ public class InaktivBrukerServiceTest {
                 new InaktivBrukerService(
                         new BrukerTilstandService(
                                 oppfolgingGateway,
-                                new SykemeldingService(new SykemeldingGatewayImpl(sykeforloepMetadataClient))),
+                                new SykemeldingService(new SykemeldingGatewayImpl(sykeforloepMetadataClient)), unleashService),
                         brukerRegistreringRepository,
                         oppfolgingGateway);
     }

--- a/src/test/java/no/nav/fo/veilarbregistrering/registrering/bruker/RegistreringTypeTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/registrering/bruker/RegistreringTypeTest.java
@@ -17,6 +17,26 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class RegistreringTypeTest {
 
     @Test
+    public void beregnRegistreringType_gir_SYKMELDT_REGISTRERING_når_bruker_er_sykemeldtMedArbeidsgiver_Og_Maksdato_Er_Null_Og_Toggle_Er_Skrudd_På() {
+        Oppfolgingsstatus oppfolgingsstatus = new Oppfolgingsstatus(
+                false,
+                false,
+                true,
+                Formidlingsgruppe.of("IARBS"),
+                Servicegruppe.of("VURDI"),
+                Rettighetsgruppe.of("IYT"));
+
+        String maksDato = null;
+        boolean erArbeidsrettetOppfolgingSykmeldtInngangAktiv = false;
+
+        SykmeldtInfoData sykeforlop = new SykmeldtInfoData(maksDato, erArbeidsrettetOppfolgingSykmeldtInngangAktiv);
+
+        RegistreringType registreringType = RegistreringType.beregnRegistreringType(oppfolgingsstatus, sykeforlop, true);
+
+        assertThat(registreringType).isEqualTo(SYKMELDT_REGISTRERING);
+    }
+
+    @Test
     public void beregnRegistreringType_gir_SPERRET_når_bruker_er_sykemeldtMedArbeidsgiver_Og_Maksdato_Er_Null() {
         Oppfolgingsstatus oppfolgingsstatus = new Oppfolgingsstatus(
                 false,

--- a/src/test/java/no/nav/fo/veilarbregistrering/registrering/bruker/RegistreringTypeTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/registrering/bruker/RegistreringTypeTest.java
@@ -31,7 +31,7 @@ public class RegistreringTypeTest {
 
         SykmeldtInfoData sykeforlop = new SykmeldtInfoData(maksDato, erArbeidsrettetOppfolgingSykmeldtInngangAktiv);
 
-        RegistreringType registreringType = RegistreringType.beregnRegistreringType(oppfolgingsstatus, sykeforlop);
+        RegistreringType registreringType = RegistreringType.beregnRegistreringType(oppfolgingsstatus, sykeforlop, false);
 
         assertThat(registreringType).isEqualTo(SPERRET);
     }
@@ -52,7 +52,7 @@ public class RegistreringTypeTest {
                 maksdato.asString(),
                 maksdato.beregnSykmeldtMellom39Og52Uker(LocalDate.of(2020, 5, 1)));
 
-        RegistreringType registreringType = RegistreringType.beregnRegistreringType(oppfolgingsstatus, sykeforlop);
+        RegistreringType registreringType = RegistreringType.beregnRegistreringType(oppfolgingsstatus, sykeforlop, false);
 
         assertThat(registreringType).isEqualTo(SPERRET);
     }
@@ -73,7 +73,7 @@ public class RegistreringTypeTest {
                 maksdato.asString(),
                 maksdato.beregnSykmeldtMellom39Og52Uker(LocalDate.of(2020, 5, 1)));
 
-        RegistreringType registreringType = RegistreringType.beregnRegistreringType(oppfolgingsstatus, sykeforlop);
+        RegistreringType registreringType = RegistreringType.beregnRegistreringType(oppfolgingsstatus, sykeforlop, false);
 
         assertThat(registreringType).isEqualTo(SYKMELDT_REGISTRERING);
     }

--- a/src/test/java/no/nav/fo/veilarbregistrering/registrering/bruker/StartRegistreringStatusServiceTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/registrering/bruker/StartRegistreringStatusServiceTest.java
@@ -12,6 +12,7 @@ import no.nav.fo.veilarbregistrering.sykemelding.SykemeldingService;
 import no.nav.fo.veilarbregistrering.sykemelding.adapter.InfotrygdData;
 import no.nav.fo.veilarbregistrering.sykemelding.adapter.SykemeldingGatewayImpl;
 import no.nav.fo.veilarbregistrering.sykemelding.adapter.SykmeldtInfoClient;
+import no.nav.sbl.featuretoggle.unleash.UnleashService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -47,10 +48,11 @@ public class StartRegistreringStatusServiceTest {
         sykeforloepMetadataClient = mock(SykmeldtInfoClient.class);
         SykemeldingService sykemeldingService = new SykemeldingService(new SykemeldingGatewayImpl(sykeforloepMetadataClient));
         personGateway = mock(PersonGateway.class);
+        UnleashService unleashService = mock(UnleashService.class);
 
         brukerRegistreringService = new StartRegistreringStatusService(
                     arbeidsforholdGateway,
-                    new BrukerTilstandService(oppfolgingGateway, sykemeldingService),
+                    new BrukerTilstandService(oppfolgingGateway, sykemeldingService, unleashService),
                     personGateway);
     }
 

--- a/src/test/java/no/nav/fo/veilarbregistrering/registrering/bruker/SykmeldtRegistreringServiceTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/registrering/bruker/SykmeldtRegistreringServiceTest.java
@@ -9,6 +9,7 @@ import no.nav.fo.veilarbregistrering.sykemelding.SykemeldingService;
 import no.nav.fo.veilarbregistrering.sykemelding.adapter.InfotrygdData;
 import no.nav.fo.veilarbregistrering.sykemelding.adapter.SykemeldingGatewayImpl;
 import no.nav.fo.veilarbregistrering.sykemelding.adapter.SykmeldtInfoClient;
+import no.nav.sbl.featuretoggle.unleash.UnleashService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -37,6 +38,7 @@ public class SykmeldtRegistreringServiceTest {
         oppfolgingClient = mock(OppfolgingClient.class);
         sykeforloepMetadataClient = mock(SykmeldtInfoClient.class);
         manuellRegistreringRepository = mock(ManuellRegistreringRepository.class);
+        UnleashService unleashService = mock(UnleashService.class);
 
         OppfolgingGatewayImpl oppfolgingGateway = new OppfolgingGatewayImpl(oppfolgingClient);
 
@@ -44,7 +46,7 @@ public class SykmeldtRegistreringServiceTest {
                 new SykmeldtRegistreringService(
                         new BrukerTilstandService(
                                 oppfolgingGateway,
-                                new SykemeldingService(new SykemeldingGatewayImpl(sykeforloepMetadataClient))),
+                                new SykemeldingService(new SykemeldingGatewayImpl(sykeforloepMetadataClient)), unleashService),
                         oppfolgingGateway,
                         brukerRegistreringRepository,
                         manuellRegistreringRepository);

--- a/src/test/java/no/nav/fo/veilarbregistrering/registrering/bruker/resources/StartRegistreringStatusDtoMapperTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/registrering/bruker/resources/StartRegistreringStatusDtoMapperTest.java
@@ -28,7 +28,7 @@ public class StartRegistreringStatusDtoMapperTest {
                 null,
                 null);
         SykmeldtInfoData sykmeldtInfoData = new SykmeldtInfoData(null, false);
-        BrukersTilstand brukersTilstand = new BrukersTilstand(oppfolgingsstatus, sykmeldtInfoData);
+        BrukersTilstand brukersTilstand = new BrukersTilstand(oppfolgingsstatus, sykmeldtInfoData, false);
 
         StartRegistreringStatusDto dto = StartRegistreringStatusDtoMapper.map(
                 brukersTilstand,
@@ -60,7 +60,7 @@ public class StartRegistreringStatusDtoMapperTest {
                 Servicegruppe.of("SERV"),
                 Rettighetsgruppe.of("AAP"));
         SykmeldtInfoData sykmeldtInfoData = new SykmeldtInfoData("01122019", true);
-        BrukersTilstand brukersTilstand = new BrukersTilstand(oppfolgingsstatus, sykmeldtInfoData);
+        BrukersTilstand brukersTilstand = new BrukersTilstand(oppfolgingsstatus, sykmeldtInfoData, false);
 
         StartRegistreringStatusDto dto = StartRegistreringStatusDtoMapper.map(
                 brukersTilstand,
@@ -92,7 +92,7 @@ public class StartRegistreringStatusDtoMapperTest {
                 Servicegruppe.of("SERV"),
                 Rettighetsgruppe.of("AAP"));
         SykmeldtInfoData sykmeldtInfoData = new SykmeldtInfoData("01122019", true);
-        BrukersTilstand brukersTilstand = new BrukersTilstand(oppfolgingsstatus, sykmeldtInfoData);
+        BrukersTilstand brukersTilstand = new BrukersTilstand(oppfolgingsstatus, sykmeldtInfoData, false);
 
         StartRegistreringStatusDto dto = StartRegistreringStatusDtoMapper.map(
                 brukersTilstand,

--- a/src/test/java/no/nav/fo/veilarbregistrering/sykemelding/adapter/SykmeldtInfoClientTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/sykemelding/adapter/SykmeldtInfoClientTest.java
@@ -13,6 +13,7 @@ import no.nav.fo.veilarbregistrering.registrering.bruker.SykmeldtRegistrering;
 import no.nav.fo.veilarbregistrering.registrering.bruker.SykmeldtRegistreringService;
 import no.nav.fo.veilarbregistrering.registrering.manuell.ManuellRegistreringRepository;
 import no.nav.fo.veilarbregistrering.sykemelding.SykemeldingService;
+import no.nav.sbl.featuretoggle.unleash.UnleashService;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
@@ -53,6 +54,7 @@ class SykmeldtInfoClientTest {
         oppfolgingClient = buildOppfolgingClient();
         BrukerRegistreringRepository brukerRegistreringRepository = mock(BrukerRegistreringRepository.class);
         sykeforloepMetadataClient = buildSykeForloepClient();
+        UnleashService unleashService = mock(UnleashService.class);
 
         OppfolgingGatewayImpl oppfolgingGateway = new OppfolgingGatewayImpl(oppfolgingClient);
         ManuellRegistreringRepository manuellRegistreringRepository = mock(ManuellRegistreringRepository.class);
@@ -61,7 +63,7 @@ class SykmeldtInfoClientTest {
                 new SykmeldtRegistreringService(
                         new BrukerTilstandService(
                                 oppfolgingGateway,
-                                new SykemeldingService(new SykemeldingGatewayImpl(sykeforloepMetadataClient))),
+                                new SykemeldingService(new SykemeldingGatewayImpl(sykeforloepMetadataClient)), unleashService),
                         oppfolgingGateway,
                         brukerRegistreringRepository,
                         manuellRegistreringRepository);

--- a/src/test/java/no/nav/veilarbregistrering/integrasjonstest/BrukerRegistreringServiceIntegrationTest.java
+++ b/src/test/java/no/nav/veilarbregistrering/integrasjonstest/BrukerRegistreringServiceIntegrationTest.java
@@ -17,6 +17,7 @@ import no.nav.fo.veilarbregistrering.registrering.tilstand.RegistreringTilstand;
 import no.nav.fo.veilarbregistrering.registrering.tilstand.RegistreringTilstandRepository;
 import no.nav.fo.veilarbregistrering.registrering.tilstand.Status;
 import no.nav.fo.veilarbregistrering.sykemelding.SykemeldingService;
+import no.nav.sbl.featuretoggle.unleash.UnleashService;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -148,6 +149,9 @@ class BrukerRegistreringServiceIntegrationTest {
     public static class BrukerregistreringConfigTest {
 
         @Bean
+        public UnleashService unleashService() { return mock(UnleashService.class); }
+
+        @Bean
         public OppfolgingGateway oppfolgingGateway() {
             return mock(OppfolgingGateway.class);
         }
@@ -168,8 +172,8 @@ class BrukerRegistreringServiceIntegrationTest {
         }
 
         @Bean
-        public BrukerTilstandService hentBrukerTilstandService(OppfolgingGateway oppfolgingGateway, SykemeldingService sykemeldingService) {
-            return new BrukerTilstandService(oppfolgingGateway, sykemeldingService);
+        public BrukerTilstandService hentBrukerTilstandService(OppfolgingGateway oppfolgingGateway, SykemeldingService sykemeldingService, UnleashService unleashService) {
+            return new BrukerTilstandService(oppfolgingGateway, sykemeldingService, unleashService);
         }
 
         @Bean

--- a/src/test/kotlin/no/nav/fo/veilarbregistrering/db/HentBrukerRegistreringServiceIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/fo/veilarbregistrering/db/HentBrukerRegistreringServiceIntegrationTest.kt
@@ -22,6 +22,7 @@ import no.nav.fo.veilarbregistrering.registrering.tilstand.RegistreringTilstand
 import no.nav.fo.veilarbregistrering.registrering.tilstand.RegistreringTilstandRepository
 import no.nav.fo.veilarbregistrering.registrering.tilstand.Status
 import no.nav.fo.veilarbregistrering.sykemelding.SykemeldingService
+import no.nav.sbl.featuretoggle.unleash.UnleashService
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -82,9 +83,12 @@ open class HentBrukerRegistreringServiceIntegrationTest(
             manuellRegistreringRepository: ManuellRegistreringRepository) = HentRegistreringService(brukerRegistreringRepository, profileringRepository, manuellRegistreringRepository, norg2Gateway())
 
             @Bean
-            open fun hentBrukerTilstandService(oppfolgingGateway: OppfolgingGateway?, sykemeldingService: SykemeldingService?): BrukerTilstandService? {
-                return BrukerTilstandService(oppfolgingGateway, sykemeldingService)
+            open fun hentBrukerTilstandService(oppfolgingGateway: OppfolgingGateway, sykemeldingService: SykemeldingService, unleashService: UnleashService): BrukerTilstandService {
+                return BrukerTilstandService(oppfolgingGateway, sykemeldingService, unleashService)
             }
+
+            @Bean
+            open fun unleashService(): UnleashService = Mockito.mock(UnleashService::class.java)
 
             @Bean
             open fun sykemeldingService(): SykemeldingService = Mockito.mock(SykemeldingService::class.java)


### PR DESCRIPTION
Helse har etterhvert kommet opp med nye løsninger som fatter vedtak ifm. sykpenger. Det gjør at data i Infotrygd blir mer og mer utdaterte.
Da funker det ikke lenger å gjøre en validering med maksdato ifm. sykmeldt-registrering. Vi ønsker derfor å kunne skru den av. I første omgang via toggle, men senere permanent om det funker.