### PR TITLE
Legger til SelfTestStatusMeterBinder for rapportering av status per selftest

### DIFF
--- a/src/main/java/no/nav/fo/veilarbregistrering/helsesjekk/HelsesjekkConfig.kt
+++ b/src/main/java/no/nav/fo/veilarbregistrering/helsesjekk/HelsesjekkConfig.kt
@@ -48,7 +48,8 @@ class HelsesjekkConfig {
     }
 
     @Bean
-    fun selfTestMeterBinder(selfTestChecks: SelfTestChecks): SelfTestMeterBinder {
-        return SelfTestMeterBinder(selfTestChecks)
-    }
+    fun selfTestAggregateMeterBinder(selfTestChecks: SelfTestChecks) = SelfTestMeterBinder(selfTestChecks)
+
+    @Bean
+    fun selfTestStatusMeterBinder(selfTestChecks: SelfTestChecks) = SelfTestStatusMeterBinder(selfTestChecks)
 }

--- a/src/test/java/no/nav/fo/veilarbregistrering/helsesjekk/HelsesjekkConfig.kt
+++ b/src/test/java/no/nav/fo/veilarbregistrering/helsesjekk/HelsesjekkConfig.kt
@@ -30,9 +30,10 @@ class HelsesjekkConfig {
             }
         }
     }
-    
+
     @Bean
-    fun selfTestMeterBinder(selfTestChecks: SelfTestChecks): SelfTestMeterBinder {
-        return SelfTestMeterBinder(selfTestChecks)
-    }
+    fun selfTestAggregateMeterBinder(selfTestChecks: SelfTestChecks) = SelfTestMeterBinder(selfTestChecks)
+
+    @Bean
+    fun selfTestStatusMeterBinder(selfTestChecks: SelfTestChecks) = SelfTestStatusMeterBinder(selfTestChecks)
 }

--- a/src/test/java/no/nav/fo/veilarbregistrering/helsesjekk/HelsesjekkConfig.kt
+++ b/src/test/java/no/nav/fo/veilarbregistrering/helsesjekk/HelsesjekkConfig.kt
@@ -4,6 +4,7 @@ import no.nav.common.health.HealthCheck
 import no.nav.common.health.HealthCheckResult
 import no.nav.common.health.selftest.SelfTestCheck
 import no.nav.common.health.selftest.SelfTestChecks
+import no.nav.common.health.selftest.SelfTestMeterBinder
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.jdbc.core.JdbcTemplate
@@ -28,5 +29,10 @@ class HelsesjekkConfig {
                 HealthCheckResult.unhealthy("Fikk ikke kontakt med databasen", e)
             }
         }
+    }
+    
+    @Bean
+    fun selfTestMeterBinder(selfTestChecks: SelfTestChecks): SelfTestMeterBinder {
+        return SelfTestMeterBinder(selfTestChecks)
     }
 }

--- a/src/test/java/no/nav/fo/veilarbregistrering/helsesjekk/HelsesjekkConfig.kt
+++ b/src/test/java/no/nav/fo/veilarbregistrering/helsesjekk/HelsesjekkConfig.kt
@@ -16,7 +16,8 @@ class HelsesjekkConfig {
         jdbcTemplate: JdbcTemplate,
     ): SelfTestChecks {
         return SelfTestChecks(listOf(
-            SelfTestCheck("Databasesjekk", true, checkDbHealth(jdbcTemplate))
+            SelfTestCheck("Databasesjekk", true, checkDbHealth(jdbcTemplate)),
+            SelfTestCheck("Dummysjekk", false, checkDummy())
         ))
     }
 
@@ -30,6 +31,8 @@ class HelsesjekkConfig {
             }
         }
     }
+
+    private fun checkDummy() = HealthCheck { HealthCheckResult.healthy() }
 
     @Bean
     fun selfTestAggregateMeterBinder(selfTestChecks: SelfTestChecks) = SelfTestMeterBinder(selfTestChecks)


### PR DESCRIPTION
Dette lar oss se _hvilke_ selftester som feiler, og ikke bare _at_ noe feiler.
Tidligere ble dette rapportert av nav-commons v1, men denne funksjonaliteten ble fjernet ved overgang til v2 siden dette ikke var i bruk.
På sikt gir det nok mening å dra dette inn i commons v2 igjen.