### PR TITLE
Innfører MetricService som interface mellom implementasjon og bruk

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,7 +53,7 @@ jobs:
     name: Deploy to dev FSS
     needs: test-build-and-push
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/feature/extract-metricsService-interface'
     steps:
       - uses: actions/checkout@v1
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,7 +53,7 @@ jobs:
     name: Deploy to dev FSS
     needs: test-build-and-push
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/feature/extract-metricsService-interface'
+    if: github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v1
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,7 +53,7 @@ jobs:
     name: Deploy to dev FSS
     needs: test-build-and-push
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/httpklient'
+    if: github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v1
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.5.6</version>
+        <version>2.6.6</version>
         <relativePath/>
     </parent>
 

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/arbeidsforhold/adapter/AaregRestClient.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/arbeidsforhold/adapter/AaregRestClient.kt
@@ -13,7 +13,7 @@ import no.nav.fo.veilarbregistrering.bruker.Foedselsnummer
 import no.nav.fo.veilarbregistrering.http.defaultHttpClient
 import no.nav.fo.veilarbregistrering.log.MDCConstants
 import no.nav.fo.veilarbregistrering.log.logger
-import no.nav.fo.veilarbregistrering.metrics.PrometheusMetricsService
+import no.nav.fo.veilarbregistrering.metrics.MetricsService
 import no.nav.fo.veilarbregistrering.metrics.TimedMetric
 import okhttp3.HttpUrl
 import okhttp3.Request
