### PR TITLE
Fjerner Toggle med tilhørende logikk rundt maksdato ifm. BrukerTilstand

### DIFF
--- a/src/main/java/no/nav/fo/veilarbregistrering/config/ServiceBeansConfig.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/config/ServiceBeansConfig.java
@@ -85,9 +85,8 @@ public class ServiceBeansConfig {
     BrukerTilstandService brukerTilstandService(
             OppfolgingGateway oppfolgingGateway,
             SykemeldingService sykemeldingService,
-            UnleashClient unleashClient,
             BrukerRegistreringRepository brukerRegistreringRepository) {
-        return new BrukerTilstandService(oppfolgingGateway, sykemeldingService, unleashClient, brukerRegistreringRepository);
+        return new BrukerTilstandService(oppfolgingGateway, sykemeldingService, brukerRegistreringRepository);
     }
 
     @Bean

--- a/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/BrukerTilstandService.kt
+++ b/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/BrukerTilstandService.kt
@@ -1,20 +1,15 @@
 package no.nav.fo.veilarbregistrering.registrering.bruker
 
-import no.nav.common.featuretoggle.UnleashClient
 import no.nav.fo.veilarbregistrering.bruker.Bruker
 import no.nav.fo.veilarbregistrering.oppfolging.OppfolgingGateway
 import no.nav.fo.veilarbregistrering.registrering.bruker.Resending.kanResendes
 import no.nav.fo.veilarbregistrering.registrering.formidling.Status
-import no.nav.fo.veilarbregistrering.sykemelding.Maksdato
 import no.nav.fo.veilarbregistrering.sykemelding.SykemeldingService
 import no.nav.fo.veilarbregistrering.sykemelding.SykmeldtInfoData
-import org.slf4j.LoggerFactory
-import kotlin.jvm.JvmOverloads
 
 class BrukerTilstandService(
         private val oppfolgingGateway: OppfolgingGateway,
         private val sykemeldingService: SykemeldingService,
-        private val unleashClient: UnleashClient,
         private val brukerRegistreringRepository: BrukerRegistreringRepository,
 ) {
     @JvmOverloads
@@ -28,16 +23,7 @@ class BrukerTilstandService(
 
         val harIgangsattRegistreringSomKanGjenopptas = harIgangsattRegistreringSomKanGjenopptas(bruker)
 
-        val brukersTilstand =
-            BrukersTilstand(oppfolgingsstatus, sykeforloepMetaData, harIgangsattRegistreringSomKanGjenopptas)
-
-        if (brukAvMaksdato()) {
-            LOG.info("Benytter maksdato")
-            return brukersTilstand
-        }
-        val brukersTilstandUtenSperret = BrukersTilstandUtenSperret(oppfolgingsstatus, sykeforloepMetaData, harIgangsattRegistreringSomKanGjenopptas)
-        loggfoerRegistreringstype(sykmeldtRegistrering, brukersTilstand, brukersTilstandUtenSperret)
-        return brukersTilstandUtenSperret
+        return BrukersTilstandUtenSperret(oppfolgingsstatus, sykeforloepMetaData, harIgangsattRegistreringSomKanGjenopptas)
     }
 
     private fun harIgangsattRegistreringSomKanGjenopptas(bruker: Bruker): Boolean =
@@ -50,37 +36,4 @@ class BrukerTilstandService(
                 )
             ).firstOrNull()
         )
-
-
-    private fun loggfoerRegistreringstype(
-        sykmeldtRegistrering: Boolean,
-        brukersTilstand: BrukersTilstand,
-        brukersTilstandUtenSperret: BrukersTilstandUtenSperret
-    ) {
-        if (!sykmeldtRegistrering) {
-            LOG.info("Benytter ikke maksdato")
-            return
-        }
-
-        var maksdato = maksdato(brukersTilstand)
-        LOG.info(
-            "Lik registreringstype? {} - når {} - med / uten: {} / {}",
-            (brukersTilstand.getRegistreringstype() == brukersTilstandUtenSperret.getRegistreringstype()),
-            maksdato,
-            brukersTilstand.getRegistreringstype(),
-            brukersTilstandUtenSperret.getRegistreringstype()
-        )
-    }
-
-    private fun maksdato(brukersTilstand: BrukersTilstand): Maksdato =
-        brukersTilstand.maksDato?.let(Maksdato::of) ?: Maksdato.nullable()
-
-
-    private fun brukAvMaksdato(): Boolean {
-        return !unleashClient.isEnabled("veilarbregistrering.maksdatoToggletAv")
-    }
-
-    companion object {
-        private val LOG = LoggerFactory.getLogger(BrukerTilstandService::class.java)
-    }
 }

