### PR TITLE
Legger til manglende veileder i HentRegistreringService

### DIFF
--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/registrering/bruker/HentRegistreringService.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/registrering/bruker/HentRegistreringService.kt
@@ -10,7 +10,6 @@ import no.nav.fo.veilarbregistrering.orgenhet.NavEnhet
 import no.nav.fo.veilarbregistrering.orgenhet.Norg2Gateway
 import no.nav.fo.veilarbregistrering.profilering.ProfileringRepository
 import no.nav.fo.veilarbregistrering.registrering.BrukerRegistreringType
-import no.nav.fo.veilarbregistrering.registrering.bruker.OrdinaerBrukerRegistrering.Companion.medProfilering
 import no.nav.fo.veilarbregistrering.registrering.bruker.resources.BrukerRegistreringWrapper
 import no.nav.fo.veilarbregistrering.registrering.bruker.resources.BrukerRegistreringWrapperFactory
 import no.nav.fo.veilarbregistrering.registrering.formidling.Status
@@ -63,7 +62,7 @@ class HentRegistreringService(
         )
         ordinaerBrukerRegistrering.manueltRegistrertAv = veileder
         val profilering = profileringRepository.hentProfileringForId(ordinaerBrukerRegistrering.id)
-        return medProfilering(ordinaerBrukerRegistrering, profilering)
+        return ordinaerBrukerRegistrering.med(profilering)
     }
 
     fun hentSykmeldtRegistrering(bruker: Bruker): SykmeldtRegistrering? {

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/registrering/bruker/OrdinaerBrukerRegistrering.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/registrering/bruker/OrdinaerBrukerRegistrering.kt
@@ -25,16 +25,16 @@ data class OrdinaerBrukerRegistrering(
         return "OrdinaerBrukerRegistrering(id=$id, opprettetDato=$opprettetDato, besvarelse=$besvarelse, teksterForBesvarelse=$teksterForBesvarelse, sisteStilling=$sisteStilling, profilering=$profilering)"
     }
 
-    companion object {
-        fun medProfilering(registrering: OrdinaerBrukerRegistrering, profilering: Profilering): OrdinaerBrukerRegistrering =
-            OrdinaerBrukerRegistrering(
-                registrering.id,
-                registrering.opprettetDato,
-                registrering.besvarelse,
-                registrering.teksterForBesvarelse,
-                registrering.sisteStilling,
-                profilering
-            )
+    fun med(profilering: Profilering) : OrdinaerBrukerRegistrering {
+        return OrdinaerBrukerRegistrering(
+            id,
+            opprettetDato,
+            besvarelse,
+            teksterForBesvarelse,
+            sisteStilling,
+            profilering,
+            manueltRegistrertAv
+        )
     }
 }
 

--- a/src/test/kotlin/no/nav/fo/veilarbregistrering/db/HentBrukerRegistreringServiceIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/fo/veilarbregistrering/db/HentBrukerRegistreringServiceIntegrationTest.kt
@@ -90,12 +90,27 @@ class HentBrukerRegistreringServiceIntegrationTest(
     @Test
     fun `hent sykmeldt med veileders enhet med navn`() {
         val id = sykmeldtRegistreringRepository.lagreSykmeldtBruker(SYKMELDT_BRUKER, BRUKER.aktorId)
-        val manuellRegistrering = ManuellRegistrering(id, BrukerRegistreringType.SYKMELDT, "H114522", "123")
+        val manuellRegistrering = ManuellRegistrering(id, BrukerRegistreringType.SYKMELDT, "H114522", "0106")
         manuellRegistreringRepository.lagreManuellRegistrering(manuellRegistrering)
 
         val brukerRegistreringWrapper = hentRegistreringService.hentBrukerregistrering(BRUKER)
         assertEquals(BrukerRegistreringType.SYKMELDT, brukerRegistreringWrapper?.type)
-        assertEquals("RANDOM", brukerRegistreringWrapper?.registrering?.manueltRegistrertAv?.enhet?.navn)
+        assertEquals("NAV Fredrikstad", brukerRegistreringWrapper?.registrering?.manueltRegistrertAv?.enhet?.navn)
+    }
+
+    @Test
+    fun `hent ordinær registrering med veileders enhet med navn`() {
+        val id = brukerRegistreringRepository.lagre(SELVGAENDE_BRUKER, BRUKER).id
+        registreringTilstandRepository.lagre(RegistreringTilstand.medStatus(Status.OVERFORT_ARENA, id))
+        profileringRepository.lagreProfilering(id, lagProfilering())
+
+        val manuellRegistrering = ManuellRegistrering(id, BrukerRegistreringType.ORDINAER, "H114522", "0106")
+        manuellRegistreringRepository.lagreManuellRegistrering(manuellRegistrering)
+
+        val brukerRegistreringWrapper = hentRegistreringService.hentBrukerregistrering(BRUKER)
+
+        assertEquals(BrukerRegistreringType.ORDINAER, brukerRegistreringWrapper?.type)
+        assertEquals("NAV Fredrikstad", brukerRegistreringWrapper?.registrering?.manueltRegistrertAv?.enhet?.navn)
     }
 
     companion object {
@@ -153,16 +168,16 @@ class HentBrukerRegistreringServiceIntegrationTest(
             fun norg2Gateway() = object : Norg2Gateway {
                 override fun hentEnhetFor(kommune: Kommune): Enhetnr? {
                     if (Kommune("1241") == kommune) {
-                        return Enhetnr("232")
+                        return Enhetnr("0106")
                     }
                     return if (Kommune.medBydel(STAVANGER) == kommune) {
-                        Enhetnr("1103")
+                        Enhetnr("0232")
                     } else null
                 }
 
                 override fun hentAlleEnheter(): Map<Enhetnr, NavEnhet> = mapOf(
-                    Enhetnr("123") to NavEnhet("123", "RANDOM"),
-                    Enhetnr("232") to NavEnhet("232", "Stavanger")
+                    Enhetnr("0106") to NavEnhet("0106", "NAV Fredrikstad"),
+                    Enhetnr("0232") to NavEnhet("0232", "Stavanger")
                 )
             }
         }


### PR DESCRIPTION
Veileder som var hentet opp, ble forkastet når vi la ved profilering og laget en ny kopi av objektet.
Erstatter samtidig funksjon i companion objekt med en metode på objektet, da vi alt har en instans av objektet.