### PR TITLE
Flytter `reaktivering` ut i egen pakke

### DIFF
--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/config/ServiceBeansConfig.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/config/ServiceBeansConfig.kt
@@ -46,6 +46,8 @@ import no.nav.fo.veilarbregistrering.registrering.manuell.ManuellRegistreringRep
 import no.nav.fo.veilarbregistrering.registrering.publisering.ArbeidssokerProfilertProducer
 import no.nav.fo.veilarbregistrering.registrering.publisering.ArbeidssokerRegistrertProducer
 import no.nav.fo.veilarbregistrering.registrering.publisering.PubliseringAvEventsService
+import no.nav.fo.veilarbregistrering.registrering.reaktivering.ReaktiveringBrukerService
+import no.nav.fo.veilarbregistrering.registrering.reaktivering.ReaktiveringRepository
 import no.nav.fo.veilarbregistrering.tidslinje.TidslinjeAggregator
 import no.nav.fo.veilarbregistrering.tidslinje.resources.TidslinjeResource
 import org.springframework.context.annotation.Bean

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/db/RepositoryConfig.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/db/RepositoryConfig.kt
@@ -1,7 +1,7 @@
 package no.nav.fo.veilarbregistrering.db
 
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
-import no.nav.fo.veilarbregistrering.registrering.bruker.ReaktiveringRepository
+import no.nav.fo.veilarbregistrering.registrering.reaktivering.ReaktiveringRepository
 import no.nav.fo.veilarbregistrering.db.registrering.ReaktiveringRepositoryImpl
 import no.nav.fo.veilarbregistrering.registrering.bruker.SykmeldtRegistreringRepository
 import no.nav.fo.veilarbregistrering.db.registrering.SykmeldtRegistreringRepositoryImpl

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/db/registrering/ReaktiveringRepositoryImpl.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/db/registrering/ReaktiveringRepositoryImpl.kt
@@ -1,8 +1,8 @@
 package no.nav.fo.veilarbregistrering.db.registrering
 
 import no.nav.fo.veilarbregistrering.bruker.AktorId
-import no.nav.fo.veilarbregistrering.registrering.bruker.Reaktivering
-import no.nav.fo.veilarbregistrering.registrering.bruker.ReaktiveringRepository
+import no.nav.fo.veilarbregistrering.registrering.reaktivering.Reaktivering
+import no.nav.fo.veilarbregistrering.registrering.reaktivering.ReaktiveringRepository
 import org.springframework.jdbc.core.RowMapper
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import java.sql.SQLException

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/feil/FeilHandtering.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/feil/FeilHandtering.kt
@@ -6,7 +6,7 @@ import no.nav.fo.veilarbregistrering.bruker.feil.*
 import no.nav.fo.veilarbregistrering.oppfolging.AktiverBrukerException
 import no.nav.fo.veilarbregistrering.oppfolging.adapter.veilarbarena.SammensattOppfolgingStatusException
 import no.nav.fo.veilarbregistrering.oppgave.OppgaveAlleredeOpprettet
-import no.nav.fo.veilarbregistrering.registrering.bruker.KanIkkeReaktiveresException
+import no.nav.fo.veilarbregistrering.registrering.reaktivering.KanIkkeReaktiveresException
 import org.springframework.http.HttpStatus.*
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.ControllerAdvice

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/registrering/bruker/Reaktivering.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/registrering/bruker/Reaktivering.kt
@@ -1,6 +1,0 @@
-package no.nav.fo.veilarbregistrering.registrering.bruker
-
-import no.nav.fo.veilarbregistrering.bruker.AktorId
-import java.time.LocalDateTime
-
-class Reaktivering(val long: Long, val string: AktorId, val opprettetTidspunkt: LocalDateTime)

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/registrering/bruker/resources/RegistreringResource.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/registrering/bruker/resources/RegistreringResource.kt
@@ -6,6 +6,7 @@ import no.nav.fo.veilarbregistrering.bruker.UserService
 import no.nav.fo.veilarbregistrering.log.logger
 import no.nav.fo.veilarbregistrering.registrering.bruker.*
 import no.nav.fo.veilarbregistrering.registrering.bruker.resources.BrukerRegistreringWrapperFactory.create
