### PR TITLE
Egen logger for å logge til secureLog.

### DIFF
--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/log/Logger.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/log/Logger.kt
@@ -7,6 +7,7 @@ inline fun <reified T:Any> loggerFor(): Logger =
     getLogger(T::class.java) ?: throw IllegalStateException("Error creating logger")
 
 inline val <reified T : Any> T.logger get() = getCachedLogger(T::class.java.name)
+inline val <reified T : Any> T.secureLogger get() = getLogger("SecureLog")
 
 fun getCachedLogger(loggerName: String): Logger {
     return LoggerCache.getLogger(loggerName)


### PR DESCRIPTION
Logg fnr til securelog når vi opplever BRUKER_KAN_IKKE_REAKTIVERES_FORENKLET feil mot arena