### PR TITLE
Henter geografisk tilknytning kun fra PDL

### DIFF
--- a/src/main/java/no/nav/fo/veilarbregistrering/bruker/adapter/PersonGatewayConfig.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/bruker/adapter/PersonGatewayConfig.java
@@ -20,7 +20,7 @@ public class PersonGatewayConfig {
     }
 
     @Bean
-    PersonGatewayImpl personGateway(VeilArbPersonClient client, PdlOppslagGateway pdlOppslagGateway, UnleashClient unleashClient) {
-        return new PersonGatewayImpl(client, pdlOppslagGateway, unleashClient);
+    PersonGatewayImpl personGateway(PdlOppslagGateway pdlOppslagGateway) {
+        return new PersonGatewayImpl(pdlOppslagGateway);
     }
 }

--- a/src/main/java/no/nav/fo/veilarbregistrering/bruker/adapter/PersonGatewayImpl.java
+++ b/src/main/java/no/nav/fo/veilarbregistrering/bruker/adapter/PersonGatewayImpl.java
@@ -1,54 +1,25 @@
 package no.nav.fo.veilarbregistrering.bruker.adapter;
 
-import no.nav.common.featuretoggle.UnleashClient;
 import no.nav.fo.veilarbregistrering.bruker.Bruker;
 import no.nav.fo.veilarbregistrering.bruker.GeografiskTilknytning;
 import no.nav.fo.veilarbregistrering.bruker.PdlOppslagGateway;
 import no.nav.fo.veilarbregistrering.bruker.PersonGateway;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.Optional;
 
 
 class PersonGatewayImpl implements PersonGateway {
 
-    private final static Logger LOG = LoggerFactory.getLogger(PersonGatewayImpl.class);
-
-    private final VeilArbPersonClient client;
     private final PdlOppslagGateway pdlOppslagGateway;
-    private final UnleashClient unleashClient;
 
-    PersonGatewayImpl(VeilArbPersonClient client, PdlOppslagGateway pdlOppslagGateway, UnleashClient unleashClient) {
-        this.client = client;
+    PersonGatewayImpl(PdlOppslagGateway pdlOppslagGateway) {
         this.pdlOppslagGateway = pdlOppslagGateway;
-        this.unleashClient = unleashClient;
     }
 
     @Override
     public Optional<GeografiskTilknytning> hentGeografiskTilknytning(Bruker bruker) {
-        Optional<GeografiskTilknytning> geografiskTilknytningTPS = client.geografisktilknytning(bruker.getGjeldendeFoedselsnummer()).map(PersonGatewayImpl::map);
-
-        if (skalHenteGtFraPdl()) {
-            Optional<GeografiskTilknytning> geografiskTilknytningPDL = pdlOppslagGateway.hentGeografiskTilknytning(bruker.getAktorId());
-            if (!geografiskTilknytningPDL.equals(geografiskTilknytningTPS)) {
-                LOG.warn("Ulikhet i geografisk tilknytning: TPS:{} - PDL:{}", geografiskTilknytningTPS, geografiskTilknytningPDL);
-            }
-
-            if (skalBrukeGtFraPdl()) {
-                return geografiskTilknytningPDL;
-            }
-        }
-
-        return geografiskTilknytningTPS;
-    }
-
-    private boolean skalBrukeGtFraPdl() {
-        return unleashClient.isEnabled("veilarbregistrering.geografiskTilknytningFraPdl.bruk");
-    }
-
-    private boolean skalHenteGtFraPdl() {
-        return unleashClient.isEnabled("veilarbregistrering.geografiskTilknytningFraPdl.sammenligning");
+        Optional<GeografiskTilknytning> geografiskTilknytningPDL = pdlOppslagGateway.hentGeografiskTilknytning(bruker.getAktorId());
+        return geografiskTilknytningPDL;
     }
 
     private static GeografiskTilknytning map(GeografiskTilknytningDto dto) {


### PR DESCRIPTION
Fjerner kobling til veilarbperson fra PeronGatewayImpl. Tidligere hentet vi geografisk tilknytning fra veilarbperson,
som igjen henter det fra TPS. Dette gir oss både redusert datakvalitet, og en kobling til systemer som skal vekk.

Ved å kun hente fra PDL, kan vi fjerne koblingen mot veilarbperson helt.