+import no.nav.fo.veilarbregistrering.registrering.reaktivering.ReaktiveringBrukerService
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/registrering/reaktivering/KanIkkeReaktiveresException.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/registrering/reaktivering/KanIkkeReaktiveresException.kt
@@ -1,3 +1,3 @@
-package no.nav.fo.veilarbregistrering.registrering.bruker
+package no.nav.fo.veilarbregistrering.registrering.reaktivering
 
 class KanIkkeReaktiveresException(message: String) : RuntimeException(message)

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/registrering/reaktivering/Reaktivering.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/registrering/reaktivering/Reaktivering.kt
@@ -1,0 +1,6 @@
+package no.nav.fo.veilarbregistrering.registrering.reaktivering
+
+import no.nav.fo.veilarbregistrering.bruker.AktorId
+import java.time.LocalDateTime
+
+class Reaktivering(val long: Long, val string: AktorId, val opprettetTidspunkt: LocalDateTime)

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/registrering/reaktivering/ReaktiveringBrukerService.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/registrering/reaktivering/ReaktiveringBrukerService.kt
@@ -1,10 +1,11 @@
-package no.nav.fo.veilarbregistrering.registrering.bruker
+package no.nav.fo.veilarbregistrering.registrering.reaktivering
 
 import no.nav.fo.veilarbregistrering.bruker.Bruker
 import no.nav.fo.veilarbregistrering.log.loggerFor
 import no.nav.fo.veilarbregistrering.metrics.Events
 import no.nav.fo.veilarbregistrering.metrics.MetricsService
 import no.nav.fo.veilarbregistrering.oppfolging.OppfolgingGateway
