### PR TITLE
Bytter ut springfox med springdoc som Swagger/OpenAPI-bibliotek

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,6 @@
         <kotlin.compiler.incremental>true</kotlin.compiler.incremental>
         <common.version>2.2021.02.23_11.33-7091f10a35ba</common.version>
         <junit.jupiter.version>5.7.0</junit.jupiter.version>
-        <springfox.version>2.9.2</springfox.version>
     </properties>
 
     <dependencies>
@@ -114,14 +113,9 @@
             <version>0.10.3</version>
         </dependency>
         <dependency>
-            <groupId>io.springfox</groupId>
-            <artifactId>springfox-swagger2</artifactId>
-            <version>${springfox.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.springfox</groupId>
-            <artifactId>springfox-swagger-ui</artifactId>
-            <version>${springfox.version}</version>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-ui</artifactId>
+            <version>1.5.9</version>
         </dependency>
         <dependency>
             <groupId>net.minidev</groupId>

--- a/src/main/java/no/nav/fo/veilarbregistrering/arbeidsforhold/resources/ArbeidsforholdApi.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/arbeidsforhold/resources/ArbeidsforholdApi.java
@@ -1,11 +1,11 @@
 package no.nav.fo.veilarbregistrering.arbeidsforhold.resources;
 
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.Operation;
 
-@Api(value = "ArbeidsforholdResource")
+@Tag(name = "ArbeidsforholdResource")
 public interface ArbeidsforholdApi {
 
-    @ApiOperation(value = "Henter informasjon om brukers siste arbeidsforhold.")
+    @Operation(summary = "Henter informasjon om brukers siste arbeidsforhold.")
     ArbeidsforholdDto hentSisteArbeidsforhold();
 }

--- a/src/main/java/no/nav/fo/veilarbregistrering/arbeidssoker/resources/ArbeidssokerApi.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/arbeidssoker/resources/ArbeidssokerApi.java
@@ -1,21 +1,25 @@
 package no.nav.fo.veilarbregistrering.arbeidssoker.resources;
 
-import io.swagger.annotations.*;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
 import java.time.LocalDate;
 
-@Api(value = "ArbeidssokerResource")
+@Tag(name = "ArbeidssokerResource")
 public interface ArbeidssokerApi {
 
-    @ApiOperation(value = "Henter alle perioder hvor bruker er registrert som arbeidssøker.")
+    @Operation(summary = "Henter alle perioder hvor bruker er registrert som arbeidssøker.")
     @ApiResponses({
-            @ApiResponse(code = 200, message = "Ok"),
-            @ApiResponse(code = 400, message = "Ugyldig periode - fra og med dato må være før til dato"),
-            @ApiResponse(code = 403, message = "Ingen tilgang"),
-            @ApiResponse(code = 500, message = "Ukjent feil")})
+            @ApiResponse(responseCode = "200", description = "Ok"),
+            @ApiResponse(responseCode = "400", description = "Ugyldig periode - fra og med dato må være før til dato"),
+            @ApiResponse(responseCode = "403", description = "Ingen tilgang"),
+            @ApiResponse(responseCode = "500", description = "Ukjent feil")})
     ArbeidssokerperioderDto hentArbeidssokerperioder(
-            @ApiParam(required = true, value = "Fødselsnummer") String fnr,
-            @ApiParam(required = true, value = "Fra og med dato") LocalDate fraOgMed,
-            @ApiParam(value = "Til og med dato") LocalDate tilOgMed
+            @Parameter(required = true, description = "Fødselsnummer") String fnr,
+            @Parameter(required = true, description = "Fra og med dato") LocalDate fraOgMed,
+            @Parameter(description = "Til og med dato") LocalDate tilOgMed
     );
 }

