### PR TITLE
Tar vare på referansen til Prometheus-metricen slik at den ikke blir GCet bort

### DIFF
--- a/src/main/java/no/nav/fo/veilarbregistrering/metrics/PrometheusMetricsService.kt
+++ b/src/main/java/no/nav/fo/veilarbregistrering/metrics/PrometheusMetricsService.kt
@@ -16,18 +16,17 @@ class PrometheusMetricsService(private val meterRegistry: MeterRegistry) {
 
     fun rapporterRegistreringStatusAntall(antallPerStatus: Map<Status, Int>) {
         antallPerStatus.forEach {
-            val registrertAntall = statusVerdier.getOrElse(it.key) {
+            val registrertAntall = statusVerdier.computeIfAbsent(it.key) { key ->
                 val atomiskAntall = AtomicInteger()
                 meterRegistry.gauge(
                         "veilarbregistrering_registrert_status",
-                        listOf(Tag.of("status", it.key.name)),
-                        atomiskAntall
-                ) { obj: AtomicInteger -> obj.get().toDouble() }
+                        listOf(Tag.of("status", key.name)),
+                        atomiskAntall)
                 atomiskAntall
             }
             registrertAntall.set(it.value)
         }
     }
-
-    private val statusVerdier: Map<Status, AtomicInteger> = HashMap()
+    
+    private val statusVerdier: MutableMap<Status, AtomicInteger> = HashMap()
 }


### PR DESCRIPTION
Prometheus-metrics baserer seg på at referansen til verdi-objektet beholdes, slik at den ikke blir GCet bort.
Når verdiene blir GCet bort, ender de opp som NaN i prometheus-metricene.
Det er derfor viktig at vi har et statusVerdier-map med referansen til AtomicInteger-objektet.