--- a/src/test/java/no/nav/fo/veilarbregistrering/db/HentBrukerRegistreringServiceIntegrationTest.kt
+++ b/src/test/java/no/nav/fo/veilarbregistrering/db/HentBrukerRegistreringServiceIntegrationTest.kt
@@ -2,7 +2,6 @@ package no.nav.fo.veilarbregistrering.db
 
 import io.mockk.every
 import io.mockk.mockk
-import no.nav.common.featuretoggle.UnleashClient
 import no.nav.fo.veilarbregistrering.besvarelse.StillingTestdataBuilder.gyldigStilling
 import no.nav.fo.veilarbregistrering.bruker.AktorId
 import no.nav.fo.veilarbregistrering.bruker.Bruker
@@ -17,10 +16,10 @@ import no.nav.fo.veilarbregistrering.profilering.ProfileringRepository
 import no.nav.fo.veilarbregistrering.profilering.ProfileringService
 import no.nav.fo.veilarbregistrering.profilering.ProfileringTestdataBuilder.lagProfilering
 import no.nav.fo.veilarbregistrering.registrering.bruker.*
-import no.nav.fo.veilarbregistrering.registrering.manuell.ManuellRegistreringRepository
 import no.nav.fo.veilarbregistrering.registrering.formidling.RegistreringTilstand
 import no.nav.fo.veilarbregistrering.registrering.formidling.RegistreringTilstandRepository
 import no.nav.fo.veilarbregistrering.registrering.formidling.Status