+import no.nav.fo.veilarbregistrering.registrering.bruker.BrukerTilstandService
 import org.springframework.transaction.annotation.Transactional
 
 open class ReaktiveringBrukerService(

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/registrering/reaktivering/ReaktiveringRepository.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/registrering/reaktivering/ReaktiveringRepository.kt
@@ -1,4 +1,4 @@
-package no.nav.fo.veilarbregistrering.registrering.bruker
+package no.nav.fo.veilarbregistrering.registrering.reaktivering
 
 import no.nav.fo.veilarbregistrering.bruker.AktorId
 

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/tidslinje/ReaktiveringTidslinje.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/tidslinje/ReaktiveringTidslinje.kt
@@ -1,7 +1,7 @@
 package no.nav.fo.veilarbregistrering.tidslinje
 
 import no.nav.fo.veilarbregistrering.bruker.Periode
-import no.nav.fo.veilarbregistrering.registrering.bruker.Reaktivering
+import no.nav.fo.veilarbregistrering.registrering.reaktivering.Reaktivering
 import kotlin.streams.toList
 
 class ReaktiveringTidslinje(private val reaktiveringer: List<Reaktivering>): Tidslinje {

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/tidslinje/TidslinjeAggregator.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/tidslinje/TidslinjeAggregator.kt
@@ -3,15 +3,15 @@ package no.nav.fo.veilarbregistrering.tidslinje
 import no.nav.fo.veilarbregistrering.arbeidssoker.ArbeidssokerRepository
 import no.nav.fo.veilarbregistrering.bruker.Bruker
 import no.nav.fo.veilarbregistrering.registrering.bruker.BrukerRegistreringRepository
-import no.nav.fo.veilarbregistrering.registrering.bruker.ReaktiveringRepository
+import no.nav.fo.veilarbregistrering.registrering.reaktivering.ReaktiveringRepository
 import no.nav.fo.veilarbregistrering.registrering.bruker.SykmeldtRegistreringRepository
 import no.nav.fo.veilarbregistrering.registrering.formidling.Status
 
 class TidslinjeAggregator(
-        private val brukerRegistreringRepository: BrukerRegistreringRepository,
-        private val sykmeldtRegistreringRepository: SykmeldtRegistreringRepository,
-        private val reaktiveringRepository: ReaktiveringRepository,
-        private val arbeidssokerRepository: ArbeidssokerRepository) {
+    private val brukerRegistreringRepository: BrukerRegistreringRepository,
+    private val sykmeldtRegistreringRepository: SykmeldtRegistreringRepository,
+    private val reaktiveringRepository: ReaktiveringRepository,
+    private val arbeidssokerRepository: ArbeidssokerRepository) {
 
     fun tidslinje(bruker: Bruker): List<TidslinjeElement> {
 

--- a/src/test/kotlin/no/nav/fo/veilarbregistrering/db/registrering/ReaktiveringRepositoryDbIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/fo/veilarbregistrering/db/registrering/ReaktiveringRepositoryDbIntegrationTest.kt
@@ -5,7 +5,7 @@ import no.nav.fo.veilarbregistrering.bruker.Bruker
 import no.nav.fo.veilarbregistrering.bruker.Foedselsnummer
 import no.nav.fo.veilarbregistrering.db.DatabaseConfig
 import no.nav.fo.veilarbregistrering.db.RepositoryConfig
-import no.nav.fo.veilarbregistrering.registrering.bruker.ReaktiveringRepository
+import no.nav.fo.veilarbregistrering.registrering.reaktivering.ReaktiveringRepository
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -19,7 +19,8 @@ import org.springframework.test.context.ContextConfiguration
 class ReaktiveringRepositoryDbIntegrationTest(
 
     @Autowired
-    private val reaktiveringRepository: ReaktiveringRepository) {
+    private val reaktiveringRepository: ReaktiveringRepository
+) {
 
     @Test
     fun `finnReaktiveringer skal returnere liste med alle reaktiveringer for gitt aktørId`() {

--- a/src/test/kotlin/no/nav/fo/veilarbregistrering/registrering/bruker/resources/RegistreringResourceTest.kt
+++ b/src/test/kotlin/no/nav/fo/veilarbregistrering/registrering/bruker/resources/RegistreringResourceTest.kt
@@ -15,6 +15,7 @@ import no.nav.fo.veilarbregistrering.profilering.ProfileringTestdataBuilder.lagP
 import no.nav.fo.veilarbregistrering.registrering.bruker.*
 import no.nav.fo.veilarbregistrering.registrering.bruker.OrdinaerBrukerRegistreringTestdataBuilder.gyldigBrukerRegistrering
 import no.nav.fo.veilarbregistrering.registrering.bruker.SykmeldtRegistreringTestdataBuilder.gyldigSykmeldtRegistrering
+import no.nav.fo.veilarbregistrering.registrering.reaktivering.ReaktiveringBrukerService
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test

--- a/src/test/kotlin/no/nav/fo/veilarbregistrering/registrering/reaktivering/ReaktiveringBrukerServiceTest.kt
+++ b/src/test/kotlin/no/nav/fo/veilarbregistrering/registrering/reaktivering/ReaktiveringBrukerServiceTest.kt
@@ -1,4 +1,4 @@
-package no.nav.fo.veilarbregistrering.registrering.bruker
+package no.nav.fo.veilarbregistrering.registrering.reaktivering
 
 import io.mockk.*
 import no.nav.fo.veilarbregistrering.bruker.AktorId
@@ -10,6 +10,10 @@ import no.nav.fo.veilarbregistrering.oppfolging.adapter.OppfolgingClient
 import no.nav.fo.veilarbregistrering.oppfolging.adapter.OppfolgingGatewayImpl
 import no.nav.fo.veilarbregistrering.oppfolging.adapter.veilarbarena.KanReaktiveresDto
 import no.nav.fo.veilarbregistrering.oppfolging.adapter.veilarbarena.VeilarbarenaClient
+import no.nav.fo.veilarbregistrering.registrering.bruker.BrukerRegistreringRepository
+import no.nav.fo.veilarbregistrering.registrering.bruker.BrukerTilstandService
+import no.nav.fo.veilarbregistrering.registrering.reaktivering.ReaktiveringBrukerService
+import no.nav.fo.veilarbregistrering.registrering.reaktivering.ReaktiveringRepository
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test

--- a/src/test/kotlin/no/nav/fo/veilarbregistrering/registrering/reaktivering/ReaktiveringTestdataBuilder.kt
+++ b/src/test/kotlin/no/nav/fo/veilarbregistrering/registrering/reaktivering/ReaktiveringTestdataBuilder.kt
@@ -1,6 +1,7 @@
-package no.nav.fo.veilarbregistrering.registrering.bruker
+package no.nav.fo.veilarbregistrering.registrering.reaktivering
 
 import no.nav.fo.veilarbregistrering.bruker.AktorId
+import no.nav.fo.veilarbregistrering.registrering.reaktivering.Reaktivering
 import java.time.LocalDateTime
 
 object ReaktiveringTestdataBuilder {

--- a/src/test/kotlin/no/nav/fo/veilarbregistrering/tidslinje/TidslinjeAggregatorTest.kt
+++ b/src/test/kotlin/no/nav/fo/veilarbregistrering/tidslinje/TidslinjeAggregatorTest.kt
@@ -8,8 +8,8 @@ import no.nav.fo.veilarbregistrering.bruker.Bruker
 import no.nav.fo.veilarbregistrering.bruker.Foedselsnummer
 import no.nav.fo.veilarbregistrering.registrering.bruker.BrukerRegistreringRepository
 import no.nav.fo.veilarbregistrering.registrering.bruker.OrdinaerBrukerRegistreringTestdataBuilder.gyldigBrukerRegistrering
-import no.nav.fo.veilarbregistrering.registrering.bruker.ReaktiveringRepository
-import no.nav.fo.veilarbregistrering.registrering.bruker.ReaktiveringTestdataBuilder.gyldigReaktivering
+import no.nav.fo.veilarbregistrering.registrering.reaktivering.ReaktiveringRepository
+import no.nav.fo.veilarbregistrering.registrering.reaktivering.ReaktiveringTestdataBuilder.gyldigReaktivering
 import no.nav.fo.veilarbregistrering.registrering.bruker.SykmeldtRegistreringRepository
 import no.nav.fo.veilarbregistrering.registrering.bruker.SykmeldtRegistreringTestdataBuilder.gyldigSykmeldtRegistrering
 import org.assertj.core.api.Assertions.assertThat


### PR DESCRIPTION
Ønsker å tydeliggjøre de ulike subdomene/use-casene. Reaktivering er en egen feature, og det er ikke så synlig nå. På sikt ønsker jeg å flytte REST-endepunkt ut også.