--- a/src/main/java/no/nav/fo/veilarbregistrering/bruker/resources/KontaktinfoApi.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/bruker/resources/KontaktinfoApi.java
@@ -1,18 +1,18 @@
 package no.nav.fo.veilarbregistrering.bruker.resources;
 
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
-@Api(value = "KontaktinfoResource")
+@Tag(name = "KontaktinfoResource")
 public interface KontaktinfoApi {
 
-    @ApiOperation(value = "Henter kontaktinformasjon (telefonnummer) til bruker.")
+    @Operation(summary = "Henter kontaktinformasjon (telefonnummer) til bruker.")
     @ApiResponses({
-            @ApiResponse(code = 403, message = "Ingen tilgang"),
-            @ApiResponse(code = 404, message = "Ikke funnet"),
-            @ApiResponse(code = 500, message = "Ukjent feil")
+            @ApiResponse(responseCode = "403", description = "Ingen tilgang"),
+            @ApiResponse(responseCode = "404", description = "Ikke funnet"),
+            @ApiResponse(responseCode = "500", description = "Ukjent feil")
     })
     KontaktinfoDto hentKontaktinfo();
 }

--- a/src/main/java/no/nav/fo/veilarbregistrering/config/SwaggerConfig.kt
+++ b/src/main/java/no/nav/fo/veilarbregistrering/config/SwaggerConfig.kt
@@ -1,24 +1,14 @@
 package no.nav.fo.veilarbregistrering.config
 
+import io.swagger.v3.oas.models.OpenAPI
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import springfox.documentation.spi.DocumentationType
-import springfox.documentation.spring.web.plugins.Docket
-import springfox.documentation.swagger2.annotations.EnableSwagger2
 
 
 @Configuration
-@EnableSwagger2
 open class SwaggerConfig {
     //  Path to Swagger UI: /veilarbregistrering/swagger-ui.html
+
     @Bean
-    open fun docket(): Docket {
-        return Docket(DocumentationType.SWAGGER_2)
-            .select()
-            .apis { handler ->
-                if (handler == null) return@apis false
-                handler.key().pathMappings.stream().anyMatch { path -> path.startsWith("/api") }
-            }
-            .build()
-    }
+    fun swaggerApi() = OpenAPI()
 }

--- a/src/main/java/no/nav/fo/veilarbregistrering/oppgave/resources/OppgaveApi.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/oppgave/resources/OppgaveApi.java
@@ -1,16 +1,19 @@
 package no.nav.fo.veilarbregistrering.oppgave.resources;
 