@@ -25,7 +25,7 @@ import org.springframework.http.MediaType
 import java.io.IOException
 
 open class AaregRestClient(
-    metricsService: PrometheusMetricsService,
+    metricsService: MetricsService,
     private val baseUrl: String,
     private val systemUserTokenProvider: SystemUserTokenProvider,
     private val authContextHolder: AuthContextHolder,

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/arbeidsforhold/adapter/ArbeidsforholdGatewayConfig.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/arbeidsforhold/adapter/ArbeidsforholdGatewayConfig.kt
@@ -8,7 +8,7 @@ import no.nav.fo.veilarbregistrering.config.isDevelopment
 import no.nav.fo.veilarbregistrering.config.requireClusterName
 import no.nav.fo.veilarbregistrering.config.requireProperty
 import no.nav.fo.veilarbregistrering.log.logger
-import no.nav.fo.veilarbregistrering.metrics.PrometheusMetricsService
+import no.nav.fo.veilarbregistrering.metrics.MetricsService
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
@@ -16,14 +16,14 @@ import org.springframework.context.annotation.Configuration
 class ArbeidsforholdGatewayConfig {
     @Bean
     fun aaregRestClient(
-        prometheusMetricsService: PrometheusMetricsService,
+        metricsService: MetricsService,
         systemUserTokenProvider: SystemUserTokenProvider,
         authContextHolder: AuthContextHolder,
         serviceToServiceTokenProvider: ServiceToServiceTokenProvider
     ): AaregRestClient {
         val aaregCluster = requireClusterName()
         return AaregRestClient(
-            prometheusMetricsService,
+            metricsService,
             requireProperty(REST_URL),
             systemUserTokenProvider,
             authContextHolder

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/arbeidssoker/ArbeidssokerService.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/arbeidssoker/ArbeidssokerService.kt
@@ -6,7 +6,7 @@ import no.nav.fo.veilarbregistrering.bruker.Periode
 import no.nav.fo.veilarbregistrering.metrics.Events
 import no.nav.fo.veilarbregistrering.metrics.JaNei
 import no.nav.fo.veilarbregistrering.metrics.Metric
-import no.nav.fo.veilarbregistrering.metrics.PrometheusMetricsService
+import no.nav.fo.veilarbregistrering.metrics.MetricsService
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -17,7 +17,7 @@ class ArbeidssokerService(
     private val arbeidssokerRepository: ArbeidssokerRepository,
     private val formidlingsgruppeGateway: FormidlingsgruppeGateway,
     private val unleashClient: UnleashClient,
-    private val prometheusMetricsService: PrometheusMetricsService
+    private val metricsService: MetricsService
 ) {
     @Transactional
     fun behandle(endretFormidlingsgruppeCommand: EndretFormidlingsgruppeCommand) {
@@ -57,7 +57,7 @@ class ArbeidssokerService(
         val overlappendeArbeidssokerperioderLokalt = arbeidssokerperioderLokalt.overlapperMed(forespurtPeriode)
         val overlappendeHistoriskePerioderORDS = arbeidssokerperioderORDS.overlapperMed(forespurtPeriode)
         val lokalErLikOrds = overlappendeArbeidssokerperioderLokalt.equals(overlappendeHistoriskePerioderORDS)
-        prometheusMetricsService.registrer(
+        metricsService.registrer(
             Events.HENT_ARBEIDSSOKERPERIODER_KILDER_GIR_SAMME_SVAR,
             if (lokalErLikOrds) JaNei.JA else JaNei.NEI
         )
@@ -70,7 +70,7 @@ class ArbeidssokerService(
             )
         }
         if (dekkerHele && brukLokalCache()) {
-            prometheusMetricsService.registrer(Events.HENT_ARBEIDSSOKERPERIODER_KILDE, Kilde.LOKAL)
+            metricsService.registrer(Events.HENT_ARBEIDSSOKERPERIODER_KILDE, Kilde.LOKAL)
             LOG.info(
                 String.format(
                     "Arbeidssokerperiodene fra egen database dekker hele perioden, og returneres: %s",
@@ -79,7 +79,7 @@ class ArbeidssokerService(
             )
             return overlappendeArbeidssokerperioderLokalt
         }
-        prometheusMetricsService.registrer(Events.HENT_ARBEIDSSOKERPERIODER_KILDE, Kilde.ORDS)
+        metricsService.registrer(Events.HENT_ARBEIDSSOKERPERIODER_KILDE, Kilde.ORDS)
         LOG.info(
             String.format(
                 "Returnerer arbeidssokerperioder fra Arena sin ORDS-tjenesten: %s",

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/arbeidssoker/adapter/FormidlingsgruppeGatewayConfig.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/arbeidssoker/adapter/FormidlingsgruppeGatewayConfig.kt
@@ -1,9 +1,8 @@
 package no.nav.fo.veilarbregistrering.arbeidssoker.adapter
 
-import no.nav.fo.veilarbregistrering.config.requireProperty
 import no.nav.fo.veilarbregistrering.arbeidssoker.FormidlingsgruppeGateway
 import no.nav.fo.veilarbregistrering.config.requireProperty
-import no.nav.fo.veilarbregistrering.metrics.PrometheusMetricsService
+import no.nav.fo.veilarbregistrering.metrics.MetricsService
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
@@ -16,11 +15,11 @@ class FormidlingsgruppeGatewayConfig {
     @Bean
     fun formidlingsgruppeRestClient(
         arenaOrdsTokenProviderClient: ArenaOrdsTokenProviderClient,
-        prometheusMetricsService: PrometheusMetricsService
+        metricsService: MetricsService
     ) =
         FormidlingsgruppeRestClient(
             requireProperty(ARENA_ORDS_API),
-            prometheusMetricsService,
+            metricsService,
         ) { arenaOrdsTokenProviderClient.token }
 
     @Bean

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/arbeidssoker/adapter/FormidlingsgruppeRestClient.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/arbeidssoker/adapter/FormidlingsgruppeRestClient.kt
@@ -10,7 +10,7 @@ import no.nav.fo.veilarbregistrering.bruker.Periode
 import no.nav.fo.veilarbregistrering.config.parse
 import no.nav.fo.veilarbregistrering.http.buildHttpClient
 import no.nav.fo.veilarbregistrering.http.defaultHttpClient
-import no.nav.fo.veilarbregistrering.metrics.PrometheusMetricsService
+import no.nav.fo.veilarbregistrering.metrics.MetricsService
 import no.nav.fo.veilarbregistrering.metrics.TimedMetric
 import okhttp3.HttpUrl
 import okhttp3.Request
@@ -23,7 +23,7 @@ import java.util.function.Supplier
 
 class FormidlingsgruppeRestClient internal constructor(
     private val baseUrl: String,
-    metricsService: PrometheusMetricsService,
+    metricsService: MetricsService,
     private val arenaOrdsTokenProvider: Supplier<String>
 ) : HealthCheck, TimedMetric(metricsService) {
 

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/config/ServiceBeansConfig.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/config/ServiceBeansConfig.kt
@@ -23,7 +23,7 @@ import no.nav.fo.veilarbregistrering.enhet.EnhetGateway
 import no.nav.fo.veilarbregistrering.featuretoggle.resources.FeaturetoggleResource
 import no.nav.fo.veilarbregistrering.feil.FeilHandtering
 import no.nav.fo.veilarbregistrering.helsesjekk.resources.HelsesjekkResource
-import no.nav.fo.veilarbregistrering.metrics.PrometheusMetricsService
+import no.nav.fo.veilarbregistrering.metrics.MetricsService
 import no.nav.fo.veilarbregistrering.oppfolging.OppfolgingGateway
 import no.nav.fo.veilarbregistrering.oppgave.OppgaveGateway
 import no.nav.fo.veilarbregistrering.oppgave.OppgaveRepository
@@ -57,7 +57,7 @@ class ServiceBeansConfig {
         profileringRepository: ProfileringRepository,
         manuellRegistreringRepository: ManuellRegistreringRepository,
         norg2Gateway: Norg2Gateway,
-        metricsService: PrometheusMetricsService
+        metricsService: MetricsService
     ): HentRegistreringService {
         return HentRegistreringService(
             brukerRegistreringRepository,
@@ -87,13 +87,13 @@ class ServiceBeansConfig {
         arbeidsforholdGateway: ArbeidsforholdGateway,
         brukerTilstandService: BrukerTilstandService,
         pdlOppslagGateway: PdlOppslagGateway,
-        prometheusMetricsService: PrometheusMetricsService
+        metricsService: MetricsService
     ): StartRegistreringStatusService {
         return StartRegistreringStatusService(
             arbeidsforholdGateway,
             brukerTilstandService,
             pdlOppslagGateway,
-            prometheusMetricsService
+            metricsService
         )
     }
 
@@ -102,13 +102,13 @@ class ServiceBeansConfig {
         brukerTilstandService: BrukerTilstandService,
         reaktiveringRepository: ReaktiveringRepository,
         oppfolgingGateway: OppfolgingGateway,
-        prometheusMetricsService: PrometheusMetricsService
+        metricsService: MetricsService
     ): InaktivBrukerService {
         return InaktivBrukerService(
             brukerTilstandService,
             reaktiveringRepository,
             oppfolgingGateway,
-            prometheusMetricsService
+            metricsService
         )
     }
 
@@ -118,14 +118,14 @@ class ServiceBeansConfig {
         oppfolgingGateway: OppfolgingGateway,
         sykmeldtRegistreringRepository: SykmeldtRegistreringRepository,
         manuellRegistreringRepository: ManuellRegistreringRepository,
-        prometheusMetricsService: PrometheusMetricsService
+        metricsService: MetricsService
     ): SykmeldtRegistreringService {
         return SykmeldtRegistreringService(
             brukerTilstandService,
             oppfolgingGateway,
             sykmeldtRegistreringRepository,
             manuellRegistreringRepository,
-            prometheusMetricsService
+            metricsService
         )
     }
 
@@ -138,7 +138,7 @@ class ServiceBeansConfig {
         registreringTilstandRepository: RegistreringTilstandRepository,
         brukerTilstandService: BrukerTilstandService,
         manuellRegistreringRepository: ManuellRegistreringRepository,
-        prometheusMetricsService: PrometheusMetricsService
+        metricsService: MetricsService
     ): BrukerRegistreringService {
         return BrukerRegistreringService(
             brukerRegistreringRepository,
@@ -148,7 +148,7 @@ class ServiceBeansConfig {
             registreringTilstandRepository,
             brukerTilstandService,
             manuellRegistreringRepository,
-            prometheusMetricsService
+            metricsService
         )
     }
 
@@ -203,13 +203,13 @@ class ServiceBeansConfig {
         oppgaveGateway: OppgaveGateway,
         oppgaveRepository: OppgaveRepository,
         oppgaveRouter: OppgaveRouter,
-        prometheusMetricsService: PrometheusMetricsService
+        metricsService: MetricsService
     ): OppgaveService {
         return OppgaveService(
             oppgaveGateway,
             oppgaveRepository,
             oppgaveRouter,
-            prometheusMetricsService
+            metricsService
         )
     }
 
@@ -219,14 +219,14 @@ class ServiceBeansConfig {
         enhetGateway: EnhetGateway,
         norg2Gateway: Norg2Gateway,
         pdlOppslagGateway: PdlOppslagGateway,
-        prometheusMetricsService: PrometheusMetricsService
+        metricsService: MetricsService
     ): OppgaveRouter {
         return OppgaveRouter(
             arbeidsforholdGateway,
             enhetGateway,
             norg2Gateway,
             pdlOppslagGateway,
-            prometheusMetricsService
+            metricsService
         )
     }
 
@@ -244,13 +244,13 @@ class ServiceBeansConfig {
         arbeidssokerRepository: ArbeidssokerRepository,
         formidlingsgruppeGateway: FormidlingsgruppeGateway,
         unleashClient: UnleashClient,
-        prometheusMetricsService: PrometheusMetricsService
+        metricsService: MetricsService
     ): ArbeidssokerService {
         return ArbeidssokerService(
             arbeidssokerRepository,
             formidlingsgruppeGateway,
             unleashClient,
-            prometheusMetricsService
+            metricsService
         )
     }
 
@@ -270,7 +270,7 @@ class ServiceBeansConfig {
         registrertProducer: ArbeidssokerRegistrertProducer,
         registreringTilstandRepository: RegistreringTilstandRepository,
         profilertProducer: ArbeidssokerProfilertProducer,
-        prometheusMetricsService: PrometheusMetricsService
+        metricsService: MetricsService
     ): PubliseringAvEventsService {
         return PubliseringAvEventsService(
             profileringRepository,
@@ -278,7 +278,7 @@ class ServiceBeansConfig {
             registrertProducer,
             registreringTilstandRepository,
             profilertProducer,
-            prometheusMetricsService
+            metricsService
         )
     }
 

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/metrics/MetricsConfig.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/metrics/MetricsConfig.kt
@@ -1,8 +1,5 @@
 package no.nav.fo.veilarbregistrering.metrics
 
-import io.micrometer.core.instrument.MeterRegistry
-import io.micrometer.prometheus.PrometheusConfig
-import io.micrometer.prometheus.PrometheusMeterRegistry
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
@@ -11,11 +8,6 @@ import org.springframework.context.annotation.Configuration
 class MetricsConfig {
 
     @Bean
-    fun meterRegistry() {
-        PrometheusMeterRegistry(PrometheusConfig.DEFAULT)
-    }
-
-    @Bean
-    fun prometheusMetricsService(meterRegistry: MeterRegistry): MetricsService =
-        PrometheusMetricsService(meterRegistry)
+    fun prometheusMetricsService(): MetricsService =
+        PrometheusMetricsService()
 }

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/metrics/MetricsConfig.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/metrics/MetricsConfig.kt
@@ -16,7 +16,6 @@ class MetricsConfig {
     }
 
     @Bean
-    fun prometheusMetricsService(meterRegistry: MeterRegistry): PrometheusMetricsService =
+    fun prometheusMetricsService(meterRegistry: MeterRegistry): MetricsService =
         PrometheusMetricsService(meterRegistry)
-
 }

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/metrics/MetricsService.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/metrics/MetricsService.kt
@@ -1,0 +1,13 @@
+package no.nav.fo.veilarbregistrering.metrics
+
+import io.micrometer.core.instrument.Tag
+import no.nav.fo.veilarbregistrering.registrering.formidling.Status
+import java.time.Duration
+
+interface MetricsService {
+    fun rapporterRegistreringStatusAntall(antallPerStatus: Map<Status, Int>)
+    fun registrer(event: Event, vararg metrikker: Metric)
+    fun registrer(event: Event, vararg tags: Tag)
+    fun registrer(event: Event)
+    fun registrerTimer(event: Event, tid: Duration, vararg metrikker: Metric)
+}

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/metrics/PrometheusMetricsService.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/metrics/PrometheusMetricsService.kt
@@ -1,6 +1,6 @@
 package no.nav.fo.veilarbregistrering.metrics
 
-import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.Metrics
 import io.micrometer.core.instrument.Tag
 import no.nav.fo.veilarbregistrering.registrering.formidling.Status
 import java.time.Duration
@@ -13,13 +13,13 @@ import java.util.concurrent.atomic.AtomicInteger
  *
  * Prometheus benytter en pull-modell, hvor appen tilbyr et endepunkt for å hente data. Se application.yml.
  */
-class PrometheusMetricsService(private val meterRegistry: MeterRegistry) : MetricsService {
+class PrometheusMetricsService : MetricsService {
 
     override fun rapporterRegistreringStatusAntall(antallPerStatus: Map<Status, Int>) {
         antallPerStatus.forEach {
             val registrertAntall = statusVerdier.computeIfAbsent(it.key) { key ->
                 val atomiskAntall = AtomicInteger()
-                meterRegistry.gauge(
+                Metrics.gauge(
                         "veilarbregistrering_registrert_status",
                         listOf(Tag.of("status", key.name)),
                         atomiskAntall)
@@ -37,11 +37,11 @@ class PrometheusMetricsService(private val meterRegistry: MeterRegistry) : Metri
     }
 
     override fun registrer(event: Event, vararg tags: Tag) {
-        meterRegistry.counter(event.key, tags.asIterable()).increment()
+        Metrics.counter(event.key, tags.asIterable()).increment()
     }
 
     override fun registrer(event: Event) {
-        meterRegistry.counter(event.key).increment()
+        Metrics.counter(event.key).increment()
     }
 
     override fun registrerTimer(event: Event, tid: Duration, vararg metrikker: Metric) {
@@ -50,6 +50,6 @@ class PrometheusMetricsService(private val meterRegistry: MeterRegistry) : Metri
     }
 
     private fun registrerTimer(event: Event, tid: Duration, vararg tags: Tag) {
-        meterRegistry.timer(event.key, tags.asIterable()).record(tid)
+        Metrics.timer(event.key, tags.asIterable()).record(tid)
     }
 }

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/metrics/PrometheusMetricsService.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/metrics/PrometheusMetricsService.kt
@@ -13,9 +13,9 @@ import java.util.concurrent.atomic.AtomicInteger
  *
  * Prometheus benytter en pull-modell, hvor appen tilbyr et endepunkt for å hente data. Se application.yml.
  */
-class PrometheusMetricsService(private val meterRegistry: MeterRegistry) {
+class PrometheusMetricsService(private val meterRegistry: MeterRegistry) : MetricsService {
 
-    fun rapporterRegistreringStatusAntall(antallPerStatus: Map<Status, Int>) {
+    override fun rapporterRegistreringStatusAntall(antallPerStatus: Map<Status, Int>) {
         antallPerStatus.forEach {
             val registrertAntall = statusVerdier.computeIfAbsent(it.key) { key ->
                 val atomiskAntall = AtomicInteger()
@@ -31,20 +31,20 @@ class PrometheusMetricsService(private val meterRegistry: MeterRegistry) {
     
     private val statusVerdier: MutableMap<Status, AtomicInteger> = EnumMap(Status::class.java)
 
-    fun registrer(event: Event, vararg metrikker: Metric) {
+    override fun registrer(event: Event, vararg metrikker: Metric) {
         val tags = metrikker.map { Tag.of(it.fieldName(), it.value().toString()) }.toTypedArray()
         registrer(event, *tags)
     }
 
-    fun registrer(event: Event, vararg tags: Tag) {
+    override fun registrer(event: Event, vararg tags: Tag) {
         meterRegistry.counter(event.key, tags.asIterable()).increment()
     }
 
-    fun registrer(event: Event) {
+    override fun registrer(event: Event) {
         meterRegistry.counter(event.key).increment()
     }
 
-    fun registrerTimer(event: Event, tid: Duration, vararg metrikker: Metric) {
+    override fun registrerTimer(event: Event, tid: Duration, vararg metrikker: Metric) {
         val tags = metrikker.map { Tag.of(it.fieldName(), it.value().toString()) }.toTypedArray()
         registrerTimer(event, tid, *tags)
     }

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/metrics/TimedMetric.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/metrics/TimedMetric.kt
@@ -4,7 +4,7 @@ import java.time.Clock
 import java.time.Duration
 import java.time.Instant
 
-abstract class TimedMetric(private val metricsService: PrometheusMetricsService) : Metric {
+abstract class TimedMetric(private val metricsService: MetricsService) : Metric {
 
     override fun fieldName() = "tjeneste"
 

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/oppfolging/adapter/AbstractOppfolgingClient.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/oppfolging/adapter/AbstractOppfolgingClient.kt
@@ -6,7 +6,7 @@ import no.nav.fo.veilarbregistrering.feil.RestException
 import no.nav.fo.veilarbregistrering.http.Headers.buildHeaders
 import no.nav.fo.veilarbregistrering.http.Json
 import no.nav.fo.veilarbregistrering.http.buildHttpClient
-import no.nav.fo.veilarbregistrering.metrics.PrometheusMetricsService
+import no.nav.fo.veilarbregistrering.metrics.MetricsService
 import no.nav.fo.veilarbregistrering.metrics.TimedMetric
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -15,7 +15,7 @@ import java.util.concurrent.TimeUnit
 
 abstract class AbstractOppfolgingClient(
     private val objectMapper: ObjectMapper,
-    metricsService: PrometheusMetricsService
+    metricsService: MetricsService
 ): TimedMetric(metricsService) {
 
     fun <R : RuntimeException> post(

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/oppfolging/adapter/OppfolgingClient.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/oppfolging/adapter/OppfolgingClient.kt
@@ -12,7 +12,7 @@ import no.nav.fo.veilarbregistrering.config.RequestContext.servletRequest
 import no.nav.fo.veilarbregistrering.feil.ForbiddenException
 import no.nav.fo.veilarbregistrering.log.logger
 import no.nav.fo.veilarbregistrering.metrics.Events.*
-import no.nav.fo.veilarbregistrering.metrics.PrometheusMetricsService
+import no.nav.fo.veilarbregistrering.metrics.MetricsService
 import no.nav.fo.veilarbregistrering.oauth2.AadOboService
 import no.nav.fo.veilarbregistrering.oppfolging.AktiverBrukerException
 import no.nav.fo.veilarbregistrering.oppfolging.AktiverBrukerFeil
@@ -21,7 +21,7 @@ import javax.ws.rs.core.HttpHeaders
 
 open class OppfolgingClient(
     private val objectMapper: ObjectMapper,
-    private val metricsService: PrometheusMetricsService,
+    private val metricsService: MetricsService,
     private val baseUrl: String,
     private val aadOboService: AadOboService,
     private val tokenProvider: () -> String,

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/oppfolging/adapter/OppfolgingGatewayConfig.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/oppfolging/adapter/OppfolgingGatewayConfig.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import no.nav.common.sts.ServiceToServiceTokenProvider
 import no.nav.fo.veilarbregistrering.config.isDevelopment
 import no.nav.fo.veilarbregistrering.config.requireProperty
-import no.nav.fo.veilarbregistrering.metrics.PrometheusMetricsService
+import no.nav.fo.veilarbregistrering.metrics.MetricsService
 import no.nav.fo.veilarbregistrering.oauth2.AadOboService
 import no.nav.fo.veilarbregistrering.oauth2.DownstreamApi
 import no.nav.fo.veilarbregistrering.oppfolging.OppfolgingGateway
@@ -18,7 +18,7 @@ class OppfolgingGatewayConfig {
     @Bean
     fun oppfolgingClient(
         objectMapper: ObjectMapper,
-        prometheusMetricsService: PrometheusMetricsService,
+        metricsService: MetricsService,
         tokenProvider: ServiceToServiceTokenProvider,
         aadOboService: AadOboService,
     ): OppfolgingClient {
@@ -26,7 +26,7 @@ class OppfolgingGatewayConfig {
 
         return OppfolgingClient(
             objectMapper,
-            prometheusMetricsService,
+            metricsService,
             requireProperty(propertyName),
             aadOboService,
         ) {
@@ -41,7 +41,7 @@ class OppfolgingGatewayConfig {
     @Bean
     fun veilarbarenaClient(
         tokenProvider: ServiceToServiceTokenProvider,
-        prometheusMetricsService: PrometheusMetricsService
+        metricsService: MetricsService
     ): VeilarbarenaClient {
         val baseUrl = requireProperty("VEILARBARENA_URL")
         val veilarbarenaCluster = requireProperty("VEILARBARENA_CLUSTER")
@@ -63,7 +63,7 @@ class OppfolgingGatewayConfig {
                 if (isDevelopment()) "dev-fss" else "prod-fss"
             )
         }
-        return VeilarbarenaClient(baseUrl, prometheusMetricsService, veilarbarenaTokenProvider, proxyTokenProvider)
+        return VeilarbarenaClient(baseUrl, metricsService, veilarbarenaTokenProvider, proxyTokenProvider)
     }
 
     @Bean

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/oppfolging/adapter/veilarbarena/VeilarbarenaClient.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/oppfolging/adapter/veilarbarena/VeilarbarenaClient.kt
@@ -7,7 +7,7 @@ import no.nav.common.health.HealthCheckUtils
 import no.nav.fo.veilarbregistrering.bruker.Foedselsnummer
 import no.nav.fo.veilarbregistrering.config.objectMapper
 import no.nav.fo.veilarbregistrering.http.defaultHttpClient
-import no.nav.fo.veilarbregistrering.metrics.PrometheusMetricsService
+import no.nav.fo.veilarbregistrering.metrics.MetricsService
 import no.nav.fo.veilarbregistrering.metrics.TimedMetric
 import okhttp3.Request
 import org.springframework.http.HttpStatus
@@ -15,10 +15,10 @@ import java.io.IOException
 
 class VeilarbarenaClient(
     private val baseUrl: String,
-    prometheusMetricsService: PrometheusMetricsService,
+    metricsService: MetricsService,
     private val veilarbarenaTokenProvider: () -> String,
     private val proxyTokenProvider: () -> String
-) : HealthCheck, TimedMetric(prometheusMetricsService) {
+) : HealthCheck, TimedMetric(metricsService) {
 
     internal fun arenaStatus(fnr: Foedselsnummer): ArenaStatusDto? {
         val proxyToken = proxyTokenProvider()

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/oppgave/OppgaveService.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/oppgave/OppgaveService.kt
@@ -3,14 +3,14 @@ package no.nav.fo.veilarbregistrering.oppgave
 import no.nav.fo.veilarbregistrering.bruker.Bruker
 import no.nav.fo.veilarbregistrering.log.loggerFor
 import no.nav.fo.veilarbregistrering.metrics.Events
-import no.nav.fo.veilarbregistrering.metrics.PrometheusMetricsService
+import no.nav.fo.veilarbregistrering.metrics.MetricsService
 import java.time.LocalDate
 
 open class OppgaveService(
     private val oppgaveGateway: OppgaveGateway,
     private val oppgaveRepository: OppgaveRepository,
     private val oppgaveRouter: OppgaveRouter,
-    private val prometheusMetricsService: PrometheusMetricsService
+    private val metricsService: MetricsService
 ) {
     fun opprettOppgave(bruker: Bruker, oppgaveType: OppgaveType): OppgaveResponse {
         validerNyOppgaveMotAktive(bruker, oppgaveType)
@@ -27,7 +27,7 @@ open class OppgaveService(
             oppgaveType, oppgaveResponse.id, oppgaveResponse.tildeltEnhetsnr
         )
         oppgaveRepository.opprettOppgave(bruker.aktorId, oppgaveType, oppgaveResponse.id)
-        prometheusMetricsService.registrer(Events.OPPGAVE_OPPRETTET_EVENT, oppgaveType)
+        metricsService.registrer(Events.OPPGAVE_OPPRETTET_EVENT, oppgaveType)
         return oppgaveResponse
     }
 
@@ -38,7 +38,7 @@ open class OppgaveService(
             .filter(OppgavePredicates.oppgaveOpprettetForMindreEnnToArbeidsdagerSiden(idag()))
             .findFirst()
         muligOppgave.ifPresent { oppgave: OppgaveImpl ->
-            prometheusMetricsService.registrer(Events.OPPGAVE_ALLEREDE_OPPRETTET_EVENT, oppgaveType)
+            metricsService.registrer(Events.OPPGAVE_ALLEREDE_OPPRETTET_EVENT, oppgaveType)
             throw OppgaveAlleredeOpprettet(
                 "Fant en oppgave av samme type ${oppgave.oppgavetype} " +
                         "som ble opprettet ${oppgave.opprettet.tidspunkt} - " +

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/oppgave/adapter/OppgaveGatewayConfig.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/oppgave/adapter/OppgaveGatewayConfig.kt
@@ -4,7 +4,7 @@ import no.nav.common.sts.ServiceToServiceTokenProvider
 import no.nav.common.sts.SystemUserTokenProvider
 import no.nav.fo.veilarbregistrering.config.isProduction
 import no.nav.fo.veilarbregistrering.config.requireProperty
-import no.nav.fo.veilarbregistrering.metrics.PrometheusMetricsService
+import no.nav.fo.veilarbregistrering.metrics.MetricsService
 import no.nav.fo.veilarbregistrering.oppgave.OppgaveGateway
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -14,13 +14,13 @@ class OppgaveGatewayConfig {
     @Bean
     fun oppgaveRestClient(
         systemUserTokenProvider: SystemUserTokenProvider,
-        prometheusMetricsService: PrometheusMetricsService,
+        metricsService: MetricsService,
         tokenProvider: ServiceToServiceTokenProvider
     ): OppgaveRestClient {
         val cluster = requireProperty(OPPGAVE_CLUSTER)
         val serviceName = if (isProduction()) "oppgave" else "oppgave-q1"
 
-        return OppgaveRestClient(requireProperty(OPPGAVE_PROPERTY_NAME), prometheusMetricsService) {
+        return OppgaveRestClient(requireProperty(OPPGAVE_PROPERTY_NAME), metricsService) {
             tokenProvider.getServiceToken(
                 serviceName,
                 "oppgavehandtering",

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/oppgave/adapter/OppgaveRestClient.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/oppgave/adapter/OppgaveRestClient.kt
@@ -5,7 +5,7 @@ import no.nav.common.health.HealthCheckResult
 import no.nav.common.health.HealthCheckUtils
 import no.nav.common.rest.client.RestClient
 import no.nav.common.rest.client.RestUtils
-import no.nav.fo.veilarbregistrering.metrics.PrometheusMetricsService
+import no.nav.fo.veilarbregistrering.metrics.MetricsService
 import no.nav.fo.veilarbregistrering.metrics.TimedMetric
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -15,7 +15,7 @@ import java.util.concurrent.TimeUnit
 
 class OppgaveRestClient(
     private val baseUrl: String,
-    metricsService: PrometheusMetricsService,
+    metricsService: MetricsService,
     private val tokenProvider: () -> String
 ) : HealthCheck, TimedMetric(metricsService) {
     internal fun opprettOppgave(oppgaveDto: OppgaveDto): OppgaveResponseDto {

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/registrering/bruker/BrukerRegistreringService.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/registrering/bruker/BrukerRegistreringService.kt
@@ -4,7 +4,7 @@ import no.nav.fo.veilarbregistrering.besvarelse.Besvarelse
 import no.nav.fo.veilarbregistrering.bruker.Bruker
 import no.nav.fo.veilarbregistrering.bruker.Foedselsnummer
 import no.nav.fo.veilarbregistrering.metrics.Events
-import no.nav.fo.veilarbregistrering.metrics.PrometheusMetricsService
+import no.nav.fo.veilarbregistrering.metrics.MetricsService
 import no.nav.fo.veilarbregistrering.oppfolging.AktiverBrukerException
 import no.nav.fo.veilarbregistrering.oppfolging.AktiverBrukerFeil.Companion.fromStatus
 import no.nav.fo.veilarbregistrering.oppfolging.OppfolgingGateway
@@ -32,7 +32,7 @@ open class BrukerRegistreringService(
     private val registreringTilstandRepository: RegistreringTilstandRepository,
     private val brukerTilstandService: BrukerTilstandService,
     private val manuellRegistreringRepository: ManuellRegistreringRepository,
-    private val prometheusMetricsService: PrometheusMetricsService
+    private val metricsService: MetricsService
 ) {
     @Transactional
     open fun registrerBrukerUtenOverforing(
@@ -47,7 +47,7 @@ open class BrukerRegistreringService(
         val profilering =
             profilerBrukerTilInnsatsgruppe(bruker.gjeldendeFoedselsnummer, opprettetBrukerRegistrering.besvarelse)
         profileringRepository.lagreProfilering(opprettetBrukerRegistrering.id, profilering)
-        prometheusMetricsService.registrer(Events.PROFILERING_EVENT, profilering.innsatsgruppe)
+        metricsService.registrer(Events.PROFILERING_EVENT, profilering.innsatsgruppe)
         val registreringTilstand = medStatus(Status.MOTTATT, opprettetBrukerRegistrering.id)
         registreringTilstandRepository.lagre(registreringTilstand)
         LOG.info(
@@ -102,7 +102,7 @@ open class BrukerRegistreringService(
 
     private fun registrerOverfortStatistikk(veileder: NavVeileder?) {
         if (veileder == null) return
-        prometheusMetricsService.registrer(Events.MANUELL_REGISTRERING_EVENT, BrukerRegistreringType.ORDINAER)
+        metricsService.registrer(Events.MANUELL_REGISTRERING_EVENT, BrukerRegistreringType.ORDINAER)
     }
 
     private fun validerBrukerRegistrering(ordinaerBrukerRegistrering: OrdinaerBrukerRegistrering, bruker: Bruker) {
@@ -126,7 +126,7 @@ open class BrukerRegistreringService(
                 ordinaerBrukerRegistrering.besvarelse,
                 ordinaerBrukerRegistrering.sisteStilling
             )
-            prometheusMetricsService.registrer(Events.INVALID_REGISTRERING_EVENT)
+            metricsService.registrer(Events.INVALID_REGISTRERING_EVENT)
             throw e
         }
     }

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/registrering/bruker/HentRegistreringService.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/registrering/bruker/HentRegistreringService.kt
@@ -4,7 +4,7 @@ import no.nav.fo.veilarbregistrering.bruker.Bruker
 import no.nav.fo.veilarbregistrering.log.logger
 import no.nav.fo.veilarbregistrering.metrics.Events
 import no.nav.fo.veilarbregistrering.metrics.JaNei
-import no.nav.fo.veilarbregistrering.metrics.PrometheusMetricsService
+import no.nav.fo.veilarbregistrering.metrics.MetricsService
 import no.nav.fo.veilarbregistrering.orgenhet.Enhetnr
 import no.nav.fo.veilarbregistrering.orgenhet.NavEnhet
 import no.nav.fo.veilarbregistrering.orgenhet.Norg2Gateway
@@ -24,7 +24,7 @@ class HentRegistreringService(
     private val profileringRepository: ProfileringRepository,
     private val manuellRegistreringRepository: ManuellRegistreringRepository,
     private val norg2Gateway: Norg2Gateway,
-    private val metricsService: PrometheusMetricsService
+    private val metricsService: MetricsService
 ) {
     fun hentBrukerregistrering(bruker: Bruker): BrukerRegistreringWrapper? {
         val ordinaerBrukerRegistrering = hentOrdinaerBrukerRegistrering(bruker)

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/registrering/bruker/InaktivBrukerService.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/registrering/bruker/InaktivBrukerService.kt
@@ -3,7 +3,7 @@ package no.nav.fo.veilarbregistrering.registrering.bruker
 import no.nav.fo.veilarbregistrering.bruker.Bruker
 import no.nav.fo.veilarbregistrering.log.loggerFor
 import no.nav.fo.veilarbregistrering.metrics.Events
-import no.nav.fo.veilarbregistrering.metrics.PrometheusMetricsService
+import no.nav.fo.veilarbregistrering.metrics.MetricsService
 import no.nav.fo.veilarbregistrering.oppfolging.OppfolgingGateway
 import org.springframework.transaction.annotation.Transactional
 
@@ -11,7 +11,7 @@ open class InaktivBrukerService(
     private val brukerTilstandService: BrukerTilstandService,
     private val reaktiveringRepository: ReaktiveringRepository,
     private val oppfolgingGateway: OppfolgingGateway,
-    private val prometheusMetricsService: PrometheusMetricsService
+    private val metricsService: MetricsService
 ) {
     @Transactional
     open fun reaktiverBruker(bruker: Bruker, erVeileder: Boolean) {
@@ -23,7 +23,7 @@ open class InaktivBrukerService(
         oppfolgingGateway.reaktiverBruker(bruker.gjeldendeFoedselsnummer)
         LOG.info("Reaktivering av bruker med aktørId : {}", bruker.aktorId)
         if (erVeileder) {
-            prometheusMetricsService.registrer(Events.MANUELL_REAKTIVERING_EVENT)
+            metricsService.registrer(Events.MANUELL_REAKTIVERING_EVENT)
         }
     }
 

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/registrering/bruker/StartRegistreringStatusService.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/registrering/bruker/StartRegistreringStatusService.kt
@@ -6,7 +6,7 @@ import no.nav.fo.veilarbregistrering.bruker.GeografiskTilknytning
 import no.nav.fo.veilarbregistrering.bruker.PdlOppslagGateway
 import no.nav.fo.veilarbregistrering.log.logger
 import no.nav.fo.veilarbregistrering.metrics.Events
-import no.nav.fo.veilarbregistrering.metrics.PrometheusMetricsService
+import no.nav.fo.veilarbregistrering.metrics.MetricsService
 import no.nav.fo.veilarbregistrering.registrering.bruker.resources.StartRegistreringStatusDto
 import no.nav.fo.veilarbregistrering.registrering.bruker.resources.StartRegistreringStatusDtoMapper.map
 import java.time.LocalDate
@@ -15,7 +15,7 @@ class StartRegistreringStatusService(
     private val arbeidsforholdGateway: ArbeidsforholdGateway,
     private val brukerTilstandService: BrukerTilstandService,
     private val pdlOppslagGateway: PdlOppslagGateway,
-    private val prometheusMetricsService: PrometheusMetricsService
+    private val metricsService: MetricsService
 ) {
     fun hentStartRegistreringStatus(bruker: Bruker): StartRegistreringStatusDto {
         val brukersTilstand = brukerTilstandService.hentBrukersTilstand(bruker)
@@ -49,7 +49,7 @@ class StartRegistreringStatusService(
     }
 
     fun registrerAtArenaHarPlanlagtNedetid() {
-        prometheusMetricsService.registrer(Events.REGISTRERING_NEDETID_ARENA)
+        metricsService.registrer(Events.REGISTRERING_NEDETID_ARENA)
     }
 
     private fun hentGeografiskTilknytning(bruker: Bruker): GeografiskTilknytning? {
@@ -67,18 +67,18 @@ class StartRegistreringStatusService(
     }
 
     private fun registrerFunksjonelleMetrikker(brukersTilstand: BrukersTilstand) {
-        prometheusMetricsService.registrer(Events.REGISTRERING_REGISTERINGSTYPE, brukersTilstand.registreringstype)
+        metricsService.registrer(Events.REGISTRERING_REGISTERINGSTYPE, brukersTilstand.registreringstype)
         brukersTilstand.servicegruppe?.let {
-            prometheusMetricsService.registrer(Events.REGISTRERING_SERVICEGRUPPE, it)
+            metricsService.registrer(Events.REGISTRERING_SERVICEGRUPPE, it)
         }
         brukersTilstand.rettighetsgruppe?.let {
-            prometheusMetricsService.registrer(Events.REGISTRERING_RETTIGHETSGRUPPE, it)
+            metricsService.registrer(Events.REGISTRERING_RETTIGHETSGRUPPE, it)
         }
 
         if (brukersTilstand.registreringstype == RegistreringType.ALLEREDE_REGISTRERT &&
             brukersTilstand.formidlingsgruppe != null && brukersTilstand.servicegruppe != null
         ) {
-            prometheusMetricsService.registrer(
+            metricsService.registrer(
                 Events.REGISTRERING_ALLEREDEREGISTRERT,
                 brukersTilstand.formidlingsgruppe,
                 brukersTilstand.servicegruppe

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/registrering/bruker/SykmeldtRegistreringService.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/registrering/bruker/SykmeldtRegistreringService.kt
@@ -2,7 +2,7 @@ package no.nav.fo.veilarbregistrering.registrering.bruker
 
 import no.nav.fo.veilarbregistrering.bruker.Bruker
 import no.nav.fo.veilarbregistrering.metrics.Events
-import no.nav.fo.veilarbregistrering.metrics.PrometheusMetricsService
+import no.nav.fo.veilarbregistrering.metrics.MetricsService
 import no.nav.fo.veilarbregistrering.oppfolging.OppfolgingGateway
 import no.nav.fo.veilarbregistrering.registrering.BrukerRegistreringType.SYKMELDT
 import no.nav.fo.veilarbregistrering.registrering.manuell.ManuellRegistrering
@@ -15,7 +15,7 @@ open class SykmeldtRegistreringService(
     private val oppfolgingGateway: OppfolgingGateway,
     private val sykmeldtRegistreringRepository: SykmeldtRegistreringRepository,
     private val manuellRegistreringRepository: ManuellRegistreringRepository,
-    private val prometheusMetricsService: PrometheusMetricsService
+    private val metricsService: MetricsService
 ) {
     @Transactional
     open fun registrerSykmeldt(sykmeldtRegistrering: SykmeldtRegistrering, bruker: Bruker, navVeileder: NavVeileder?): Long {
@@ -25,7 +25,7 @@ open class SykmeldtRegistreringService(
         lagreManuellRegistrering(id, navVeileder)
         registrerOverfortStatistikk(navVeileder)
         LOG.info("Sykmeldtregistrering gjennomført med data {}", sykmeldtRegistrering)
-        prometheusMetricsService.registrer(Events.SYKMELDT_BESVARELSE_EVENT)
+        metricsService.registrer(Events.SYKMELDT_BESVARELSE_EVENT)
         return id
     }
 
@@ -42,7 +42,7 @@ open class SykmeldtRegistreringService(
 
     private fun registrerOverfortStatistikk(veileder: NavVeileder?) {
         if (veileder == null) return
-        prometheusMetricsService.registrer(Events.MANUELL_REGISTRERING_EVENT, SYKMELDT)
+        metricsService.registrer(Events.MANUELL_REGISTRERING_EVENT, SYKMELDT)
     }
 
     companion object {

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/registrering/publisering/PubliseringAvEventsService.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/registrering/publisering/PubliseringAvEventsService.kt
@@ -1,6 +1,6 @@
 package no.nav.fo.veilarbregistrering.registrering.publisering
 
-import no.nav.fo.veilarbregistrering.metrics.PrometheusMetricsService
+import no.nav.fo.veilarbregistrering.metrics.MetricsService
 import no.nav.fo.veilarbregistrering.profilering.ProfileringRepository
 import no.nav.fo.veilarbregistrering.registrering.bruker.BrukerRegistreringRepository
 import no.nav.fo.veilarbregistrering.registrering.formidling.RegistreringTilstand
@@ -17,7 +17,7 @@ class PubliseringAvEventsService(
     private val registrertProducer: ArbeidssokerRegistrertProducer,
     private val registreringTilstandRepository: RegistreringTilstandRepository,
     private val profilertProducer: ArbeidssokerProfilertProducer,
-    private val prometheusMetricsService: PrometheusMetricsService
+    private val metricsService: MetricsService
 ) {
     @Transactional
     fun publiserEvents() {
@@ -63,7 +63,7 @@ class PubliseringAvEventsService(
     private fun rapporterRegistreringStatusAntallForPublisering() {
         try {
             val antallPerStatus = registreringTilstandRepository.hentAntallPerStatus()
-            prometheusMetricsService.rapporterRegistreringStatusAntall(antallPerStatus)
+            metricsService.rapporterRegistreringStatusAntall(antallPerStatus)
         } catch (e: Exception) {
             LOG.error("Feil ved rapportering av antall statuser", e)
         }

--- a/src/test/kotlin/no/nav/fo/veilarbregistrering/arbeidssoker/ArbeidssokerServiceHentArbeidssokerperioderTest.kt
+++ b/src/test/kotlin/no/nav/fo/veilarbregistrering/arbeidssoker/ArbeidssokerServiceHentArbeidssokerperioderTest.kt
@@ -8,7 +8,7 @@ import no.nav.fo.veilarbregistrering.bruker.AktorId
 import no.nav.fo.veilarbregistrering.bruker.Bruker
 import no.nav.fo.veilarbregistrering.bruker.Foedselsnummer
 import no.nav.fo.veilarbregistrering.bruker.Periode
-import no.nav.fo.veilarbregistrering.metrics.PrometheusMetricsService
+import no.nav.fo.veilarbregistrering.metrics.MetricsService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -17,7 +17,7 @@ import java.time.LocalDate
 class ArbeidssokerServiceHentArbeidssokerperioderTest {
     private lateinit var arbeidssokerService: ArbeidssokerService
     private val unleashService = mockk<UnleashClient>()
-    private val prometheusMetricsService = mockk<PrometheusMetricsService>(relaxed = true)
+    private val metricsService = mockk<MetricsService>(relaxed = true)
 
     @BeforeEach
     fun setup() {
@@ -25,7 +25,7 @@ class ArbeidssokerServiceHentArbeidssokerperioderTest {
             StubArbeidssokerRepository(),
             StubFormidlingsgruppeGateway(),
             unleashService,
-            prometheusMetricsService,
+            metricsService,
         )
     }
 

--- a/src/test/kotlin/no/nav/fo/veilarbregistrering/db/HentBrukerRegistreringServiceIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/fo/veilarbregistrering/db/HentBrukerRegistreringServiceIntegrationTest.kt
@@ -8,7 +8,7 @@ import no.nav.fo.veilarbregistrering.bruker.Bruker
 import no.nav.fo.veilarbregistrering.bruker.Foedselsnummer
 import no.nav.fo.veilarbregistrering.enhet.Kommune
 import no.nav.fo.veilarbregistrering.enhet.Kommune.KommuneMedBydel.STAVANGER
-import no.nav.fo.veilarbregistrering.metrics.PrometheusMetricsService
+import no.nav.fo.veilarbregistrering.metrics.MetricsService
 import no.nav.fo.veilarbregistrering.oppfolging.OppfolgingGateway
 import no.nav.fo.veilarbregistrering.oppfolging.Oppfolgingsstatus
 import no.nav.fo.veilarbregistrering.orgenhet.Enhetnr
@@ -106,7 +106,7 @@ class HentBrukerRegistreringServiceIntegrationTest(
                     sykmeldtRegistreringRepository: SykmeldtRegistreringRepository,
                     profileringRepository: ProfileringRepository,
                     manuellRegistreringRepository: ManuellRegistreringRepository,
-                    metricsService: PrometheusMetricsService
+                    metricsService: MetricsService
             ) = HentRegistreringService(
                     brukerRegistreringRepository,
                     sykmeldtRegistreringRepository,
@@ -128,7 +128,7 @@ class HentBrukerRegistreringServiceIntegrationTest(
             }
 
             @Bean
-            fun metricsService(): PrometheusMetricsService = mockk(relaxed = true)
+            fun metricsService(): MetricsService = mockk(relaxed = true)
 
             @Bean
             fun oppfolgingGateway(): OppfolgingGateway = mockk()

--- a/src/test/kotlin/no/nav/fo/veilarbregistrering/oppgave/OppgaveRouterTest.kt
+++ b/src/test/kotlin/no/nav/fo/veilarbregistrering/oppgave/OppgaveRouterTest.kt
@@ -10,7 +10,7 @@ import no.nav.fo.veilarbregistrering.enhet.Forretningsadresse
 import no.nav.fo.veilarbregistrering.enhet.Kommune
 import no.nav.fo.veilarbregistrering.enhet.Kommune.KommuneMedBydel.STAVANGER
 import no.nav.fo.veilarbregistrering.enhet.Organisasjonsdetaljer
-import no.nav.fo.veilarbregistrering.metrics.PrometheusMetricsService
+import no.nav.fo.veilarbregistrering.metrics.MetricsService
 import no.nav.fo.veilarbregistrering.orgenhet.Enhetnr
 import no.nav.fo.veilarbregistrering.orgenhet.NavEnhet
 import no.nav.fo.veilarbregistrering.orgenhet.Norg2Gateway
@@ -137,9 +137,9 @@ class OppgaveRouterTest {
         enhetGateway: EnhetGateway = EnhetGateway { null },
         norg2Gateway: Norg2Gateway = StubNorg2Gateway(),
         pdlOppslagGateway: PdlOppslagGateway = StubPdlOppslagGateway(),
-        prometheusMetricsService: PrometheusMetricsService = mockk(relaxed = true)
+        metricsService: MetricsService = mockk(relaxed = true)
     ) =
-            OppgaveRouter(arbeidsforholdGateway, enhetGateway, norg2Gateway, pdlOppslagGateway, prometheusMetricsService)
+            OppgaveRouter(arbeidsforholdGateway, enhetGateway, norg2Gateway, pdlOppslagGateway, metricsService)
 
     private class StubNorg2Gateway : Norg2Gateway {
         override fun hentEnhetFor(kommune: Kommune): Enhetnr? {

--- a/src/test/kotlin/no/nav/fo/veilarbregistrering/registrering/bruker/InaktivBrukerServiceTest.kt
+++ b/src/test/kotlin/no/nav/fo/veilarbregistrering/registrering/bruker/InaktivBrukerServiceTest.kt
@@ -4,7 +4,7 @@ import io.mockk.*
 import no.nav.fo.veilarbregistrering.bruker.AktorId
 import no.nav.fo.veilarbregistrering.bruker.Bruker
 import no.nav.fo.veilarbregistrering.bruker.FoedselsnummerTestdataBuilder
-import no.nav.fo.veilarbregistrering.metrics.PrometheusMetricsService
+import no.nav.fo.veilarbregistrering.metrics.MetricsService
 import no.nav.fo.veilarbregistrering.oppfolging.adapter.ErUnderOppfolgingDto
 import no.nav.fo.veilarbregistrering.oppfolging.adapter.OppfolgingClient
 import no.nav.fo.veilarbregistrering.oppfolging.adapter.OppfolgingGatewayImpl
@@ -21,7 +21,7 @@ class InaktivBrukerServiceTest {
     private val reaktiveringRepository: ReaktiveringRepository = mockk(relaxed = true)
     private val oppfolgingClient: OppfolgingClient = mockk(relaxed = true)
     private val veilarbarenaClient: VeilarbarenaClient = mockk(relaxed = true)
-    private val prometheusMetricsService: PrometheusMetricsService = mockk(relaxed = true)
+    private val metricsService: MetricsService = mockk(relaxed = true)
 
     @BeforeEach
     fun setup() {
@@ -34,7 +34,7 @@ class InaktivBrukerServiceTest {
                 ),
                 reaktiveringRepository,
                 oppfolgingGateway,
-                prometheusMetricsService
+                metricsService
         )
     }
 

--- a/src/test/kotlin/no/nav/fo/veilarbregistrering/registrering/bruker/StartRegistreringStatusServiceTest.kt
+++ b/src/test/kotlin/no/nav/fo/veilarbregistrering/registrering/bruker/StartRegistreringStatusServiceTest.kt
@@ -6,7 +6,7 @@ import no.nav.fo.veilarbregistrering.arbeidsforhold.Arbeidsforhold
 import no.nav.fo.veilarbregistrering.arbeidsforhold.ArbeidsforholdGateway
 import no.nav.fo.veilarbregistrering.arbeidsforhold.FlereArbeidsforhold
 import no.nav.fo.veilarbregistrering.bruker.*
-import no.nav.fo.veilarbregistrering.metrics.PrometheusMetricsService
+import no.nav.fo.veilarbregistrering.metrics.MetricsService
 import no.nav.fo.veilarbregistrering.oppfolging.adapter.ErUnderOppfolgingDto
 import no.nav.fo.veilarbregistrering.oppfolging.adapter.OppfolgingClient
 import no.nav.fo.veilarbregistrering.oppfolging.adapter.OppfolgingGatewayImpl
@@ -31,7 +31,7 @@ class StartRegistreringStatusServiceTest {
         oppfolgingClient = mockk()
         veilarbarenaClient = mockk()
         pdlOppslagGateway = mockk()
-        val metricsService: PrometheusMetricsService = mockk(relaxed = true)
+        val metricsService: MetricsService = mockk(relaxed = true)
         val oppfolgingGateway = OppfolgingGatewayImpl(oppfolgingClient, veilarbarenaClient)
         brukerRegistreringService = StartRegistreringStatusService(
             arbeidsforholdGateway,

--- a/src/test/kotlin/no/nav/fo/veilarbregistrering/registrering/bruker/SykmeldtRegistreringServiceTest.kt
+++ b/src/test/kotlin/no/nav/fo/veilarbregistrering/registrering/bruker/SykmeldtRegistreringServiceTest.kt
@@ -8,7 +8,7 @@ import no.nav.fo.veilarbregistrering.autorisasjon.AutorisasjonService
 import no.nav.fo.veilarbregistrering.bruker.AktorId
 import no.nav.fo.veilarbregistrering.bruker.Bruker
 import no.nav.fo.veilarbregistrering.bruker.FoedselsnummerTestdataBuilder
-import no.nav.fo.veilarbregistrering.metrics.PrometheusMetricsService
+import no.nav.fo.veilarbregistrering.metrics.MetricsService
 import no.nav.fo.veilarbregistrering.oppfolging.adapter.OppfolgingClient
 import no.nav.fo.veilarbregistrering.oppfolging.adapter.OppfolgingGatewayImpl
 import no.nav.fo.veilarbregistrering.oppfolging.adapter.veilarbarena.ArenaStatusDto
@@ -29,7 +29,7 @@ class SykmeldtRegistreringServiceTest {
     private val oppfolgingClient: OppfolgingClient = mockk(relaxed = true)
     private val veilarbarenaClient: VeilarbarenaClient = mockk(relaxed = true)
     private val autorisasjonService: AutorisasjonService = mockk()
-    private val metricsService: PrometheusMetricsService = mockk(relaxed = true)
+    private val metricsService: MetricsService = mockk(relaxed = true)
 
     @BeforeEach
     fun setup() {

--- a/src/test/kotlin/no/nav/veilarbregistrering/integrasjonstest/ArbeidssokerServiceIT.kt
+++ b/src/test/kotlin/no/nav/veilarbregistrering/integrasjonstest/ArbeidssokerServiceIT.kt
@@ -12,7 +12,7 @@ import no.nav.fo.veilarbregistrering.bruker.Periode
 import no.nav.fo.veilarbregistrering.db.DatabaseConfig
 import no.nav.fo.veilarbregistrering.db.RepositoryConfig
 import no.nav.fo.veilarbregistrering.kafka.FormidlingsgruppeEvent
-import no.nav.fo.veilarbregistrering.metrics.PrometheusMetricsService
+import no.nav.fo.veilarbregistrering.metrics.MetricsService
 import no.nav.fo.veilarbregistrering.oppfolging.OppfolgingGateway
 import no.nav.fo.veilarbregistrering.profilering.ProfileringService
 import org.junit.jupiter.api.AfterEach
@@ -66,7 +66,7 @@ internal class ArbeidssokerServiceIT @Autowired constructor(
         fun profileringService(): ProfileringService = mockk(relaxed = true)
 
         @Bean
-        fun metricsService(): PrometheusMetricsService = mockk(relaxed = true)
+        fun metricsService(): MetricsService = mockk(relaxed = true)
 
         @Bean
         fun unleashClient(): UnleashClient = mockk(relaxed = true)
@@ -80,7 +80,7 @@ internal class ArbeidssokerServiceIT @Autowired constructor(
             arbeidssokerRepository: ArbeidssokerRepository,
             unleashClient: UnleashClient,
             formidlingsgruppeGateway: FormidlingsgruppeGateway,
-            metricsService: PrometheusMetricsService
+            metricsService: MetricsService
         ): ArbeidssokerService = ArbeidssokerService(
             arbeidssokerRepository,
             formidlingsgruppeGateway,

--- a/src/test/kotlin/no/nav/veilarbregistrering/integrasjonstest/BrukerRegistreringServiceIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/veilarbregistrering/integrasjonstest/BrukerRegistreringServiceIntegrationTest.kt
@@ -7,7 +7,7 @@ import no.nav.fo.veilarbregistrering.bruker.Bruker
 import no.nav.fo.veilarbregistrering.bruker.FoedselsnummerTestdataBuilder
 import no.nav.fo.veilarbregistrering.db.DatabaseConfig
 import no.nav.fo.veilarbregistrering.db.RepositoryConfig
-import no.nav.fo.veilarbregistrering.metrics.PrometheusMetricsService
+import no.nav.fo.veilarbregistrering.metrics.MetricsService
 import no.nav.fo.veilarbregistrering.oppfolging.AktiverBrukerException
 import no.nav.fo.veilarbregistrering.oppfolging.AktiverBrukerFeil
 import no.nav.fo.veilarbregistrering.oppfolging.OppfolgingGateway
@@ -152,18 +152,18 @@ internal class BrukerRegistreringServiceIntegrationTest @Autowired constructor(
         }
 
         @Bean
-        fun metricsService(): PrometheusMetricsService  = mockk(relaxed = true)
+        fun metricsService(): MetricsService  = mockk(relaxed = true)
 
         @Bean
         fun brukerRegistreringService(
-                brukerRegistreringRepository: BrukerRegistreringRepository,
-                profileringRepository: ProfileringRepository,
-                oppfolgingGateway: OppfolgingGateway,
-                profileringService: ProfileringService,
-                registreringTilstandRepository: RegistreringTilstandRepository,
-                brukerTilstandService: BrukerTilstandService,
-                manuellRegistreringRepository: ManuellRegistreringRepository,
-                prometheusMetricsService: PrometheusMetricsService
+            brukerRegistreringRepository: BrukerRegistreringRepository,
+            profileringRepository: ProfileringRepository,
+            oppfolgingGateway: OppfolgingGateway,
+            profileringService: ProfileringService,
+            registreringTilstandRepository: RegistreringTilstandRepository,
+            brukerTilstandService: BrukerTilstandService,
+            manuellRegistreringRepository: ManuellRegistreringRepository,
+            metricsService: MetricsService
         ): BrukerRegistreringService {
             return BrukerRegistreringService(
                 brukerRegistreringRepository,
@@ -173,7 +173,7 @@ internal class BrukerRegistreringServiceIntegrationTest @Autowired constructor(
                 registreringTilstandRepository,
                 brukerTilstandService,
                 manuellRegistreringRepository,
-                prometheusMetricsService
+                metricsService
             )
         }
 


### PR DESCRIPTION
Tenker det kan være greit at bruken av MetricService ikke kjenner til detaljene bak ift. hvilken teknologi som ligger bak.
Håper samtidig at dette kan hjelpe til med den sirkulære avhengigheten vi opplevde når vi oppgraderte Spring-boot.