### PR TITLE
Renamer ArbeidsforholdGateway og fjerner config

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -109,7 +109,7 @@ jobs:
       env:
         APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
         CLUSTER: prod-fss
-        DRY_RUN: false
+        DRY_RUN: true
         RESOURCE: nais/nais.yaml
         VARS: nais/vars-p.yaml
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ for beskrivelse av APIet til `veilarbregistrering`.
 - [Arena ORDS : REST](src/main/java/no/nav/fo/veilarbregistrering/arbeidssoker/adapter/README.md)
 - veilarbperson : REST
 - ABAC (tilgangskontroll)
-- Aareg (siste arbeidsforhold) : SOAP
+- [Aareg (siste arbeidsforhold) : REST](src/main/java/no/nav/fo/veilarbregistrering/arbeidsforhold/adapter/README.md)
 - [Enhetsregisteret : REST](src/main/java/no/nav/fo/veilarbregistrering/enhet/adapter/README.md)
 - [NAV Organisasjon (for veileder pr ident) : REST](src/main/java/no/nav/fo/veilarbregistrering/orgenhet/adapter/README.md)
 - Infotrygd (maksdato) : REST

--- a/nais/nais.yaml
+++ b/nais/nais.yaml
@@ -18,8 +18,6 @@ spec:
       value: {{ app_environment_name }}
     - name: FEATURE_ENDPOINT_URL
       value: {{ feature_endpoint_url }}
-    - name: VIRKSOMHET_ARBEIDSFORHOLD_V3_ENDPOINTURL
-      value: {{ aareg_url }}
     - name: AAREG_REST_API
       value: {{ aareg_rest_api }}
     - name: OPENAM_DISCOVERY_URL

--- a/nais/vars-p.yaml
+++ b/nais/vars-p.yaml
@@ -1,7 +1,6 @@
 namespace: default
 app_environment_name: p
 feature_endpoint_url: https://feature-fss.nais.adeo.no/feature
-aareg_url: https://modapp.adeo.no/aareg-services/ArbeidsforholdService/v3
 aareg_rest_api: https://modapp.adeo.no/aareg-services/api
 openam_discovery_url: https://isso.adeo.no/isso/oauth2/.well-known/openid-configuration
 veilarblogin_openam_clientid: veilarblogin-p

--- a/nais/vars-q0.yaml
+++ b/nais/vars-q0.yaml
@@ -1,7 +1,6 @@
 namespace: q0
 app_environment_name: q0
 feature_endpoint_url: https://feature-fss-q0.nais.preprod.local/feature
-aareg_url: https://modapp-q0.adeo.no/aareg-services/ArbeidsforholdService/v3
 aareg_rest_api: https://modapp-q0.adeo.no/aareg-services/api
 openam_discovery_url: https://isso-q.adeo.no/isso/oauth2/.well-known/openid-configuration
 veilarblogin_openam_clientid: veilarblogin-q0

--- a/nais/vars-q1.yaml
+++ b/nais/vars-q1.yaml
@@ -1,7 +1,6 @@
 namespace: q1
 app_environment_name: q1
 feature_endpoint_url: https://feature-fss-q1.nais.preprod.local/feature
-aareg_url: https://modapp-q1.adeo.no/aareg-services/ArbeidsforholdService/v3
 aareg_rest_api: https://modapp-q1.adeo.no/aareg-services/api
 openam_discovery_url: https://isso-q.adeo.no/isso/oauth2/.well-known/openid-configuration
 veilarblogin_openam_clientid: veilarblogin-q1

--- a/src/main/java/no/nav/fo/veilarbregistrering/arbeidsforhold/adapter/AAregServiceWSConfig.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/arbeidsforhold/adapter/AAregServiceWSConfig.java
@@ -18,7 +18,7 @@ public class AAregServiceWSConfig {
     }
 
     @Bean
-    ArbeidsforholdGateway restArbeidsforholdGateway(AaregRestClient aaregRestClient) {
-        return new RestArbeidsforholdGateway(aaregRestClient);
+    ArbeidsforholdGateway arbeidsforholdGateway(AaregRestClient aaregRestClient) {
+        return new ArbeidsforholdGatewayImpl(aaregRestClient);
     }
 }

--- a/src/main/java/no/nav/fo/veilarbregistrering/arbeidsforhold/adapter/ArbeidsforholdGatewayImpl.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/arbeidsforhold/adapter/ArbeidsforholdGatewayImpl.java
@@ -8,18 +8,18 @@ import org.springframework.cache.annotation.Cacheable;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static no.nav.fo.veilarbregistrering.config.CacheConfig.HENT_ARBEIDSFORHOLD_REST;
+import static no.nav.fo.veilarbregistrering.config.CacheConfig.HENT_ARBEIDSFORHOLD;
 