-import io.swagger.annotations.*;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
-@Api(value = "OppgaveResource")
+@Tag(name = "OppgaveResource")
 public interface OppgaveApi {
 
-    @ApiOperation(value = "Oppretter 'kontakt bruker'-oppgave på vegne av bruker.")
+    @Operation(summary = "Oppretter 'kontakt bruker'-oppgave på vegne av bruker.")
     @ApiResponses({
-            @ApiResponse(code = 200, message = "Oppgave opprettet OK"),
-            @ApiResponse(code = 403, message = "Duplikat - fant tilsvarende oppgave " +
+            @ApiResponse(responseCode = "200", description = "Oppgave opprettet OK"),
+            @ApiResponse(responseCode = "403", description = "Duplikat - fant tilsvarende oppgave " +
                     "som ble opprettet innenfor de siste 2 arbeidsdager"),
-            @ApiResponse(code = 500, message = "Ukjent teknisk feil")
+            @ApiResponse(responseCode = "500", description = "Ukjent teknisk feil")
     })
     OppgaveDto opprettOppgave(OppgaveDto oppgaveDto);
 }

--- a/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/resources/RegistreringApi.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/registrering/bruker/resources/RegistreringApi.java
@@ -1,30 +1,30 @@
 package no.nav.fo.veilarbregistrering.registrering.bruker.resources;
 
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.Operation;
 import no.nav.fo.veilarbregistrering.registrering.bruker.OrdinaerBrukerRegistrering;
 import no.nav.fo.veilarbregistrering.registrering.bruker.SykmeldtRegistrering;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 
-@Api(value = "RegistreringResource")
+@Tag(name = "RegistreringResource")
 public interface RegistreringApi {
 
-    @ApiOperation(value = "Henter oppfølgingsinformasjon om arbeidssøker.")
+    @Operation(summary = "Henter oppfølgingsinformasjon om arbeidssøker.")
     StartRegistreringStatusDto hentStartRegistreringStatus();
 
-    @ApiOperation(value = "Starter nyregistrering av arbeidssøker.")
+    @Operation(summary = "Starter nyregistrering av arbeidssøker.")
     OrdinaerBrukerRegistrering registrerBruker(OrdinaerBrukerRegistrering ordinaerBrukerRegistrering);
 
-    @ApiOperation(value = "Henter siste registrering av bruker.")
+    @Operation(summary = "Henter siste registrering av bruker.")
     ResponseEntity<BrukerRegistreringWrapper> hentRegistrering();
 
     @GetMapping("/registrering")
     ResponseEntity<BrukerRegistreringWrapper> hentPaabegyntRegistrering();
 
-    @ApiOperation(value = "Starter reaktivering av arbeidssøker.")
+    @Operation(summary = "Starter reaktivering av arbeidssøker.")
     void reaktivering();
 
-    @ApiOperation(value = "Starter nyregistrering av sykmeldt med arbeidsgiver.")
+    @Operation(summary = "Starter nyregistrering av sykmeldt med arbeidsgiver.")
     void registrerSykmeldt(SykmeldtRegistrering sykmeldtRegistrering);
 }

--- a/src/main/java/no/nav/fo/veilarbregistrering/sykemelding/resources/SykemeldingApi.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/sykemelding/resources/SykemeldingApi.java
@@ -1,12 +1,12 @@
 package no.nav.fo.veilarbregistrering.sykemelding.resources;
 
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import no.nav.fo.veilarbregistrering.sykemelding.SykmeldtInfoData;
 
-@Api(value = "SykemeldingResource")
+@Tag(name = "SykemeldingResource")
 public interface SykemeldingApi {
 
-    @ApiOperation(value = "Henter sykmeldt informasjon")
+    @Operation(summary = "Henter sykmeldt informasjon")
     SykmeldtInfoData hentSykmeldtInfoData();
 }

--- a/src/main/java/no/nav/fo/veilarbregistrering/tidslinje/resources/TidslinjeApi.kt
+++ b/src/main/java/no/nav/fo/veilarbregistrering/tidslinje/resources/TidslinjeApi.kt
@@ -1,12 +1,12 @@
 package no.nav.fo.veilarbregistrering.tidslinje.resources
 
-import io.swagger.annotations.Api
-import io.swagger.annotations.ApiOperation
+import io.swagger.v3.oas.annotations.tags.Tag
+import io.swagger.v3.oas.annotations.Operation
 
-@Api(value = "TidslinjeResource")
+@Tag(name = "TidslinjeResource")
 interface TidslinjeApi {
 
-    @ApiOperation(value = "Returnerer en tidslinje over alle historiske hendelser knyttet til arbeidssøkerregistrering")
+    @Operation(summary = "Returnerer en tidslinje over alle historiske hendelser knyttet til arbeidssøkerregistrering")
     fun tidslinje() : TidslinjeDto
 
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,9 +12,14 @@ spring:
       maximum-pool-size: 10
       minimum-idle: 2
 
+
 server:
   servlet:
     context-path: /veilarbregistrering
+
+springdoc:
+  packages-to-scan: no.nav.fo.veilarbregistrering
+  paths-to-match: /api/**
 
 management:
   endpoint:

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -15,6 +15,10 @@ server:
   servlet:
     context-path: /veilarbregistrering
 
+springdoc:
+  packages-to-scan: no.nav.fo.veilarbregistrering
+  paths-to-match: /api/**
+
 management:
   endpoint:
     metrics:


### PR DESCRIPTION
Dagens versjon, springfox 2.9.2, er gammel og inneholder sårbarheter.

Neste minor-versjon uten sårbarheten er 2.10.5, men denne anbefales ikke av springfox.

Videre anbefales springfox 3.0.0, som vi gjorde det forsøk med.
3.0.0 løser sikkerhetsproblematikken, men innfører andre særheter og endringer i oppførsel fra 2.9.2.
Blant annet er det ikke mulig å sette "baseUrl", og alle endepunkt blir i stedet prefikset med "/veilarbregistrering/api/".
En versjon 3.0.1 ble nevnt som en løsning, men det var fra sommeren 2020, og det har ikke kommet noen endringer i prosjektet siden.
Prosjektet springfox anses derfor som dødt.

springdoc er et alternativ til springfox, og er aktivt vedlikeholdt på Github.
Jeg fulgte her migreringsguiden deres for overgang fra springfox:
https://springdoc.org/#migrating-from-springfox

Det er ulikheter i openapi-json-responsen mellom springfox og springdoc,
men disse kommer av overgang fra OpenAPI 2 til OpenAPI 3-formatet.