### PR TITLE
Fjern støtte for å autentisere OpenAM-tokens

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,7 +53,7 @@ jobs:
     name: Deploy to dev FSS
     needs: test-build-and-push
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/fjern-openam'
+    if: github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v1
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,7 +53,7 @@ jobs:
     name: Deploy to dev FSS
     needs: test-build-and-push
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/fjern-openam'
     steps:
       - uses: actions/checkout@v1
 

--- a/nais/nais-dev-fss.yaml
+++ b/nais/nais-dev-fss.yaml
@@ -61,8 +61,6 @@ spec:
       value: dev-fss
     - name: ENHET_URL
       value: https://modapp-q1.adeo.no/ereg
-    - name: ISSO_ISALIVE_URL
-      value: https://isso-q.adeo.no/isso/isAlive.jsp
     - name: KAFKA_SERVERS
       value: b27apvl00045.preprod.local:8443,b27apvl00046.preprod.local:8443,b27apvl00047.preprod.local:8443
     - name: KAFKA_SCHEMA

--- a/nais/nais-dev-fss.yaml
+++ b/nais/nais-dev-fss.yaml
@@ -23,12 +23,6 @@ spec:
   env:
     - name: AAREG_REST_API
       value: https://aareg-services-q1.dev.intern.nav.no/api
-    - name: OPENAM_DISCOVERY_URL
-      value: https://isso-q.adeo.no/isso/oauth2/.well-known/openid-configuration
-    - name: VEILARBLOGIN_OPENAM_CLIENT_ID
-      value: veilarblogin-q1
-    - name: VEILARBLOGIN_OPENAM_REFRESH_URL
-      value: https://app-q1.adeo.no/veilarblogin/api/openam-refresh
     - name: AAD_DISCOVERY_URL
       value: https://login.microsoftonline.com/966ac572-f5b7-4bbe-aa88-c76419c0f851/v2.0/.well-known/openid-configuration
     - name: VEILARBLOGIN_AAD_CLIENT_ID

--- a/nais/nais-dev-gcp.yaml
+++ b/nais/nais-dev-gcp.yaml
@@ -57,8 +57,6 @@ spec:
       value: dev-fss
     - name: ENHET_URL
       value: https://modapp-q1.adeo.no/ereg
-    - name: ISSO_ISALIVE_URL
-      value: https://isso-q.adeo.no/isso/isAlive.jsp
     - name: KAFKA_SERVERS
       value: b27apvl00045.preprod.local:8443,b27apvl00046.preprod.local:8443,b27apvl00047.preprod.local:8443
     - name: KAFKA_SCHEMA

--- a/nais/nais-dev-gcp.yaml
+++ b/nais/nais-dev-gcp.yaml
@@ -23,12 +23,6 @@ spec:
   env:
     - name: AAREG_REST_API
       value: https://aareg-services-q1.dev.intern.nav.no/api
-    - name: OPENAM_DISCOVERY_URL
-      value: https://isso-q.adeo.no/isso/oauth2/.well-known/openid-configuration
-    - name: VEILARBLOGIN_OPENAM_CLIENT_ID
-      value: veilarblogin-q1
-    - name: VEILARBLOGIN_OPENAM_REFRESH_URL
-      value: https://app-q1.adeo.no/veilarblogin/api/openam-refresh
     - name: AAD_DISCOVERY_URL
       value: https://login.microsoftonline.com/966ac572-f5b7-4bbe-aa88-c76419c0f851/v2.0/.well-known/openid-configuration
     - name: VEILARBLOGIN_AAD_CLIENT_ID

--- a/nais/nais-prod-fss.yaml
+++ b/nais/nais-prod-fss.yaml
@@ -22,12 +22,6 @@ spec:
   env:
     - name: AAREG_REST_API
       value: https://aareg-services.intern.nav.no/api
-    - name: OPENAM_DISCOVERY_URL
-      value: https://isso.adeo.no/isso/oauth2/.well-known/openid-configuration
-    - name: VEILARBLOGIN_OPENAM_CLIENT_ID
-      value: veilarblogin-p
-    - name: VEILARBLOGIN_OPENAM_REFRESH_URL
-      value: https://app.adeo.no/veilarblogin/api/openam-refresh
     - name: AAD_DISCOVERY_URL
       value: https://login.microsoftonline.com/62366534-1ec3-4962-8869-9b5535279d0b/v2.0/.well-known/openid-configuration
     - name: VEILARBLOGIN_AAD_CLIENT_ID

--- a/nais/nais-prod-fss.yaml
+++ b/nais/nais-prod-fss.yaml
@@ -60,8 +60,6 @@ spec:
       value: prod-fss
     - name: ENHET_URL
       value: https://modapp.adeo.no/ereg
-    - name: ISSO_ISALIVE_URL
-      value: https://isso.adeo.no/isso/isAlive.jsp
     - name: KAFKA_SERVERS
       value: a01apvl00145.adeo.no:8443,a01apvl00146.adeo.no:8443,a01apvl00147.adeo.no:8443,a01apvl00149.adeo.no:8443
     - name: KAFKA_SCHEMA

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/config/filters/AuthStatsFilter.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/config/filters/AuthStatsFilter.kt
@@ -28,7 +28,6 @@ class AuthStatsFilter(private val metricsService: MetricsService) : Filter {
         val type = when {
             Constants.AZURE_AD_B2C_ID_TOKEN_COOKIE_NAME in cookieNames -> "AADB2C"
             Constants.AZURE_AD_ID_TOKEN_COOKIE_NAME in cookieNames -> "AAD"
-            Constants.OPEN_AM_ID_TOKEN_COOKIE_NAME in cookieNames -> "OPENAM"
             !bearerToken.isNullOrBlank() -> checkBearerTokenForType(bearerToken)
             else -> null
         }

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/config/filters/FilterConfig.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/config/filters/FilterConfig.kt
@@ -59,7 +59,6 @@ class FilterConfig {
         val registration = FilterRegistrationBean<OidcAuthenticationFilterMigreringBypass>()
         val authenticationFilter = OidcAuthenticationFilterMigreringBypass(
             OidcAuthenticator.fromConfigs(
-                createOpenAmAuthenticatorConfig(),
                 createVeilarbloginAADConfig(),
                 createAzureAdB2CConfig(),
                 createAadTokenConfig(),
@@ -69,19 +68,6 @@ class FilterConfig {
         registration.order = 4
         registration.addUrlPatterns("/api/*")
         return registration
-    }
-
-    private fun createOpenAmAuthenticatorConfig(): OidcAuthenticatorConfig? {
-        val discoveryUrl = requireProperty("OPENAM_DISCOVERY_URL")
-        val clientId = requireProperty("VEILARBLOGIN_OPENAM_CLIENT_ID")
-        val refreshUrl = requireProperty("VEILARBLOGIN_OPENAM_REFRESH_URL")
-        return OidcAuthenticatorConfig()
-            .withDiscoveryUrl(discoveryUrl)
-            .withClientId(clientId)
-            .withRefreshUrl(refreshUrl)
-            .withRefreshTokenCookieName(Constants.REFRESH_TOKEN_COOKIE_NAME)
-            .withIdTokenCookieName(Constants.OPEN_AM_ID_TOKEN_COOKIE_NAME) //FIXME: Verifiser riktig bruk
-            .withUserRole(UserRole.INTERN)
     }
 
     private fun createVeilarbloginAADConfig(): OidcAuthenticatorConfig? {


### PR DESCRIPTION
Ingen konsumenter bruker OpenAM lenger, og vi må fjerne OpenAM for å komme oss ut i GCP