### PR TITLE
Fjerner bruk av no.nav.commons:jdbc da den er overflødig

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -109,7 +109,7 @@ jobs:
       env:
         APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
         CLUSTER: prod-fss
-        DRY_RUN: false
+        DRY_RUN: true
         RESOURCE: nais/nais.yaml
         VARS: nais/vars-p.yaml
 

--- a/pom.xml
+++ b/pom.xml
@@ -234,10 +234,6 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>no.nav.common</groupId>
-            <artifactId>jdbc</artifactId>
-        </dependency>
-        <dependency>
             <groupId>io.swagger</groupId>
             <artifactId>swagger-annotations</artifactId>
         </dependency>

--- a/src/main/java/no/nav/fo/veilarbregistrering/db/DatabaseConfig.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/db/DatabaseConfig.java
@@ -3,7 +3,6 @@ package no.nav.fo.veilarbregistrering.db;
 
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
-import no.nav.sbl.jdbc.Database;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -51,11 +50,6 @@ public class DatabaseConfig {
     @Bean
     public NamedParameterJdbcTemplate namedParameterJdbcTemplate(DataSource dataSource) {
         return new NamedParameterJdbcTemplate(dataSource);
-    }
-
-    @Bean
-    public Database database(JdbcTemplate jdbcTemplate) {
-        return new Database(jdbcTemplate);
     }
 
 }

--- a/src/test/java/no/nav/fo/veilarbregistrering/db/DatabaseConfig.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/db/DatabaseConfig.java
@@ -2,7 +2,6 @@ package no.nav.fo.veilarbregistrering.db;
 
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
-import no.nav.sbl.jdbc.Database;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -44,11 +43,6 @@ public class DatabaseConfig {
     @Bean
     public NamedParameterJdbcTemplate namedParameterJdbcTemplate(DataSource dataSource) {
         return new NamedParameterJdbcTemplate(dataSource);
-    }
-
-    @Bean
-    public Database database(JdbcTemplate jdbcTemplate) {
-        return new Database(jdbcTemplate);
     }
 
 }


### PR DESCRIPTION
Denne avhengigheten tilbyr en wrapper rundt DataSource og NamedJdbcTemplate som ikke gir noen verdi og som vi ikke lenger benytter. Kan derfor fjernes.