### PR TITLE
Fjerner cxf-dependencies

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -109,7 +109,7 @@ jobs:
       env:
         APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
         CLUSTER: prod-fss
-        DRY_RUN: false
+        DRY_RUN: true
         RESOURCE: nais/nais.yaml
         VARS: nais/vars-p.yaml
 

--- a/pom.xml
+++ b/pom.xml
@@ -61,10 +61,6 @@
             <artifactId>nais</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.cxf</groupId>
-            <artifactId>cxf-core</artifactId>
-        </dependency>
-        <dependency>
             <groupId>no.nav.common</groupId>
             <artifactId>types</artifactId>
         </dependency>
@@ -79,11 +75,6 @@
         <dependency>
             <groupId>io.vavr</groupId>
             <artifactId>vavr</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>no.nav.tjenestespesifikasjoner</groupId>
-            <artifactId>nav-arbeidsforhold-v3-tjenestespesifikasjon</artifactId>
-            <version>1.2019.09.25-00.21-49b69f0625e0</version>
         </dependency>
         <dependency>
             <groupId>no.bekk.bekkopen</groupId>
@@ -119,10 +110,6 @@
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>no.nav.common</groupId>
-            <artifactId>cxf</artifactId>
         </dependency>
         <dependency>
             <groupId>org.glassfish.hk2.external</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,11 @@
             <version>1.2020.02.21_09.07-69c044da9255</version>
         </dependency>
         <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk15on</artifactId>
+            <version>1.60</version>
+        </dependency>
+        <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
         </dependency>


### PR DESCRIPTION
Disse er mest sannsynlig vært i bruk ifm. SOAP/WebService, og nå som den siste (Aareg) er ute kan vi kjøre uten. Det gjør appen litt "slankere".