### PR TITLE
Retry-mekanisme ved lesing av formidlingsgruppe fra Arena-kafka

### DIFF
--- a/src/main/java/no/nav/fo/veilarbregistrering/kafka/FormidlingsgruppeKafkaConsumer.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/kafka/FormidlingsgruppeKafkaConsumer.java
@@ -43,8 +43,9 @@ class FormidlingsgruppeKafkaConsumer implements Runnable {
         this.arbeidssokerService = arbeidssokerService;
         this.unleashClient = unleashClient;
 
+        int forsinkelseIMinutterVedOppstart = 5;
         Executors.newSingleThreadScheduledExecutor()
-                .schedule(this, 5, MINUTES);
+                .schedule(this, forsinkelseIMinutterVedOppstart, MINUTES);
     }
 
     @Override

--- a/src/main/java/no/nav/fo/veilarbregistrering/kafka/FormidlingsgruppeKafkaConsumer.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/kafka/FormidlingsgruppeKafkaConsumer.java
@@ -57,6 +57,11 @@ class FormidlingsgruppeKafkaConsumer implements Runnable {
         final String mdcOffsetKey = "offset";
         final String mdcPartitionKey = "partition";
 
+        if (stopKonsumeringAvFormidlingsgruppe()) {
+            LOG.info("Kill-switch '{}' aktivert. Hopper over lesing fra kafka", KILL_SWITCH_TOGGLE_NAME);
+            return;
+        }
+
         MDC.put(mdcTopicKey, topic);
         LOG.info("Running");
 

--- a/src/main/java/no/nav/fo/veilarbregistrering/kafka/FormidlingsgruppeKafkaConsumer.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/kafka/FormidlingsgruppeKafkaConsumer.java
@@ -27,6 +27,8 @@ import static no.nav.common.log.MDCConstants.MDC_CALL_ID;
 class FormidlingsgruppeKafkaConsumer implements Runnable {
 
     private static final Logger LOG = LoggerFactory.getLogger(FormidlingsgruppeKafkaConsumer.class);
+    
+    private static final String KILL_SWITCH_TOGGLE_NAME = "veilarbregistrering.stopKonsumeringAvFormidlingsgruppe";
 
     private final Properties kafkaConsumerProperties;
     private final String topic;
@@ -104,6 +106,6 @@ class FormidlingsgruppeKafkaConsumer implements Runnable {
     }
 
     private boolean stopKonsumeringAvFormidlingsgruppe() {
-        return unleashClient.isEnabled("veilarbregistrering.stopKonsumeringAvFormidlingsgruppe");
+        return unleashClient.isEnabled(KILL_SWITCH_TOGGLE_NAME);
     }
 }

--- a/src/main/java/no/nav/fo/veilarbregistrering/kafka/FormidlingsgruppeKafkaConsumer.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/kafka/FormidlingsgruppeKafkaConsumer.java
@@ -46,8 +46,9 @@ class FormidlingsgruppeKafkaConsumer implements Runnable {
         this.unleashClient = unleashClient;
 
         int forsinkelseIMinutterVedOppstart = 5;
+        int forsinkelseIMinutterVedStopp = 5;
         Executors.newSingleThreadScheduledExecutor()
-                .schedule(this, forsinkelseIMinutterVedOppstart, MINUTES);
+                .scheduleWithFixedDelay(this, forsinkelseIMinutterVedOppstart, forsinkelseIMinutterVedStopp, MINUTES);
     }
 
     @Override

--- a/src/main/java/no/nav/fo/veilarbregistrering/kafka/FormidlingsgruppeKafkaConsumer.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/kafka/FormidlingsgruppeKafkaConsumer.java
@@ -90,7 +90,7 @@ class FormidlingsgruppeKafkaConsumer implements Runnable {
                 consumer.commitSync();
             }
 
-            LOG.info("Stopper lesing av topic etter at toggle `veilarbregistrering.stopKonsumeringAvFormidlingsgruppe` er skrudd på");
+            LOG.info("Stopper lesing av topic etter at toggle `{}` er skrudd på", KILL_SWITCH_TOGGLE_NAME);
 
         } catch (Exception e) {
             LOG.error(String.format("Det oppstod en ukjent feil ifm. konsumering av events fra %s", topic), e);


### PR DESCRIPTION
I stedet for at lesingen stopper opp ved første feil, vil vi i stedet starte en ny lesetråd 5 minutter etter det stopper opp.

Dette burde være lenge nok til å ikke hamre på kafka ved feil, men likevel kort nok til å ikke ha for store brukermessige konsekvenser.