### PR TITLE
Oppgrader spring

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,7 +53,7 @@ jobs:
     name: Deploy to dev FSS
     needs: test-build-and-push
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/oppgrader-spring'
+    if: github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v1
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,7 +53,7 @@ jobs:
     name: Deploy to dev FSS
     needs: test-build-and-push
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/httpklient'
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/oppgrader-spring'
     steps:
       - uses: actions/checkout@v1
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.5.6</version>
+        <version>2.6.6</version>
         <relativePath/>
     </parent>
 

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/metrics/MetricsConfig.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/metrics/MetricsConfig.kt
@@ -11,9 +11,8 @@ import org.springframework.context.annotation.Configuration
 class MetricsConfig {
 
     @Bean
-    fun meterRegistry() {
+    fun meterRegistry(): MeterRegistry =
         PrometheusMeterRegistry(PrometheusConfig.DEFAULT)
-    }
 
     @Bean
     fun prometheusMetricsService(meterRegistry: MeterRegistry): MetricsService =

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/metrics/MetricsConfig.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/metrics/MetricsConfig.kt
@@ -1,8 +1,5 @@
 package no.nav.fo.veilarbregistrering.metrics
 
-import io.micrometer.core.instrument.MeterRegistry
-import io.micrometer.prometheus.PrometheusConfig
-import io.micrometer.prometheus.PrometheusMeterRegistry
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
@@ -11,10 +8,6 @@ import org.springframework.context.annotation.Configuration
 class MetricsConfig {
 
     @Bean
-    fun meterRegistry(): MeterRegistry =
-        PrometheusMeterRegistry(PrometheusConfig.DEFAULT)
-
-    @Bean
-    fun prometheusMetricsService(meterRegistry: MeterRegistry): MetricsService =
-        PrometheusMetricsService(meterRegistry)
+    fun prometheusMetricsService(): MetricsService =
+        PrometheusMetricsService()
 }

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/metrics/PrometheusMetricsService.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/metrics/PrometheusMetricsService.kt
@@ -1,6 +1,6 @@
 package no.nav.fo.veilarbregistrering.metrics
 
-import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.Metrics
 import io.micrometer.core.instrument.Tag
 import no.nav.fo.veilarbregistrering.registrering.formidling.Status
 import java.time.Duration
@@ -13,13 +13,13 @@ import java.util.concurrent.atomic.AtomicInteger
  *
  * Prometheus benytter en pull-modell, hvor appen tilbyr et endepunkt for å hente data. Se application.yml.
  */
-class PrometheusMetricsService(private val meterRegistry: MeterRegistry) : MetricsService {
+class PrometheusMetricsService : MetricsService {
 
     override fun rapporterRegistreringStatusAntall(antallPerStatus: Map<Status, Int>) {
         antallPerStatus.forEach {
             val registrertAntall = statusVerdier.computeIfAbsent(it.key) { key ->
                 val atomiskAntall = AtomicInteger()
-                meterRegistry.gauge(
+                Metrics.gauge(
                         "veilarbregistrering_registrert_status",
                         listOf(Tag.of("status", key.name)),
                         atomiskAntall)
@@ -37,11 +37,11 @@ class PrometheusMetricsService(private val meterRegistry: MeterRegistry) : Metri
     }
 
     override fun registrer(event: Event, vararg tags: Tag) {
-        meterRegistry.counter(event.key, tags.asIterable()).increment()
+        Metrics.counter(event.key, tags.asIterable()).increment()
     }
 
     override fun registrer(event: Event) {
-        meterRegistry.counter(event.key).increment()
+        Metrics.counter(event.key).increment()
     }
 
     override fun registrerTimer(event: Event, tid: Duration, vararg metrikker: Metric) {
@@ -50,6 +50,6 @@ class PrometheusMetricsService(private val meterRegistry: MeterRegistry) : Metri
     }
 
     private fun registrerTimer(event: Event, tid: Duration, vararg tags: Tag) {
-        meterRegistry.timer(event.key, tags.asIterable()).record(tid)
+        Metrics.timer(event.key, tags.asIterable()).record(tid)
     }
 }


### PR DESCRIPTION
Forslag på å løse opp i den sykliske avhengigheten ved å la `PrometheusMetricsService` bruke statiske metoder for å registrere countere og timere i stedet for å bruke `MeterRegistry`. Har sjekket at metrikker fortsatt blir registrert i Grafana :) 