### PR TITLE
Bytt til https-URL for eksternt maven-repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <repositories>
         <repository>
             <id>confluent</id>
-            <url>http://packages.confluent.io/maven</url>
+            <url>https://packages.confluent.io/maven</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
http-lenker blir nå blokkert av maven, ref. https://maven.apache.org/docs/3.8.1/release-notes.html