### PR TITLE
Legger til mulighet for å sende med fnr i body for å ikke logge fnr

### DIFF
--- a/src/main/java/no/nav/fo/veilarbregistrering/arbeidssoker/resources/ArbeidssokerApi.kt
+++ b/src/main/java/no/nav/fo/veilarbregistrering/arbeidssoker/resources/ArbeidssokerApi.kt
@@ -2,6 +2,7 @@ package no.nav.fo.veilarbregistrering.arbeidssoker.resources
 
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.parameters.RequestBody
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
@@ -9,6 +10,8 @@ import java.time.LocalDate
 
 @Tag(name = "ArbeidssokerResource")
 interface ArbeidssokerApi {
+
+    @Deprecated("Bruk POST med ident i body for å unngå fnr i logger")
     @Operation(summary = "Henter alle perioder hvor bruker er registrert som arbeidssøker.")
     @ApiResponses(
         ApiResponse(responseCode = "200", description = "Ok"),
@@ -20,5 +23,18 @@ interface ArbeidssokerApi {
         @Parameter(required = true, description = "Fødselsnummer") fnr: String,
         @Parameter(required = true, description = "Fra og med dato") fraOgMed: LocalDate,
         @Parameter(description = "Til og med dato") tilOgMed: LocalDate?
+    ): ArbeidssokerperioderDto
+
+    @Operation(summary = "Henter alle perioder hvor bruker er registrert som arbeidssøker.")
+    @ApiResponses(
+            ApiResponse(responseCode = "200", description = "Ok"),
+            ApiResponse(responseCode = "400", description = "Ugyldig periode - fra og med dato må være før til dato"),
+            ApiResponse(responseCode = "403", description = "Ingen tilgang"),
+            ApiResponse(responseCode = "500", description = "Ukjent feil")
+    )
+    fun hentArbeidssokerperioder(
+            @RequestBody(required = true, description = "Fødselsnummer") fnr: Fnr,
+            @Parameter(required = true, description = "Fra og med dato") fraOgMed: LocalDate,
+            @Parameter(description = "Til og med dato") tilOgMed: LocalDate?
     ): ArbeidssokerperioderDto
 }

--- a/src/main/java/no/nav/fo/veilarbregistrering/arbeidssoker/resources/ArbeidssokerResource.kt
+++ b/src/main/java/no/nav/fo/veilarbregistrering/arbeidssoker/resources/ArbeidssokerResource.kt
@@ -3,11 +3,15 @@ package no.nav.fo.veilarbregistrering.arbeidssoker.resources
 import no.nav.fo.veilarbregistrering.arbeidssoker.ArbeidssokerService
 import no.nav.fo.veilarbregistrering.arbeidssoker.Arbeidssokerperiode
 import no.nav.fo.veilarbregistrering.autorisasjon.AutorisasjonService
+import no.nav.fo.veilarbregistrering.bruker.Bruker
+import no.nav.fo.veilarbregistrering.bruker.Foedselsnummer
 import no.nav.fo.veilarbregistrering.bruker.Periode
 import no.nav.fo.veilarbregistrering.bruker.UserService
 import no.nav.fo.veilarbregistrering.log.loggerFor
 import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
@@ -28,6 +32,22 @@ class ArbeidssokerResource(
         @RequestParam(value = "tilOgMed", required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") tilOgMed: LocalDate?
     ): ArbeidssokerperioderDto {
         val bruker = userService.finnBrukerGjennomPdl()
+        return hentArbeidssokerperioder(bruker, fraOgMed, tilOgMed)
+    }
+
+    @PostMapping("/perioder")
+    override fun hentArbeidssokerperioder(
+        @RequestBody fnr: Fnr,
+        @RequestParam("fraOgMed") @DateTimeFormat(pattern = "yyyy-MM-dd") fraOgMed: LocalDate,
+        @RequestParam(value = "tilOgMed", required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") tilOgMed: LocalDate?
+    ): ArbeidssokerperioderDto {
+        val bruker = userService.finnBrukerGjennomPdl(Foedselsnummer.of(fnr.fnr))
+        return hentArbeidssokerperioder(bruker, fraOgMed, tilOgMed)
+    }
+
+    private fun hentArbeidssokerperioder(bruker: Bruker,
+                                         fraOgMed: LocalDate,
+                                         tilOgMed: LocalDate?): ArbeidssokerperioderDto {
         autorisasjonService.sjekkLesetilgangTilBruker(bruker.gjeldendeFoedselsnummer)
         val arbeidssokerperiodes = arbeidssokerService.hentArbeidssokerperioder(
             bruker, Periode.gyldigPeriode(fraOgMed, tilOgMed)


### PR DESCRIPTION
Setter deprecated på forrige GET-metode

Noe som burde avklares:
* Domeneobjekt for `FNR`, burde det kalles for noe annet? `Personident`.. ? 
* Stylingen i testfila ble nog ikke helt enligt deres code styling