-public class RestArbeidsforholdGateway implements ArbeidsforholdGateway {
+public class ArbeidsforholdGatewayImpl implements ArbeidsforholdGateway {
 
     private final AaregRestClient aaregRestClient;
 
-    public RestArbeidsforholdGateway(AaregRestClient aaregRestClient) {
+    public ArbeidsforholdGatewayImpl(AaregRestClient aaregRestClient) {
         this.aaregRestClient = aaregRestClient;
     }
 
     @Override
-    @Cacheable(HENT_ARBEIDSFORHOLD_REST)
+    @Cacheable(HENT_ARBEIDSFORHOLD)
     public FlereArbeidsforhold hentArbeidsforhold(Foedselsnummer fnr) {
         List<ArbeidsforholdDto> arbeidsforholdDtos = aaregRestClient.finnArbeidsforhold(fnr);
         return FlereArbeidsforhold.of(arbeidsforholdDtos.stream()

--- a/src/main/java/no/nav/fo/veilarbregistrering/config/CacheConfig.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/config/CacheConfig.java
@@ -14,8 +14,8 @@ import static no.nav.sbl.dialogarena.common.abac.pep.context.AbacContext.ABAC_CA
 @EnableCaching
 public class CacheConfig {
 
-    public static final String HENT_ARBEIDSFORHOLD_REST = "hentArbeidsforholdRest";
-    private static final CacheConfiguration HENT_ARBEIDSFORHOLD_REST_CACHE = new CacheConfiguration(HENT_ARBEIDSFORHOLD_REST, 100000)
+    public static final String HENT_ARBEIDSFORHOLD = "hentArbeidsforhold";
+    private static final CacheConfiguration HENT_ARBEIDSFORHOLD_CACHE = new CacheConfiguration(HENT_ARBEIDSFORHOLD, 100000)
             .memoryStoreEvictionPolicy(LRU)
             .timeToIdleSeconds(3600)
             .timeToLiveSeconds(3600);
@@ -48,7 +48,7 @@ public class CacheConfig {
     public CacheManager cacheManager() {
         net.sf.ehcache.config.Configuration config = new net.sf.ehcache.config.Configuration();
         config.addCache(ABAC_CACHE);
-        config.addCache(HENT_ARBEIDSFORHOLD_REST_CACHE);
+        config.addCache(HENT_ARBEIDSFORHOLD_CACHE);
         config.addCache(HENT_ALLE_ENHETER_CACHE);
         config.addCache(HENT_ALLE_ENHETER_V2_CACHE);
         config.addCache(HENT_PERSON_FOR_AKTORID_CACHE);

--- a/src/test/java/no/nav/fo/veilarbregistrering/arbeidsforhold/adapter/AAregServiceWSConfig.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/arbeidsforhold/adapter/AAregServiceWSConfig.java
@@ -8,7 +8,7 @@ import org.springframework.context.annotation.Configuration;
 public class AAregServiceWSConfig {
 
     @Bean
-    ArbeidsforholdGateway restArbeidsforholdGateway() {
-        return new RestArbeidsforholdGateway(new StubAaregRestClient());
+    ArbeidsforholdGateway arbeidsforholdGateway() {
+        return new ArbeidsforholdGatewayImpl(new StubAaregRestClient());
     }
 }

--- a/src/test/java/no/nav/fo/veilarbregistrering/arbeidsforhold/adapter/ArbeidsforholdGatewayImplTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/arbeidsforhold/adapter/ArbeidsforholdGatewayImplTest.java
@@ -11,12 +11,12 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class RestArbeidsforholdGatewayTest {
+public class ArbeidsforholdGatewayImplTest {
 
     private final UnleashService unleashService = mock(UnleashService.class);
 
     private ArbeidsforholdGateway arbeidsforholdGatewayProxy =
-            new RestArbeidsforholdGateway(new StubAaregRestClient());
+            new ArbeidsforholdGatewayImpl(new StubAaregRestClient());
 
     @Test
     public void hent_arbeidsforhold_fra_aareg_via_rest() {

--- a/src/test/java/no/nav/fo/veilarbregistrering/arbeidsforhold/adapter/ArbeidsforholdGatewayTest.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/arbeidsforhold/adapter/ArbeidsforholdGatewayTest.java
@@ -25,7 +25,7 @@ class ArbeidsforholdGatewayTest {
     public static void setup() {
         aaregRestClient = mock(AaregRestClient.class);
 
-        BeanDefinition beanDefinition = BeanDefinitionBuilder.rootBeanDefinition(RestArbeidsforholdGateway.class)
+        BeanDefinition beanDefinition = BeanDefinitionBuilder.rootBeanDefinition(ArbeidsforholdGatewayImpl.class)
                 .addConstructorArgValue(aaregRestClient).getBeanDefinition();
 
         context = new AnnotationConfigApplicationContext();


### PR DESCRIPTION
Renamer ArbeidsforholdGateway til å ikkke fokusere på REST. Ønsker ikke at det skal være så sentralt, langt opp i stacken.
Fjerner samtidig config knyttet til gammel SOAP-tjeneste.