### PR TITLE
Oppgraderer til neste versjon av commons-java m/ AuthContextHolder

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
         <java.version>11</java.version>
         <kotlin.version>1.4.21</kotlin.version>
         <kotlin.compiler.incremental>true</kotlin.compiler.incremental>
-        <common.version>2.2021.02.15_10.01-e640ec7bd33a</common.version>
+        <common.version>2.2021.02.23_11.33-7091f10a35ba</common.version>
         <junit.jupiter.version>5.7.0</junit.jupiter.version>
         <springfox.version>2.9.2</springfox.version>
     </properties>

--- a/src/main/java/no/nav/fo/veilarbregistrering/arbeidsforhold/adapter/AaregRestClient.kt
+++ b/src/main/java/no/nav/fo/veilarbregistrering/arbeidsforhold/adapter/AaregRestClient.kt
@@ -21,7 +21,10 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import java.io.IOException
 
-open class AaregRestClient(private val baseUrl: String, private val systemUserTokenProvider: SystemUserTokenProvider) : HealthCheck {
+open class AaregRestClient(
+        private val baseUrl: String,
+        private val systemUserTokenProvider: SystemUserTokenProvider,
+        private val authContextHolder: AuthContextHolder) : HealthCheck {
     /**
      * "Finn arbeidsforhold (detaljer) per arbeidstaker"
      */
@@ -37,7 +40,7 @@ open class AaregRestClient(private val baseUrl: String, private val systemUserTo
                         .addQueryParameter("regelverk", "A_ORDNINGEN")
                         .build())
                 .header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
-                .header(HttpHeaders.AUTHORIZATION, "Bearer " + AuthContextHolder.requireIdTokenString())
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + authContextHolder.requireIdTokenString())
                 .header(NAV_CONSUMER_TOKEN, "Bearer " + systemUserTokenProvider.systemUserToken)
                 .header(NAV_PERSONIDENT, fnr.stringValue())
                 .header(NAV_CALL_ID_HEADER, MDC.get(MDCConstants.MDC_CALL_ID))

--- a/src/main/java/no/nav/fo/veilarbregistrering/arbeidsforhold/adapter/ArbeidsforholdGatewayConfig.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/arbeidsforhold/adapter/ArbeidsforholdGatewayConfig.java
@@ -1,5 +1,6 @@
 package no.nav.fo.veilarbregistrering.arbeidsforhold.adapter;
 
+import no.nav.common.auth.context.AuthContextHolder;
 import no.nav.common.sts.SystemUserTokenProvider;
 import no.nav.fo.veilarbregistrering.arbeidsforhold.ArbeidsforholdGateway;
 import org.springframework.context.annotation.Bean;
@@ -13,8 +14,13 @@ public class ArbeidsforholdGatewayConfig {
     private final static String REST_URL = "AAREG_REST_API";
 
     @Bean
-    AaregRestClient aaregRestClient(SystemUserTokenProvider systemUserTokenProvider) {
-        return new AaregRestClient(getRequiredProperty(REST_URL), systemUserTokenProvider);
+    AaregRestClient aaregRestClient(
+            SystemUserTokenProvider systemUserTokenProvider,
+            AuthContextHolder authContextHolder) {
+        return new AaregRestClient(
+                getRequiredProperty(REST_URL),
+                systemUserTokenProvider,
+                authContextHolder);
     }
 
     @Bean

--- a/src/main/java/no/nav/fo/veilarbregistrering/autorisasjon/AutorisasjonService.kt
+++ b/src/main/java/no/nav/fo/veilarbregistrering/autorisasjon/AutorisasjonService.kt
@@ -9,10 +9,10 @@ import no.nav.fo.veilarbregistrering.bruker.Foedselsnummer
 import org.springframework.http.HttpStatus
 import org.springframework.web.server.ResponseStatusException
 
-open class AutorisasjonService(private val veilarbPep: Pep) {
+open class AutorisasjonService(private val veilarbPep: Pep, private val authContextHolder: AuthContextHolder) {
 
     fun erInternBruker(): Boolean {
-        return AuthContextHolder.erInternBruker()
+        return authContextHolder.erInternBruker()
     }
 
     fun sjekkLesetilgangTilBruker(fnr: Foedselsnummer) = veilarbPep.harTilgangTilPerson(innloggetBrukerToken, ActionId.READ, Fnr(fnr.stringValue()))
@@ -32,12 +32,12 @@ open class AutorisasjonService(private val veilarbPep: Pep) {
     }
 
     private val innloggetBrukerToken: String
-        get() = AuthContextHolder.getIdTokenString()
+        get() = authContextHolder.getIdTokenString()
             .orElseThrow { ResponseStatusException(HttpStatus.UNAUTHORIZED, "Fant ikke token for innlogget bruker") }
 
     // NAV ident, fnr eller annen ID
     val innloggetBrukerIdent: String
-        get() = AuthContextHolder.getSubject()
+        get() = authContextHolder.getSubject()
             .orElseThrow { ResponseStatusException(HttpStatus.UNAUTHORIZED, "NAV ident is missing") }
 
     val innloggetVeilederIdent: String

--- a/src/main/java/no/nav/fo/veilarbregistrering/bruker/UserService.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/bruker/UserService.java
@@ -1,20 +1,21 @@
 package no.nav.fo.veilarbregistrering.bruker;
 
 import no.bekk.bekkopen.person.FodselsnummerValidator;
-import no.nav.common.types.identer.Fnr;
+import no.nav.common.auth.context.AuthContextHolder;
 import no.nav.fo.veilarbregistrering.bruker.feil.ManglendeBrukerInfoException;
 import org.springframework.stereotype.Service;
 
-import static no.nav.common.auth.context.AuthContextHolder.getSubject;
 import static no.nav.fo.veilarbregistrering.config.RequestContext.servletRequest;
 
 @Service
 public class UserService {
 
     private final PdlOppslagGateway pdlOppslagGateway;
+    private final AuthContextHolder authContextHolder;
 
-    public UserService(PdlOppslagGateway pdlOppslagGateway) {
+    public UserService(PdlOppslagGateway pdlOppslagGateway, AuthContextHolder authContextHolder) {
         this.pdlOppslagGateway = pdlOppslagGateway;
+        this.authContextHolder = authContextHolder;
     }
 
     public Bruker finnBrukerGjennomPdl() {
@@ -57,7 +58,7 @@ public class UserService {
     }
 
     private String getFnr() {
-        return getSubject().orElseThrow(IllegalArgumentException::new);
+        return authContextHolder.getSubject().orElseThrow(IllegalArgumentException::new);
     }
 
     public String getEnhetIdFromUrlOrThrow() {

--- a/src/main/java/no/nav/fo/veilarbregistrering/config/ServiceBeansConfig.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/config/ServiceBeansConfig.java
@@ -1,6 +1,8 @@
 package no.nav.fo.veilarbregistrering.config;
 
 import no.nav.common.abac.Pep;
+import no.nav.common.auth.context.AuthContextHolder;
+import no.nav.common.auth.context.AuthContextHolderThreadLocal;
 import no.nav.common.featuretoggle.UnleashClient;
 import no.nav.common.health.selftest.SelfTestChecks;
 import no.nav.fo.veilarbregistrering.arbeidsforhold.ArbeidsforholdGateway;
@@ -45,6 +47,11 @@ import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class ServiceBeansConfig {
+
+    @Bean
+    public AuthContextHolder authContextHolder() {
+        return AuthContextHolderThreadLocal.instance();
+    }
 
     @Bean
     SykemeldingService sykemeldingService(
@@ -277,8 +284,8 @@ public class ServiceBeansConfig {
     }
 
     @Bean
-    UserService userService(PdlOppslagGateway pdlOppslagGateway) {
-        return new UserService(pdlOppslagGateway);
+    UserService userService(PdlOppslagGateway pdlOppslagGateway, AuthContextHolder authContextHolder) {
+        return new UserService(pdlOppslagGateway, authContextHolder);
     }
 
     @Bean
@@ -318,8 +325,8 @@ public class ServiceBeansConfig {
     }
 
     @Bean
-    AutorisasjonService autorisasjonService(Pep veilarbPep) {
-        return new AutorisasjonService(veilarbPep);
+    AutorisasjonService autorisasjonService(Pep veilarbPep, AuthContextHolder authContextHolder) {
+        return new AutorisasjonService(veilarbPep, authContextHolder);
     }
 
     @Bean

--- a/src/main/java/no/nav/fo/veilarbregistrering/helsesjekk/HelsesjekkConfig.kt
+++ b/src/main/java/no/nav/fo/veilarbregistrering/helsesjekk/HelsesjekkConfig.kt
@@ -1,7 +1,7 @@
 package no.nav.fo.veilarbregistrering.helsesjekk
 
 import no.nav.common.abac.Pep
-import no.nav.common.featuretoggle.UnleashClientImpl
+import no.nav.common.featuretoggle.UnleashClient
 import no.nav.common.health.selftest.SelfTestCheck
 import no.nav.common.health.selftest.SelfTestChecks
 import no.nav.common.health.selftest.SelfTestMeterBinder
@@ -23,7 +23,7 @@ class HelsesjekkConfig {
     fun selfTestChecks(
             dbHelsesjekk: DatabaseHelsesjekk,
             veilarbPep: Pep,
-            unleashClient: UnleashClientImpl,
+            unleashClient: UnleashClient,
             oppfolgingClient: OppfolgingClient,
             sykmeldtInfoClient: SykmeldtInfoClient,
             formidlingsgruppeRestClient: FormidlingsgruppeRestClient,

--- a/src/test/java/no/nav/fo/veilarbregistrering/arbeidsforhold/adapter/StubAaregRestClient.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/arbeidsforhold/adapter/StubAaregRestClient.java
@@ -1,5 +1,6 @@
 package no.nav.fo.veilarbregistrering.arbeidsforhold.adapter;
 
+import no.nav.common.auth.context.AuthContextHolder;
 import no.nav.common.sts.SystemUserTokenProvider;
 import no.nav.fo.veilarbregistrering.FileToJson;
 import no.nav.fo.veilarbregistrering.bruker.Foedselsnummer;
@@ -9,7 +10,7 @@ import static org.mockito.Mockito.mock;
 class StubAaregRestClient extends AaregRestClient {
 
     StubAaregRestClient() {
-        super("/test.nav.no", mock(SystemUserTokenProvider.class));
+        super("/test.nav.no", mock(SystemUserTokenProvider.class), mock(AuthContextHolder.class));
     }
 
     @Override

--- a/src/test/java/no/nav/fo/veilarbregistrering/bruker/UserServiceTest.kt
+++ b/src/test/java/no/nav/fo/veilarbregistrering/bruker/UserServiceTest.kt
@@ -4,6 +4,7 @@ import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
+import no.nav.common.auth.context.AuthContextHolder
 import no.nav.fo.veilarbregistrering.config.RequestContext
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
@@ -16,12 +17,14 @@ class UserServiceTest {
 
     private lateinit var userService: UserService
     private lateinit var pdlOppslagGateway: PdlOppslagGateway
+    private lateinit var authContextHolder: AuthContextHolder
 
     @BeforeEach
     fun setup() {
         clearAllMocks()
         pdlOppslagGateway = mockk()
-        userService = UserService(pdlOppslagGateway)
+        authContextHolder = mockk()
+        userService = UserService(pdlOppslagGateway, authContextHolder)
     }
 
     @Test

--- a/src/test/java/no/nav/fo/veilarbregistrering/config/ApplicationTestConfig.java
+++ b/src/test/java/no/nav/fo/veilarbregistrering/config/ApplicationTestConfig.java
@@ -25,7 +25,7 @@ public class ApplicationTestConfig extends ApplicationConfig {
     private class StubUserService extends UserService {
 
         public StubUserService() {
-            super(null);
+            super(null, null);
         }
 
         @Override

--- a/src/test/java/no/nav/fo/veilarbregistrering/registrering/bruker/resources/RegistreringResourceTest.kt
+++ b/src/test/java/no/nav/fo/veilarbregistrering/registrering/bruker/resources/RegistreringResourceTest.kt
@@ -1,6 +1,7 @@
 package no.nav.fo.veilarbregistrering.registrering.bruker.resources
 
 import io.mockk.*
+import no.nav.common.auth.context.AuthContextHolder
 import no.nav.common.featuretoggle.UnleashClient
 import no.nav.fo.veilarbregistrering.FileToJson
 import no.nav.fo.veilarbregistrering.autorisasjon.AutorisasjonService
@@ -272,7 +273,9 @@ private class RegistreringResourceConfig {
     @Bean
     fun startRegistreringStatusService(): StartRegistreringStatusService = mockk()
     @Bean
-    fun userService(pdlOppslagGateway: PdlOppslagGateway): UserService = UserService(pdlOppslagGateway)
+    fun authContextHolder(): AuthContextHolder = mockk()
+    @Bean
+    fun userService(pdlOppslagGateway: PdlOppslagGateway, authContextHolder: AuthContextHolder): UserService = UserService(pdlOppslagGateway, authContextHolder)
     @Bean
     fun sykmeldtRegistreringService(): SykmeldtRegistreringService = mockk(relaxed = true)
     @Bean

--- a/src/test/java/no/nav/fo/veilarbregistrering/tidslinje/resources/TidslinjeResourceTest.kt
+++ b/src/test/java/no/nav/fo/veilarbregistrering/tidslinje/resources/TidslinjeResourceTest.kt
@@ -4,6 +4,7 @@ import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
+import no.nav.common.auth.context.AuthContextHolder
 import no.nav.fo.veilarbregistrering.autorisasjon.AutorisasjonService
 import no.nav.fo.veilarbregistrering.bruker.*
 import no.nav.fo.veilarbregistrering.bruker.FoedselsnummerTestdataBuilder.aremark
@@ -99,7 +100,10 @@ private class TidslinjeResourceConfig {
     fun pdlOppslagGateway(): PdlOppslagGateway = mockk()
 
     @Bean
-    fun userService(pdlOppslagGateway: PdlOppslagGateway): UserService = UserService(pdlOppslagGateway)
+    fun authContextHolder(): AuthContextHolder = mockk()
+
+    @Bean
+    fun userService(pdlOppslagGateway: PdlOppslagGateway, authContextHolder: AuthContextHolder): UserService = UserService(pdlOppslagGateway, authContextHolder)
 
     @Bean
     fun tidslinjeAggregator(): TidslinjeAggregator = mockk()


### PR DESCRIPTION
I versjon 2.2021.02.23 av commons-java så er AuthContextHolder gjort om til en Bean fremfor bruk av static metoder.
Versjonen fikser også Helsesjekk på UnleashClient.