### PR TITLE
Dropper sammenligning mellom SOAP og REST.

### DIFF
--- a/src/main/java/no/nav/fo/veilarbregistrering/arbeidsforhold/adapter/AaregRestClient.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/arbeidsforhold/adapter/AaregRestClient.java
@@ -11,10 +11,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 
-import javax.ws.rs.BadRequestException;
-import javax.ws.rs.ForbiddenException;
-import javax.ws.rs.NotAuthorizedException;
-import javax.ws.rs.NotFoundException;
+import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import java.util.Collections;
 import java.util.List;
@@ -58,21 +55,9 @@ class AaregRestClient {
             String jsonResponse = utforRequest(fnr);
             return parse(jsonResponse);
 
-        } catch (BadRequestException e) {
-            throw new RuntimeException("Ugyldig input", e);
-
-        } catch (NotAuthorizedException e) {
-            throw new RuntimeException("Token mangler eller er ugyldig", e);
-
-        } catch (ForbiddenException e) {
-            throw new RuntimeException("Ingen tilgang til forespurt ressurs", e);
-
         } catch (NotFoundException e) {
             LOG.warn("Søk på arbeidforhold gav ingen treff", e);
             return Collections.emptyList();
-
-        } catch (RuntimeException e) {
-            throw new RuntimeException("Noe gikk galt mot Aareg", e);
         }
     }
 