+import no.nav.fo.veilarbregistrering.registrering.manuell.ManuellRegistreringRepository
 import no.nav.fo.veilarbregistrering.sykemelding.SykemeldingService
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
@@ -79,9 +78,9 @@ class HentBrukerRegistreringServiceIntegrationTest(
             .setOpprettetDato(LocalDate.of(2018, 12, 8).atStartOfDay())
 
         @Configuration
-        open class TestContext {
+        class TestContext {
             @Bean
-            open fun hentRegistreringService(
+            fun hentRegistreringService(
                     db: JdbcTemplate,
                     brukerRegistreringRepository: BrukerRegistreringRepository,
                     sykmeldtRegistreringRepository: SykmeldtRegistreringRepository,
@@ -96,34 +95,29 @@ class HentBrukerRegistreringServiceIntegrationTest(
             )
 
             @Bean
-            open fun hentBrukerTilstandService(
+            fun hentBrukerTilstandService(
                     oppfolgingGateway: OppfolgingGateway,
                     sykemeldingService: SykemeldingService,
-                    unleashClient: UnleashClient,
                     brukerRegistreringRepository: BrukerRegistreringRepository,
             ): BrukerTilstandService {
                 return BrukerTilstandService(
                     oppfolgingGateway,
                     sykemeldingService,
-                    unleashClient,
                     brukerRegistreringRepository
                 )
             }
 
             @Bean
-            open fun unleashService(): UnleashClient = mockk()
+            fun sykemeldingService(): SykemeldingService = mockk()
 
             @Bean
-            open fun sykemeldingService(): SykemeldingService = mockk()
+            fun oppfolgingGateway(): OppfolgingGateway = mockk()
 
             @Bean
-            open fun oppfolgingGateway(): OppfolgingGateway = mockk()
+            fun profileringService(): ProfileringService = mockk()
 
             @Bean
-            open fun profileringService(): ProfileringService = mockk()
-
-            @Bean
-            open fun norg2Gateway() = object : Norg2Gateway {
+            fun norg2Gateway() = object : Norg2Gateway {
                 override fun hentEnhetFor(kommunenummer: Kommunenummer): Optional<Enhetnr> {
                     if (Kommunenummer.of("1241") == kommunenummer) {
                         return Optional.of(Enhetnr.of("232"))
@@ -134,7 +128,6 @@ class HentBrukerRegistreringServiceIntegrationTest(
                 }
 
                 override fun hentAlleEnheter(): Map<Enhetnr, NavEnhet> = emptyMap()
-
             }
         }
     }

--- a/src/test/java/no/nav/fo/veilarbregistrering/registrering/bruker/BrukerTilstandServiceTest.kt
+++ b/src/test/java/no/nav/fo/veilarbregistrering/registrering/bruker/BrukerTilstandServiceTest.kt
@@ -1,7 +1,7 @@
 package no.nav.fo.veilarbregistrering.registrering.bruker
 
-import io.mockk.*
-import no.nav.common.featuretoggle.UnleashClient
+import io.mockk.every
+import io.mockk.mockk
 import no.nav.fo.veilarbregistrering.arbeidssoker.Formidlingsgruppe
 import no.nav.fo.veilarbregistrering.bruker.AktorId
 import no.nav.fo.veilarbregistrering.bruker.Bruker
@@ -15,30 +15,26 @@ import no.nav.fo.veilarbregistrering.sykemelding.SykmeldtInfoData
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import java.time.LocalDate
 
 class BrukerTilstandServiceTest {
     private lateinit var oppfolgingGateway: OppfolgingGateway
     private lateinit var sykemeldingService: SykemeldingService
-    private lateinit var unleashClient: UnleashClient
     private lateinit var brukerRegistreringRepository: BrukerRegistreringRepository
     private lateinit var brukerTilstandService: BrukerTilstandService
     @BeforeEach
     fun setUp() {
         oppfolgingGateway = mockk()
         sykemeldingService = mockk()
-        unleashClient = mockk()
         brukerRegistreringRepository = mockk(relaxed = true)
         brukerTilstandService = BrukerTilstandService(
             oppfolgingGateway,
             sykemeldingService,
-            unleashClient,
             brukerRegistreringRepository
         )
     }
 
     @Test
-    fun `brukers tilstand skal gi sperret når toggle ikke er skrudd på`() {
+    fun `brukersTilstand skal gi sykmeldtRegistrering når bruker er sykmeldt med arbeidsgiver`() {
         val oppfolgingsstatus = Oppfolgingsstatus(
             false,
             false,
@@ -50,62 +46,7 @@ class BrukerTilstandServiceTest {
         every { oppfolgingGateway.hentOppfolgingsstatus(any()) } returns oppfolgingsstatus
         val sykeforlop = SykmeldtInfoData(null, false)
         every { sykemeldingService.hentSykmeldtInfoData(any()) } returns sykeforlop
-        every { unleashClient.isEnabled(any()) } returns false
         val brukersTilstand = brukerTilstandService.hentBrukersTilstand(testBruker)
-        Assertions.assertThat(brukersTilstand.registreringstype).isEqualTo(RegistreringType.SPERRET)
-    }
-
-    @Test
-    fun `brukersTilstand skal gi sykmeldtRegistrering når toggle er enablet`() {
-        val oppfolgingsstatus = Oppfolgingsstatus(
-            false,
-            false,
-            true,
-            Formidlingsgruppe.of("IARBS"),
-            Servicegruppe.of("VURDI"),
-            Rettighetsgruppe.of("IYT")
-        )
-        every { oppfolgingGateway.hentOppfolgingsstatus(any()) } returns oppfolgingsstatus
-        val sykeforlop = SykmeldtInfoData(null, false)
-        every { sykemeldingService.hentSykmeldtInfoData(any()) } returns sykeforlop
-        every { unleashClient.isEnabled(any()) } returns true
-        val brukersTilstand = brukerTilstandService.hentBrukersTilstand(testBruker)
-        Assertions.assertThat(brukersTilstand.registreringstype).isEqualTo(RegistreringType.SYKMELDT_REGISTRERING)
-    }
-
-    @Test
-    fun brukersTilstand_hvor_med_og_uten_maksdato_gir_ulike_svar() {
-        val oppfolgingsstatus = Oppfolgingsstatus(
-            false,
-            false,
-            true,
-            Formidlingsgruppe.of("IARBS"),
-            Servicegruppe.of("VURDI"),
-            Rettighetsgruppe.of("IYT")
-        )
-        every { oppfolgingGateway.hentOppfolgingsstatus(any()) } returns oppfolgingsstatus
-        val sykeforlop = SykmeldtInfoData(null, false)
-        every { sykemeldingService.hentSykmeldtInfoData(any()) } returns sykeforlop
-        every { unleashClient.isEnabled(any()) } returns true
-        val brukersTilstand = brukerTilstandService.hentBrukersTilstand(testBruker, true)
-        Assertions.assertThat(brukersTilstand.registreringstype).isEqualTo(RegistreringType.SYKMELDT_REGISTRERING)
-    }
-
-    @Test
-    fun brukersTilstand_hvor_med_og_uten_maksdato_gir_like_svar() {
-        val oppfolgingsstatus = Oppfolgingsstatus(
-            false,
-            false,
-            true,
-            Formidlingsgruppe.of("IARBS"),
-            Servicegruppe.of("VURDI"),
-            Rettighetsgruppe.of("IYT")
-        )
-        every { oppfolgingGateway.hentOppfolgingsstatus(any()) } returns oppfolgingsstatus
-        val sykeforlop = SykmeldtInfoData(LocalDate.now().minusWeeks(10).toString(), true)
-        every { sykemeldingService.hentSykmeldtInfoData(any()) } returns sykeforlop
-        every { unleashClient.isEnabled(any()) } returns true
-        val brukersTilstand = brukerTilstandService.hentBrukersTilstand(testBruker, true)
         Assertions.assertThat(brukersTilstand.registreringstype).isEqualTo(RegistreringType.SYKMELDT_REGISTRERING)
     }
 

--- a/src/test/java/no/nav/fo/veilarbregistrering/registrering/bruker/InaktivBrukerServiceTest.kt
+++ b/src/test/java/no/nav/fo/veilarbregistrering/registrering/bruker/InaktivBrukerServiceTest.kt
@@ -1,7 +1,6 @@
 package no.nav.fo.veilarbregistrering.registrering.bruker
 
 import io.mockk.*
-import no.nav.common.featuretoggle.UnleashClient
 import no.nav.fo.veilarbregistrering.autorisasjon.AutorisasjonService
 import no.nav.fo.veilarbregistrering.bruker.AktorId
 import no.nav.fo.veilarbregistrering.bruker.Bruker
@@ -24,7 +23,6 @@ class InaktivBrukerServiceTest {
     private val brukerRegistreringRepository: BrukerRegistreringRepository = mockk(relaxed = true)
     private val reaktiveringRepository: ReaktiveringRepository = mockk(relaxed = true)
     private val oppfolgingClient: OppfolgingClient = mockk(relaxed = true)
-    private val unleashClient: UnleashClient = mockk(relaxed = true)
     private val autorisasjonService: AutorisasjonService = mockk()
     private val influxMetricsService: InfluxMetricsService = mockk()
 
@@ -40,7 +38,6 @@ class InaktivBrukerServiceTest {
                     autorisasjonService,
                     influxMetricsService
                 ),
-                unleashClient,
                 brukerRegistreringRepository
             ),
             reaktiveringRepository,
@@ -76,7 +73,6 @@ class InaktivBrukerServiceTest {
 
     private fun mockOppfolgingMedRespons(oppfolgingStatusData: OppfolgingStatusData) =
             every { oppfolgingClient.hentOppfolgingsstatus(any()) } returns oppfolgingStatusData
-
 
     companion object {
         private val FNR_OPPFYLLER_KRAV =

--- a/src/test/java/no/nav/fo/veilarbregistrering/registrering/bruker/SykmeldtRegistreringServiceTest.kt
+++ b/src/test/java/no/nav/fo/veilarbregistrering/registrering/bruker/SykmeldtRegistreringServiceTest.kt
@@ -4,7 +4,6 @@ import io.mockk.Called
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
-import no.nav.common.featuretoggle.UnleashClient
 import no.nav.fo.veilarbregistrering.autorisasjon.AutorisasjonService
 import no.nav.fo.veilarbregistrering.bruker.AktorId
 import no.nav.fo.veilarbregistrering.bruker.Bruker
@@ -18,7 +17,7 @@ import no.nav.fo.veilarbregistrering.sykemelding.SykemeldingService
 import no.nav.fo.veilarbregistrering.sykemelding.adapter.InfotrygdData
 import no.nav.fo.veilarbregistrering.sykemelding.adapter.SykemeldingGatewayImpl
 import no.nav.fo.veilarbregistrering.sykemelding.adapter.SykmeldtInfoClient
-import org.assertj.core.api.Assertions.*
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -33,7 +32,6 @@ class SykmeldtRegistreringServiceTest {
     private val sykeforloepMetadataClient: SykmeldtInfoClient = mockk()
     private val oppfolgingClient: OppfolgingClient = mockk(relaxed = true)
     private val autorisasjonService: AutorisasjonService = mockk()
-    private val unleashClient: UnleashClient = mockk(relaxed = true)
     private val influxMetricsService: InfluxMetricsService = mockk(relaxed = true)
 
     @BeforeEach
@@ -49,7 +47,6 @@ class SykmeldtRegistreringServiceTest {
                     autorisasjonService,
                     influxMetricsService
                 ),
-                unleashClient,
                 brukerRegistreringRepository
             ),
             oppfolgingGateway,

--- a/src/test/java/no/nav/fo/veilarbregistrering/sykemelding/adapter/SykmeldtInfoClientTest.kt
+++ b/src/test/java/no/nav/fo/veilarbregistrering/sykemelding/adapter/SykmeldtInfoClientTest.kt
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
-import no.nav.common.featuretoggle.UnleashClient
 import no.nav.common.sts.SystemUserTokenProvider
 import no.nav.fo.veilarbregistrering.autorisasjon.AutorisasjonService
 import no.nav.fo.veilarbregistrering.bruker.AktorId
@@ -45,7 +44,6 @@ internal class SykmeldtInfoClientTest(private val mockServer: ClientAndServer) {
         val brukerRegistreringRepository: BrukerRegistreringRepository = mockk()
         val sykmeldtRegistreringRepository: SykmeldtRegistreringRepository = mockk()
         val manuellRegistreringRepository: ManuellRegistreringRepository = mockk()
-        val unleashClient: UnleashClient = mockk(relaxed = true)
         val influxMetricsService: InfluxMetricsService = mockk(relaxed = true)
         val autorisasjonService: AutorisasjonService = mockk(relaxed = true)
         oppfolgingClient = buildOppfolgingClient(influxMetricsService, jacksonObjectMapper().findAndRegisterModules())
@@ -61,7 +59,6 @@ internal class SykmeldtInfoClientTest(private val mockServer: ClientAndServer) {
                     autorisasjonService,
                     influxMetricsService
                 ),
-                unleashClient,
                 brukerRegistreringRepository
             ),
             oppfolgingGateway,

--- a/src/test/java/no/nav/veilarbregistrering/integrasjonstest/BrukerRegistreringServiceIntegrationTest.kt
+++ b/src/test/java/no/nav/veilarbregistrering/integrasjonstest/BrukerRegistreringServiceIntegrationTest.kt
@@ -2,7 +2,6 @@ package no.nav.veilarbregistrering.integrasjonstest
 
 import io.mockk.*
 import io.vavr.control.Try
-import no.nav.common.featuretoggle.UnleashClient
 import no.nav.fo.veilarbregistrering.autorisasjon.AutorisasjonService
 import no.nav.fo.veilarbregistrering.bruker.AktorId
 import no.nav.fo.veilarbregistrering.bruker.Bruker
@@ -15,10 +14,10 @@ import no.nav.fo.veilarbregistrering.profilering.ProfileringRepository
 import no.nav.fo.veilarbregistrering.profilering.ProfileringService
 import no.nav.fo.veilarbregistrering.profilering.ProfileringTestdataBuilder
 import no.nav.fo.veilarbregistrering.registrering.bruker.*
-import no.nav.fo.veilarbregistrering.registrering.manuell.ManuellRegistreringRepository
 import no.nav.fo.veilarbregistrering.registrering.formidling.RegistreringTilstand
 import no.nav.fo.veilarbregistrering.registrering.formidling.RegistreringTilstandRepository
 import no.nav.fo.veilarbregistrering.registrering.formidling.Status
+import no.nav.fo.veilarbregistrering.registrering.manuell.ManuellRegistreringRepository
 import no.nav.fo.veilarbregistrering.sykemelding.SykemeldingService
 import no.nav.veilarbregistrering.integrasjonstest.BrukerRegistreringServiceIntegrationTest.BrukerregistreringConfigTest
 import org.assertj.core.api.Assertions
@@ -145,8 +144,6 @@ internal class BrukerRegistreringServiceIntegrationTest @Autowired constructor(
 
     @Configuration
     class BrukerregistreringConfigTest {
-        @Bean
-        fun unleashClient(): UnleashClient  =  mockk(relaxed = true)
 
         @Bean
         fun oppfolgingGateway(): OppfolgingGateway  = mockk(relaxed = true)
@@ -161,10 +158,9 @@ internal class BrukerRegistreringServiceIntegrationTest @Autowired constructor(
         fun hentBrukerTilstandService(
                 oppfolgingGateway: OppfolgingGateway,
                 sykemeldingService: SykemeldingService,
-                unleashClient: UnleashClient,
                 brukerRegistreringRepository: BrukerRegistreringRepository
         ): BrukerTilstandService {
-            return BrukerTilstandService(oppfolgingGateway, sykemeldingService, unleashClient, brukerRegistreringRepository)
+            return BrukerTilstandService(oppfolgingGateway, sykemeldingService, brukerRegistreringRepository)
         }
 
         @Bean


### PR DESCRIPTION
Vi har kuttet ut bruken av Maksdato ifm. BrukerTilstand for brukere som er Sykmeldt med arbeidsgiver. Det gjør at vi nå kan rydde bort gammel kode, hvor maksdato var involert. Gjør dette i 2 steg. Først toggle plus død kode . Neste steg mer av maksdato og integrajonen ifm. BrukerTilstandService.