--- a/src/main/java/no/nav/fo/veilarbregistrering/arbeidsforhold/adapter/ProxyArbeidsforholdGateway.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/arbeidsforhold/adapter/ProxyArbeidsforholdGateway.java
@@ -26,21 +26,14 @@ public class ProxyArbeidsforholdGateway implements ArbeidsforholdGateway {
 
     @Override
     public FlereArbeidsforhold hentArbeidsforhold(Foedselsnummer fnr) {
-        FlereArbeidsforhold arbeidsforholdFraSoap = hentArbeidsforholdFraSoap(fnr);
-
+        FlereArbeidsforhold flereArbeidsforhold;
         if (arbeidsforholdRestIsEnabled()) {
-            FlereArbeidsforhold arbeidsforholdFraRest = hentArbeidsforholdFraRest(fnr);
-
-            if (arbeidsforholdFraSoap.erLik(arbeidsforholdFraRest)) {
-                LOG.info("Ny og gammel respons er lik");
-            } else {
-                LOG.info("Ny og gammel respons er ulik");
-                LOG.info(String.format("SOAP: %s", arbeidsforholdFraSoap.toString()));
-                LOG.info(String.format("REST: %s", arbeidsforholdFraRest.toString()));
-            }
+            flereArbeidsforhold = hentArbeidsforholdFraRest(fnr);
+        } else {
+            flereArbeidsforhold = hentArbeidsforholdFraSoap(fnr);
         }
 
-        return arbeidsforholdFraSoap;
+        return flereArbeidsforhold;
     }
 
     private FlereArbeidsforhold hentArbeidsforholdFraSoap(Foedselsnummer fnr) {

--- a/src/test/java/no/nav/fo/veilarbregistrering/arbeidsforhold/ArbeidsforholdTestdataBuilder.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/arbeidsforhold/ArbeidsforholdTestdataBuilder.java
@@ -4,43 +4,87 @@ import java.time.LocalDate;
 
 public class ArbeidsforholdTestdataBuilder {
 
+    private LocalDate fom;
+    private LocalDate tom;
+    private String organisasjonsnummer;
+    private String styrk;
+    private String navArbeidsforholdId;
+
     public static Arbeidsforhold tidligereArbeidsforhold() {
-        return medDato(
-                LocalDate.of(2012, 3, 1),
-                LocalDate.of(2016, 3, 31));
+        return new ArbeidsforholdTestdataBuilder()
+                .periode(
+                        LocalDate.of(2012, 3, 1),
+                        LocalDate.of(2016, 3, 31))
+                .build();
     }
 
     public static Arbeidsforhold åpentArbeidsforhold() {
-        return medDato(
-                LocalDate.of(2016, 4, 1),
-                null);
+        return new ArbeidsforholdTestdataBuilder()
+                .periode(
+                        LocalDate.of(2016, 4, 1),
+                        null)
+                .build();
     }
 
     public static Arbeidsforhold paagaaende() {
-        LocalDate fom = LocalDate.of(2017,11,1);
-        LocalDate tom = null;
-        return new Arbeidsforhold("555555555", null, fom, tom, null);
+        return new ArbeidsforholdTestdataBuilder()
+                .organisasjonsnummer("555555555")
+                .periode(LocalDate.of(2017, 11, 1), null)
+                .build();
     }
 
     public static Arbeidsforhold siste() {
-        LocalDate fom = LocalDate.of(2017,11,1);
-        LocalDate tom = LocalDate.of(2017,11,30);
-        return new Arbeidsforhold("123456789", null, fom, tom, null);
+        return new ArbeidsforholdTestdataBuilder()
+                .organisasjonsnummer("123456789")
+                .periode(
+                        LocalDate.of(2017, 11, 1),
+                        LocalDate.of(2017, 11, 30))
+                .build();
     }
 
     public static Arbeidsforhold nestSiste() {
-        LocalDate fom = LocalDate.of(2017,9,1);
-        LocalDate tom = LocalDate.of(2017,9,30);
-        return new Arbeidsforhold("987654321", null, fom, tom, null);
+        return new ArbeidsforholdTestdataBuilder()
+                .organisasjonsnummer("987654321")
+                .periode(
+                        LocalDate.of(2017, 9, 1),
+                        LocalDate.of(2017, 9, 30))
+                .build();
     }
 
     public static Arbeidsforhold eldre() {
-        LocalDate fom = LocalDate.of(2017,4,1);
-        LocalDate tom = LocalDate.of(2017,4,30);
-        return new Arbeidsforhold(null, null, fom, tom, null);
+        return new ArbeidsforholdTestdataBuilder()
+                .periode(
+                        LocalDate.of(2017, 4, 1),
+                        LocalDate.of(2017, 4, 30))
+                .build();
     }
 
     public static Arbeidsforhold medDato(LocalDate fom, LocalDate tom) {
-        return new Arbeidsforhold(null, null, fom, tom, null);
+        return new ArbeidsforholdTestdataBuilder().periode(fom, tom).build();
+    }
+
+    public ArbeidsforholdTestdataBuilder periode(LocalDate fom, LocalDate tom) {
+        this.fom = fom;
+        this.tom = tom;
+        return this;
+    }
+
+    public ArbeidsforholdTestdataBuilder organisasjonsnummer(String organisasjonsnummer) {
+        this.organisasjonsnummer = organisasjonsnummer;
+        return this;
+    }
+
+    public ArbeidsforholdTestdataBuilder styrk(String styrk) {
+        this.styrk = styrk;
+        return this;
+    }
+
+    public ArbeidsforholdTestdataBuilder navArbeidsforholdId(String navArbeidsforholdId) {
+        this.navArbeidsforholdId = navArbeidsforholdId;
+        return this;
+    }
+
+    public Arbeidsforhold build() {
+        return new Arbeidsforhold(organisasjonsnummer, styrk, fom, tom, navArbeidsforholdId);
     }
 }

--- a/src/test/java/no/nav/fo/veilarbregistrering/arbeidsforhold/FlereArbeidsforholdTestdataBuilder.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/arbeidsforhold/FlereArbeidsforholdTestdataBuilder.java
@@ -1,5 +1,6 @@
 package no.nav.fo.veilarbregistrering.arbeidsforhold;
 
+import java.time.LocalDate;
 import java.util.List;
 
 import static java.util.Arrays.asList;
@@ -11,6 +12,19 @@ public class FlereArbeidsforholdTestdataBuilder {
 
         // Skal hente sistearbeidsforhold
         List<Arbeidsforhold> tilfeldigSortertListe = asList(eldre(), siste(), nestSiste());
+        return FlereArbeidsforhold.of(tilfeldigSortertListe);
+    }
+
+    public static FlereArbeidsforhold somJson() {
+
+        // Skal hente sistearbeidsforhold
+        List<Arbeidsforhold> tilfeldigSortertListe = asList(new ArbeidsforholdTestdataBuilder()
+                .organisasjonsnummer("981129687")
+                .styrk("2130123")
+                .periode(LocalDate.of(2014, 7, 1), LocalDate.of(2015, 12, 31))
+                .navArbeidsforholdId("123456")
+                .build());
+
         return FlereArbeidsforhold.of(tilfeldigSortertListe);
     }
 }

--- a/src/test/java/no/nav/fo/veilarbregistrering/arbeidsforhold/adapter/ProxyArbeidsforholdGatewayTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/arbeidsforhold/adapter/ProxyArbeidsforholdGatewayTest.java
@@ -2,6 +2,7 @@ package no.nav.fo.veilarbregistrering.arbeidsforhold.adapter;
 
 import no.nav.fo.veilarbregistrering.arbeidsforhold.ArbeidsforholdGateway;
 import no.nav.fo.veilarbregistrering.arbeidsforhold.FlereArbeidsforhold;
+import no.nav.fo.veilarbregistrering.arbeidsforhold.FlereArbeidsforholdTestdataBuilder;
 import no.nav.fo.veilarbregistrering.bruker.Foedselsnummer;
 import no.nav.sbl.featuretoggle.unleash.UnleashService;
 import org.junit.jupiter.api.Test;
@@ -35,6 +36,6 @@ public class ProxyArbeidsforholdGatewayTest {
 
         FlereArbeidsforhold flereArbeidsforhold = arbeidsforholdGatewayProxy.hentArbeidsforhold(Foedselsnummer.of("12345678910"));
 
-        assertThat(flereArbeidsforhold.siste()).isEqualTo(åpentArbeidsforhold());
+        assertThat(flereArbeidsforhold).isEqualTo(FlereArbeidsforholdTestdataBuilder.somJson());
     }
 }


### PR DESCRIPTION
Siste steg før vi kvitter oss med SOAP. Begynner nå å kalle REST som default og ikke SOAP. Er vi happy, så skrur vi av SOAP.