### PR TITLE
Flytter ut `ordinaer` i egen pakke

### DIFF
--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/config/ServiceBeansConfig.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/config/ServiceBeansConfig.kt
@@ -43,6 +43,8 @@ import no.nav.fo.veilarbregistrering.registrering.formidling.RegistreringTilstan
 import no.nav.fo.veilarbregistrering.registrering.formidling.RegistreringTilstandService
 import no.nav.fo.veilarbregistrering.registrering.formidling.resources.InternalRegistreringStatusoversiktResource
 import no.nav.fo.veilarbregistrering.registrering.manuell.ManuellRegistreringRepository
+import no.nav.fo.veilarbregistrering.registrering.ordinaer.BrukerRegistreringRepository
+import no.nav.fo.veilarbregistrering.registrering.ordinaer.BrukerRegistreringService
 import no.nav.fo.veilarbregistrering.registrering.publisering.ArbeidssokerProfilertProducer
 import no.nav.fo.veilarbregistrering.registrering.publisering.ArbeidssokerRegistrertProducer
 import no.nav.fo.veilarbregistrering.registrering.publisering.PubliseringAvEventsService

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/db/RepositoryConfig.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/db/RepositoryConfig.kt
@@ -5,7 +5,7 @@ import no.nav.fo.veilarbregistrering.registrering.reaktivering.ReaktiveringRepos
 import no.nav.fo.veilarbregistrering.db.registrering.ReaktiveringRepositoryImpl
 import no.nav.fo.veilarbregistrering.registrering.sykmeldt.SykmeldtRegistreringRepository
 import no.nav.fo.veilarbregistrering.db.registrering.SykmeldtRegistreringRepositoryImpl
-import no.nav.fo.veilarbregistrering.registrering.bruker.BrukerRegistreringRepository
+import no.nav.fo.veilarbregistrering.registrering.ordinaer.BrukerRegistreringRepository
 import no.nav.fo.veilarbregistrering.db.registrering.BrukerRegistreringRepositoryImpl
 import no.nav.fo.veilarbregistrering.registrering.formidling.RegistreringTilstandRepository
 import no.nav.fo.veilarbregistrering.db.registrering.RegistreringTilstandRepositoryImpl

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/db/registrering/BrukerRegistreringRepositoryImpl.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/db/registrering/BrukerRegistreringRepositoryImpl.kt
@@ -8,8 +8,8 @@ import no.nav.fo.veilarbregistrering.bruker.AktorId
 import no.nav.fo.veilarbregistrering.bruker.Bruker
 import no.nav.fo.veilarbregistrering.bruker.Foedselsnummer
 import no.nav.fo.veilarbregistrering.db.registrering.RegistreringTilstandRepositoryImpl.Companion.REGISTRERING_TILSTAND
-import no.nav.fo.veilarbregistrering.registrering.bruker.BrukerRegistreringRepository
-import no.nav.fo.veilarbregistrering.registrering.bruker.OrdinaerBrukerRegistrering
+import no.nav.fo.veilarbregistrering.registrering.ordinaer.BrukerRegistreringRepository
+import no.nav.fo.veilarbregistrering.registrering.ordinaer.OrdinaerBrukerRegistrering
 import no.nav.fo.veilarbregistrering.registrering.bruker.TekstForSporsmal
 import no.nav.fo.veilarbregistrering.registrering.formidling.Status
 import org.springframework.jdbc.core.RowMapper
@@ -17,7 +17,6 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import java.io.IOException
 import java.sql.SQLException
 import java.sql.Timestamp
-import java.time.LocalDateTime.now
 
 class BrukerRegistreringRepositoryImpl(private val db: NamedParameterJdbcTemplate) : BrukerRegistreringRepository {
 

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/migrering/resources/MigreringResource.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/migrering/resources/MigreringResource.kt
@@ -4,7 +4,7 @@ import no.nav.fo.veilarbregistrering.config.Secrets
 import no.nav.fo.veilarbregistrering.migrering.TabellNavn
 import no.nav.fo.veilarbregistrering.log.logger
 import no.nav.fo.veilarbregistrering.migrering.MigreringRepository
-import no.nav.fo.veilarbregistrering.registrering.bruker.BrukerRegistreringRepository
+import no.nav.fo.veilarbregistrering.registrering.ordinaer.BrukerRegistreringRepository
 import no.nav.fo.veilarbregistrering.registrering.formidling.RegistreringTilstandRepository
 import no.nav.fo.veilarbregistrering.registrering.formidling.Status
 import org.springframework.web.bind.annotation.*

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/profilering/ProfilertInnsatsgruppeService.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/profilering/ProfilertInnsatsgruppeService.kt
@@ -3,7 +3,7 @@ package no.nav.fo.veilarbregistrering.profilering
 import no.nav.fo.veilarbregistrering.bruker.Bruker
 import no.nav.fo.veilarbregistrering.oppfolging.OppfolgingGateway
 import no.nav.fo.veilarbregistrering.oppfolging.Servicegruppe
-import no.nav.fo.veilarbregistrering.registrering.bruker.BrukerRegistreringRepository
+import no.nav.fo.veilarbregistrering.registrering.ordinaer.BrukerRegistreringRepository
 import no.nav.fo.veilarbregistrering.registrering.formidling.Status
 
 class ProfilertInnsatsgruppeService(

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/registrering/bruker/BrukerTilstandService.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/registrering/bruker/BrukerTilstandService.kt
@@ -3,6 +3,8 @@ package no.nav.fo.veilarbregistrering.registrering.bruker
 import no.nav.fo.veilarbregistrering.bruker.Bruker
 import no.nav.fo.veilarbregistrering.oppfolging.OppfolgingGateway
 import no.nav.fo.veilarbregistrering.registrering.formidling.Status
+import no.nav.fo.veilarbregistrering.registrering.ordinaer.BrukerRegistreringRepository
+import no.nav.fo.veilarbregistrering.registrering.ordinaer.kanResendes
 
 class BrukerTilstandService(
     private val oppfolgingGateway: OppfolgingGateway,

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/registrering/bruker/HentRegistreringService.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/registrering/bruker/HentRegistreringService.kt
@@ -16,6 +16,9 @@ import no.nav.fo.veilarbregistrering.registrering.formidling.Status
 import no.nav.fo.veilarbregistrering.registrering.formidling.Status.*
 import no.nav.fo.veilarbregistrering.registrering.manuell.ManuellRegistreringRepository
 import no.nav.fo.veilarbregistrering.registrering.manuell.Veileder
+import no.nav.fo.veilarbregistrering.registrering.ordinaer.BrukerRegistreringRepository
+import no.nav.fo.veilarbregistrering.registrering.ordinaer.OrdinaerBrukerRegistrering
+import no.nav.fo.veilarbregistrering.registrering.ordinaer.kanResendes
 import no.nav.fo.veilarbregistrering.registrering.sykmeldt.SykmeldtRegistrering
 import no.nav.fo.veilarbregistrering.registrering.sykmeldt.SykmeldtRegistreringRepository
 

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/registrering/bruker/ValideringUtils.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/registrering/bruker/ValideringUtils.kt
@@ -1,6 +1,7 @@
 package no.nav.fo.veilarbregistrering.registrering.bruker
 
 import no.nav.fo.veilarbregistrering.besvarelse.*
+import no.nav.fo.veilarbregistrering.registrering.ordinaer.OrdinaerBrukerRegistrering
 
 
 object ValideringUtils {

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/registrering/bruker/resources/BrukerRegistreringWrapperFactory.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/registrering/bruker/resources/BrukerRegistreringWrapperFactory.kt
@@ -1,6 +1,6 @@
 package no.nav.fo.veilarbregistrering.registrering.bruker.resources
 
-import no.nav.fo.veilarbregistrering.registrering.bruker.OrdinaerBrukerRegistrering
+import no.nav.fo.veilarbregistrering.registrering.ordinaer.OrdinaerBrukerRegistrering
 import no.nav.fo.veilarbregistrering.registrering.sykmeldt.SykmeldtRegistrering
 
 object BrukerRegistreringWrapperFactory {

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/registrering/bruker/resources/RegistreringApi.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/registrering/bruker/resources/RegistreringApi.kt
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.ExternalDocumentation
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.tags.Tag
-import no.nav.fo.veilarbregistrering.registrering.bruker.OrdinaerBrukerRegistrering
+import no.nav.fo.veilarbregistrering.registrering.ordinaer.OrdinaerBrukerRegistrering
 import no.nav.fo.veilarbregistrering.registrering.sykmeldt.SykmeldtRegistrering
 import org.springframework.http.ResponseEntity
 

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/registrering/bruker/resources/RegistreringResource.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/registrering/bruker/resources/RegistreringResource.kt
@@ -6,6 +6,8 @@ import no.nav.fo.veilarbregistrering.bruker.UserService
 import no.nav.fo.veilarbregistrering.log.logger
 import no.nav.fo.veilarbregistrering.registrering.bruker.*
 import no.nav.fo.veilarbregistrering.registrering.bruker.resources.BrukerRegistreringWrapperFactory.create
+import no.nav.fo.veilarbregistrering.registrering.ordinaer.BrukerRegistreringService
+import no.nav.fo.veilarbregistrering.registrering.ordinaer.OrdinaerBrukerRegistrering
 import no.nav.fo.veilarbregistrering.registrering.reaktivering.ReaktiveringBrukerService
 import no.nav.fo.veilarbregistrering.registrering.sykmeldt.SykmeldtRegistrering
 import no.nav.fo.veilarbregistrering.registrering.sykmeldt.SykmeldtRegistreringService

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/registrering/ordinaer/BrukerRegistreringRepository.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/registrering/ordinaer/BrukerRegistreringRepository.kt
@@ -1,4 +1,4 @@
-package no.nav.fo.veilarbregistrering.registrering.bruker
+package no.nav.fo.veilarbregistrering.registrering.ordinaer
 
 import no.nav.fo.veilarbregistrering.bruker.AktorId
 import no.nav.fo.veilarbregistrering.bruker.Bruker

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/registrering/ordinaer/BrukerRegistreringService.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/registrering/ordinaer/BrukerRegistreringService.kt
@@ -1,4 +1,4 @@
-package no.nav.fo.veilarbregistrering.registrering.bruker
+package no.nav.fo.veilarbregistrering.registrering.ordinaer
 
 import no.nav.fo.veilarbregistrering.besvarelse.Besvarelse
 import no.nav.fo.veilarbregistrering.bruker.Bruker
@@ -13,6 +13,8 @@ import no.nav.fo.veilarbregistrering.profilering.Profilering
 import no.nav.fo.veilarbregistrering.profilering.ProfileringRepository
 import no.nav.fo.veilarbregistrering.profilering.ProfileringService
 import no.nav.fo.veilarbregistrering.registrering.BrukerRegistreringType
+import no.nav.fo.veilarbregistrering.registrering.bruker.BrukerTilstandService
+import no.nav.fo.veilarbregistrering.registrering.bruker.NavVeileder
 import no.nav.fo.veilarbregistrering.registrering.bruker.ValideringUtils.validerBrukerRegistrering
 import no.nav.fo.veilarbregistrering.registrering.formidling.RegistreringTilstand
 import no.nav.fo.veilarbregistrering.registrering.formidling.RegistreringTilstand.Companion.medStatus

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/registrering/ordinaer/OrdinaerBrukerRegistrering.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/registrering/ordinaer/OrdinaerBrukerRegistrering.kt
@@ -1,9 +1,11 @@
-package no.nav.fo.veilarbregistrering.registrering.bruker
+package no.nav.fo.veilarbregistrering.registrering.ordinaer
 
 import no.nav.fo.veilarbregistrering.besvarelse.Besvarelse
 import no.nav.fo.veilarbregistrering.besvarelse.Stilling
 import no.nav.fo.veilarbregistrering.profilering.Profilering
 import no.nav.fo.veilarbregistrering.registrering.BrukerRegistreringType
+import no.nav.fo.veilarbregistrering.registrering.bruker.BrukerRegistrering
+import no.nav.fo.veilarbregistrering.registrering.bruker.TekstForSporsmal
 import no.nav.fo.veilarbregistrering.registrering.manuell.Veileder
 import java.time.LocalDateTime
 

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/registrering/publisering/PubliseringAvEventsService.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/registrering/publisering/PubliseringAvEventsService.kt
@@ -2,7 +2,7 @@ package no.nav.fo.veilarbregistrering.registrering.publisering
 
 import no.nav.fo.veilarbregistrering.metrics.MetricsService
 import no.nav.fo.veilarbregistrering.profilering.ProfileringRepository
-import no.nav.fo.veilarbregistrering.registrering.bruker.BrukerRegistreringRepository
+import no.nav.fo.veilarbregistrering.registrering.ordinaer.BrukerRegistreringRepository
 import no.nav.fo.veilarbregistrering.registrering.formidling.RegistreringTilstand
 import no.nav.fo.veilarbregistrering.registrering.formidling.RegistreringTilstandRepository
 import no.nav.fo.veilarbregistrering.registrering.formidling.Status

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/tidslinje/OrdinaerRegistreringTidslinje.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/tidslinje/OrdinaerRegistreringTidslinje.kt
@@ -1,7 +1,7 @@
 package no.nav.fo.veilarbregistrering.tidslinje
 
 import no.nav.fo.veilarbregistrering.bruker.Periode
-import no.nav.fo.veilarbregistrering.registrering.bruker.OrdinaerBrukerRegistrering
+import no.nav.fo.veilarbregistrering.registrering.ordinaer.OrdinaerBrukerRegistrering
 import kotlin.streams.toList
 
 class OrdinaerRegistreringTidslinje(private var ordinaereBrukerRegistreringer: List<OrdinaerBrukerRegistrering>) : Tidslinje {

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/tidslinje/TidslinjeAggregator.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/tidslinje/TidslinjeAggregator.kt
@@ -2,7 +2,7 @@ package no.nav.fo.veilarbregistrering.tidslinje
 
 import no.nav.fo.veilarbregistrering.arbeidssoker.ArbeidssokerRepository
 import no.nav.fo.veilarbregistrering.bruker.Bruker
-import no.nav.fo.veilarbregistrering.registrering.bruker.BrukerRegistreringRepository
+import no.nav.fo.veilarbregistrering.registrering.ordinaer.BrukerRegistreringRepository
 import no.nav.fo.veilarbregistrering.registrering.reaktivering.ReaktiveringRepository
 import no.nav.fo.veilarbregistrering.registrering.sykmeldt.SykmeldtRegistreringRepository
 import no.nav.fo.veilarbregistrering.registrering.formidling.Status

--- a/src/test/kotlin/no/nav/fo/veilarbregistrering/db/CreateViewTest.kt
+++ b/src/test/kotlin/no/nav/fo/veilarbregistrering/db/CreateViewTest.kt
@@ -6,8 +6,8 @@ import no.nav.fo.veilarbregistrering.bruker.Foedselsnummer
 import no.nav.fo.veilarbregistrering.profilering.Innsatsgruppe
 import no.nav.fo.veilarbregistrering.profilering.Profilering
 import no.nav.fo.veilarbregistrering.profilering.ProfileringRepository
-import no.nav.fo.veilarbregistrering.registrering.bruker.BrukerRegistreringRepository
-import no.nav.fo.veilarbregistrering.registrering.bruker.OrdinaerBrukerRegistreringTestdataBuilder
+import no.nav.fo.veilarbregistrering.registrering.ordinaer.BrukerRegistreringRepository
+import no.nav.fo.veilarbregistrering.registrering.ordinaer.OrdinaerBrukerRegistreringTestdataBuilder
 import no.nav.fo.veilarbregistrering.registrering.formidling.RegistreringTilstand
 import no.nav.fo.veilarbregistrering.registrering.formidling.RegistreringTilstandRepository
 import no.nav.fo.veilarbregistrering.registrering.formidling.Status

--- a/src/test/kotlin/no/nav/fo/veilarbregistrering/db/HentBrukerRegistreringServiceIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/fo/veilarbregistrering/db/HentBrukerRegistreringServiceIntegrationTest.kt
@@ -24,6 +24,8 @@ import no.nav.fo.veilarbregistrering.registrering.formidling.RegistreringTilstan
 import no.nav.fo.veilarbregistrering.registrering.formidling.Status
 import no.nav.fo.veilarbregistrering.registrering.manuell.ManuellRegistrering
 import no.nav.fo.veilarbregistrering.registrering.manuell.ManuellRegistreringRepository
+import no.nav.fo.veilarbregistrering.registrering.ordinaer.BrukerRegistreringRepository
+import no.nav.fo.veilarbregistrering.registrering.ordinaer.OrdinaerBrukerRegistreringTestdataBuilder
 import no.nav.fo.veilarbregistrering.registrering.sykmeldt.SykmeldtRegistreringRepository
 import no.nav.fo.veilarbregistrering.registrering.sykmeldt.SykmeldtRegistreringTestdataBuilder
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -161,8 +163,8 @@ class HentBrukerRegistreringServiceIntegrationTest(
 
             @Bean
             fun hentBrukerTilstandService(
-                    oppfolgingGateway: OppfolgingGateway,
-                    brukerRegistreringRepository: BrukerRegistreringRepository,
+                oppfolgingGateway: OppfolgingGateway,
+                brukerRegistreringRepository: BrukerRegistreringRepository,
             ): BrukerTilstandService {
                 return BrukerTilstandService(
                     oppfolgingGateway,

--- a/src/test/kotlin/no/nav/fo/veilarbregistrering/db/registrering/BrukerRegistreringRepositoryDbIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/fo/veilarbregistrering/db/registrering/BrukerRegistreringRepositoryDbIntegrationTest.kt
@@ -7,9 +7,9 @@ import no.nav.fo.veilarbregistrering.bruker.Bruker
 import no.nav.fo.veilarbregistrering.bruker.Foedselsnummer
 import no.nav.fo.veilarbregistrering.db.DatabaseConfig
 import no.nav.fo.veilarbregistrering.db.RepositoryConfig
-import no.nav.fo.veilarbregistrering.registrering.bruker.BrukerRegistreringRepository
-import no.nav.fo.veilarbregistrering.registrering.bruker.OrdinaerBrukerRegistrering
-import no.nav.fo.veilarbregistrering.registrering.bruker.OrdinaerBrukerRegistreringTestdataBuilder
+import no.nav.fo.veilarbregistrering.registrering.ordinaer.BrukerRegistreringRepository
+import no.nav.fo.veilarbregistrering.registrering.ordinaer.OrdinaerBrukerRegistrering
+import no.nav.fo.veilarbregistrering.registrering.ordinaer.OrdinaerBrukerRegistreringTestdataBuilder
 import no.nav.fo.veilarbregistrering.registrering.sykmeldt.SykmeldtRegistreringRepository
 import no.nav.fo.veilarbregistrering.registrering.formidling.RegistreringTilstandRepository
 import no.nav.fo.veilarbregistrering.registrering.formidling.RegistreringTilstandTestdataBuilder.registreringTilstand

--- a/src/test/kotlin/no/nav/fo/veilarbregistrering/db/registrering/RegistreringTilstandRepositoryDbIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/fo/veilarbregistrering/db/registrering/RegistreringTilstandRepositoryDbIntegrationTest.kt
@@ -5,8 +5,8 @@ import no.nav.fo.veilarbregistrering.bruker.Bruker
 import no.nav.fo.veilarbregistrering.bruker.Foedselsnummer
 import no.nav.fo.veilarbregistrering.db.DatabaseConfig
 import no.nav.fo.veilarbregistrering.db.RepositoryConfig
-import no.nav.fo.veilarbregistrering.registrering.bruker.BrukerRegistreringRepository
-import no.nav.fo.veilarbregistrering.registrering.bruker.OrdinaerBrukerRegistreringTestdataBuilder
+import no.nav.fo.veilarbregistrering.registrering.ordinaer.BrukerRegistreringRepository
+import no.nav.fo.veilarbregistrering.registrering.ordinaer.OrdinaerBrukerRegistreringTestdataBuilder
 import no.nav.fo.veilarbregistrering.registrering.formidling.RegistreringTilstand
 import no.nav.fo.veilarbregistrering.registrering.formidling.RegistreringTilstandRepository
 import no.nav.fo.veilarbregistrering.registrering.formidling.RegistreringTilstandTestdataBuilder

--- a/src/test/kotlin/no/nav/fo/veilarbregistrering/json/JsonDeserializationTest.kt
+++ b/src/test/kotlin/no/nav/fo/veilarbregistrering/json/JsonDeserializationTest.kt
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import no.nav.fo.veilarbregistrering.FileToJson
 import no.nav.fo.veilarbregistrering.bruker.pdl.endepunkt.PdlHentPersonResponse
-import no.nav.fo.veilarbregistrering.registrering.bruker.OrdinaerBrukerRegistrering
+import no.nav.fo.veilarbregistrering.registrering.ordinaer.OrdinaerBrukerRegistrering
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.time.LocalDate

--- a/src/test/kotlin/no/nav/fo/veilarbregistrering/migrering/resources/MigreringResourceTest.kt
+++ b/src/test/kotlin/no/nav/fo/veilarbregistrering/migrering/resources/MigreringResourceTest.kt
@@ -6,7 +6,7 @@ import no.nav.fo.veilarbregistrering.config.Secrets
 import no.nav.fo.veilarbregistrering.db.migrering.MigreringRepositoryImpl
 import no.nav.fo.veilarbregistrering.log.logger
 import no.nav.fo.veilarbregistrering.migrering.resources.MigreringResource
-import no.nav.fo.veilarbregistrering.registrering.bruker.BrukerRegistreringRepository
+import no.nav.fo.veilarbregistrering.registrering.ordinaer.BrukerRegistreringRepository
 import no.nav.fo.veilarbregistrering.registrering.formidling.RegistreringTilstandRepository
 import no.nav.fo.veilarbregistrering.registrering.formidling.Status
 import org.assertj.core.api.Assertions.assertThat
@@ -86,8 +86,8 @@ private class MigreringResourceConfig {
     @Bean
     fun migreringResource(
         migreringRepositoryImpl: MigreringRepositoryImpl,
-            brukerRegistreringRepository: BrukerRegistreringRepository,
-            registreringTilstandRepository: RegistreringTilstandRepository,
+        brukerRegistreringRepository: BrukerRegistreringRepository,
+        registreringTilstandRepository: RegistreringTilstandRepository,
             ) = MigreringResource(
         migreringRepositoryImpl,
         brukerRegistreringRepository,

--- a/src/test/kotlin/no/nav/fo/veilarbregistrering/profilering/ProfileringServiceTest.kt
+++ b/src/test/kotlin/no/nav/fo/veilarbregistrering/profilering/ProfileringServiceTest.kt
@@ -5,8 +5,8 @@ import no.nav.fo.veilarbregistrering.arbeidsforhold.ArbeidsforholdTestdata.medDa
 import no.nav.fo.veilarbregistrering.arbeidsforhold.FlereArbeidsforhold
 import no.nav.fo.veilarbregistrering.besvarelse.*
 import no.nav.fo.veilarbregistrering.bruker.Foedselsnummer
-import no.nav.fo.veilarbregistrering.registrering.bruker.OrdinaerBrukerRegistrering
-import no.nav.fo.veilarbregistrering.registrering.bruker.OrdinaerBrukerRegistreringTestdataBuilder
+import no.nav.fo.veilarbregistrering.registrering.ordinaer.OrdinaerBrukerRegistrering
+import no.nav.fo.veilarbregistrering.registrering.ordinaer.OrdinaerBrukerRegistreringTestdataBuilder
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.fail
 import org.junit.jupiter.api.BeforeEach

--- a/src/test/kotlin/no/nav/fo/veilarbregistrering/profilering/ProfilertInnsatsgruppeServiceTest.kt
+++ b/src/test/kotlin/no/nav/fo/veilarbregistrering/profilering/ProfilertInnsatsgruppeServiceTest.kt
@@ -8,8 +8,8 @@ import no.nav.fo.veilarbregistrering.bruker.Foedselsnummer
 import no.nav.fo.veilarbregistrering.oppfolging.OppfolgingGateway
 import no.nav.fo.veilarbregistrering.oppfolging.Oppfolgingsstatus
 import no.nav.fo.veilarbregistrering.oppfolging.Servicegruppe
-import no.nav.fo.veilarbregistrering.registrering.bruker.BrukerRegistreringRepository
-import no.nav.fo.veilarbregistrering.registrering.bruker.OrdinaerBrukerRegistreringTestdataBuilder
+import no.nav.fo.veilarbregistrering.registrering.ordinaer.BrukerRegistreringRepository
+import no.nav.fo.veilarbregistrering.registrering.ordinaer.OrdinaerBrukerRegistreringTestdataBuilder
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals

--- a/src/test/kotlin/no/nav/fo/veilarbregistrering/registrering/bruker/BrukerTilstandServiceTest.kt
+++ b/src/test/kotlin/no/nav/fo/veilarbregistrering/registrering/bruker/BrukerTilstandServiceTest.kt
@@ -10,6 +10,7 @@ import no.nav.fo.veilarbregistrering.oppfolging.OppfolgingGateway
 import no.nav.fo.veilarbregistrering.oppfolging.Oppfolgingsstatus
 import no.nav.fo.veilarbregistrering.oppfolging.Rettighetsgruppe
 import no.nav.fo.veilarbregistrering.oppfolging.Servicegruppe
+import no.nav.fo.veilarbregistrering.registrering.ordinaer.BrukerRegistreringRepository
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test

--- a/src/test/kotlin/no/nav/fo/veilarbregistrering/registrering/bruker/HentRegistreringServiceTest.kt
+++ b/src/test/kotlin/no/nav/fo/veilarbregistrering/registrering/bruker/HentRegistreringServiceTest.kt
@@ -11,8 +11,9 @@ import no.nav.fo.veilarbregistrering.orgenhet.NavEnhet
 import no.nav.fo.veilarbregistrering.orgenhet.Norg2Gateway
 import no.nav.fo.veilarbregistrering.profilering.ProfileringRepository
 import no.nav.fo.veilarbregistrering.profilering.ProfileringTestdataBuilder.lagProfilering
-import no.nav.fo.veilarbregistrering.registrering.bruker.OrdinaerBrukerRegistreringTestdataBuilder.gyldigBrukerRegistrering
+import no.nav.fo.veilarbregistrering.registrering.ordinaer.OrdinaerBrukerRegistreringTestdataBuilder.gyldigBrukerRegistrering
 import no.nav.fo.veilarbregistrering.registrering.manuell.ManuellRegistreringRepository
+import no.nav.fo.veilarbregistrering.registrering.ordinaer.BrukerRegistreringRepository
 import no.nav.fo.veilarbregistrering.registrering.sykmeldt.SykmeldtRegistreringRepository
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach

--- a/src/test/kotlin/no/nav/fo/veilarbregistrering/registrering/bruker/ValideringUtilsTest.kt
+++ b/src/test/kotlin/no/nav/fo/veilarbregistrering/registrering/bruker/ValideringUtilsTest.kt
@@ -3,7 +3,7 @@ package no.nav.fo.veilarbregistrering.registrering.bruker
 import no.nav.fo.veilarbregistrering.besvarelse.*
 import no.nav.fo.veilarbregistrering.besvarelse.BesvarelseTestdataBuilder.gyldigBesvarelse
 import no.nav.fo.veilarbregistrering.besvarelse.StillingTestdataBuilder.gyldigStilling
-import no.nav.fo.veilarbregistrering.registrering.bruker.OrdinaerBrukerRegistreringTestdataBuilder.gyldigBrukerRegistrering
+import no.nav.fo.veilarbregistrering.registrering.ordinaer.OrdinaerBrukerRegistreringTestdataBuilder.gyldigBrukerRegistrering
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 

--- a/src/test/kotlin/no/nav/fo/veilarbregistrering/registrering/bruker/resources/RegistreringResourceTest.kt
+++ b/src/test/kotlin/no/nav/fo/veilarbregistrering/registrering/bruker/resources/RegistreringResourceTest.kt
@@ -13,7 +13,8 @@ import no.nav.fo.veilarbregistrering.bruker.*
 import no.nav.fo.veilarbregistrering.config.RequestContext
 import no.nav.fo.veilarbregistrering.profilering.ProfileringTestdataBuilder.lagProfilering
 import no.nav.fo.veilarbregistrering.registrering.bruker.*
-import no.nav.fo.veilarbregistrering.registrering.bruker.OrdinaerBrukerRegistreringTestdataBuilder.gyldigBrukerRegistrering
+import no.nav.fo.veilarbregistrering.registrering.ordinaer.OrdinaerBrukerRegistreringTestdataBuilder.gyldigBrukerRegistrering
+import no.nav.fo.veilarbregistrering.registrering.ordinaer.BrukerRegistreringService
 import no.nav.fo.veilarbregistrering.registrering.sykmeldt.SykmeldtRegistreringTestdataBuilder.gyldigSykmeldtRegistrering
 import no.nav.fo.veilarbregistrering.registrering.reaktivering.ReaktiveringBrukerService
 import no.nav.fo.veilarbregistrering.registrering.sykmeldt.SykmeldtRegistreringService

--- a/src/test/kotlin/no/nav/fo/veilarbregistrering/registrering/ordinaer/OrdinaerBrukerRegistreringTestdataBuilder.kt
+++ b/src/test/kotlin/no/nav/fo/veilarbregistrering/registrering/ordinaer/OrdinaerBrukerRegistreringTestdataBuilder.kt
@@ -1,7 +1,9 @@
-package no.nav.fo.veilarbregistrering.registrering.bruker
+package no.nav.fo.veilarbregistrering.registrering.ordinaer
 
 import no.nav.fo.veilarbregistrering.besvarelse.*
 import no.nav.fo.veilarbregistrering.profilering.Profilering
+import no.nav.fo.veilarbregistrering.registrering.bruker.TekstForSporsmal
+import no.nav.fo.veilarbregistrering.registrering.bruker.TekstForSporsmalTestdataBuilder
 import java.time.LocalDateTime
 
 object OrdinaerBrukerRegistreringTestdataBuilder {
@@ -14,11 +16,11 @@ object OrdinaerBrukerRegistreringTestdataBuilder {
         profilering: Profilering? = null,
     ): OrdinaerBrukerRegistrering {
         return OrdinaerBrukerRegistrering(
-                opprettetDato = opprettetDato,
-                sisteStilling = stilling,
-                besvarelse = besvarelse,
-                teksterForBesvarelse = teksterForBesvarelse,
-                profilering = profilering,
+            opprettetDato = opprettetDato,
+            sisteStilling = stilling,
+            besvarelse = besvarelse,
+            teksterForBesvarelse = teksterForBesvarelse,
+            profilering = profilering,
         )
     }
 

--- a/src/test/kotlin/no/nav/fo/veilarbregistrering/registrering/reaktivering/ReaktiveringBrukerServiceTest.kt
+++ b/src/test/kotlin/no/nav/fo/veilarbregistrering/registrering/reaktivering/ReaktiveringBrukerServiceTest.kt
@@ -10,10 +10,8 @@ import no.nav.fo.veilarbregistrering.oppfolging.adapter.OppfolgingClient
 import no.nav.fo.veilarbregistrering.oppfolging.adapter.OppfolgingGatewayImpl
 import no.nav.fo.veilarbregistrering.oppfolging.adapter.veilarbarena.KanReaktiveresDto
 import no.nav.fo.veilarbregistrering.oppfolging.adapter.veilarbarena.VeilarbarenaClient
-import no.nav.fo.veilarbregistrering.registrering.bruker.BrukerRegistreringRepository
+import no.nav.fo.veilarbregistrering.registrering.ordinaer.BrukerRegistreringRepository
 import no.nav.fo.veilarbregistrering.registrering.bruker.BrukerTilstandService
-import no.nav.fo.veilarbregistrering.registrering.reaktivering.ReaktiveringBrukerService
-import no.nav.fo.veilarbregistrering.registrering.reaktivering.ReaktiveringRepository
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test

--- a/src/test/kotlin/no/nav/fo/veilarbregistrering/registrering/sykmeldt/SykmeldtRegistreringServiceTest.kt
+++ b/src/test/kotlin/no/nav/fo/veilarbregistrering/registrering/sykmeldt/SykmeldtRegistreringServiceTest.kt
@@ -13,7 +13,7 @@ import no.nav.fo.veilarbregistrering.oppfolging.adapter.OppfolgingClient
 import no.nav.fo.veilarbregistrering.oppfolging.adapter.OppfolgingGatewayImpl
 import no.nav.fo.veilarbregistrering.oppfolging.adapter.veilarbarena.ArenaStatusDto
 import no.nav.fo.veilarbregistrering.oppfolging.adapter.veilarbarena.VeilarbarenaClient
-import no.nav.fo.veilarbregistrering.registrering.bruker.BrukerRegistreringRepository
+import no.nav.fo.veilarbregistrering.registrering.ordinaer.BrukerRegistreringRepository
 import no.nav.fo.veilarbregistrering.registrering.bruker.BrukerTilstandService
 import no.nav.fo.veilarbregistrering.registrering.bruker.NavVeileder
 import no.nav.fo.veilarbregistrering.registrering.manuell.ManuellRegistreringRepository

--- a/src/test/kotlin/no/nav/fo/veilarbregistrering/tidslinje/TidslinjeAggregatorTest.kt
+++ b/src/test/kotlin/no/nav/fo/veilarbregistrering/tidslinje/TidslinjeAggregatorTest.kt
@@ -6,8 +6,8 @@ import no.nav.fo.veilarbregistrering.arbeidssoker.ArbeidssokerRepository
 import no.nav.fo.veilarbregistrering.bruker.AktorId
 import no.nav.fo.veilarbregistrering.bruker.Bruker
 import no.nav.fo.veilarbregistrering.bruker.Foedselsnummer
-import no.nav.fo.veilarbregistrering.registrering.bruker.BrukerRegistreringRepository
-import no.nav.fo.veilarbregistrering.registrering.bruker.OrdinaerBrukerRegistreringTestdataBuilder.gyldigBrukerRegistrering
+import no.nav.fo.veilarbregistrering.registrering.ordinaer.BrukerRegistreringRepository
+import no.nav.fo.veilarbregistrering.registrering.ordinaer.OrdinaerBrukerRegistreringTestdataBuilder.gyldigBrukerRegistrering
 import no.nav.fo.veilarbregistrering.registrering.reaktivering.ReaktiveringRepository
 import no.nav.fo.veilarbregistrering.registrering.reaktivering.ReaktiveringTestdataBuilder.gyldigReaktivering
 import no.nav.fo.veilarbregistrering.registrering.sykmeldt.SykmeldtRegistreringRepository

--- a/src/test/kotlin/no/nav/fo/veilarbregistrering/tidslinje/TidslinjeTestdataBuilder.kt
+++ b/src/test/kotlin/no/nav/fo/veilarbregistrering/tidslinje/TidslinjeTestdataBuilder.kt
@@ -1,6 +1,6 @@
 package no.nav.fo.veilarbregistrering.tidslinje
 
-import no.nav.fo.veilarbregistrering.registrering.bruker.OrdinaerBrukerRegistreringTestdataBuilder.gyldigBrukerRegistrering
+import no.nav.fo.veilarbregistrering.registrering.ordinaer.OrdinaerBrukerRegistreringTestdataBuilder.gyldigBrukerRegistrering
 import java.time.LocalDate
 
 class TidslinjeTestdataBuilder {

--- a/src/test/kotlin/no/nav/veilarbregistrering/integrasjonstest/BrukerRegistreringServiceIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/veilarbregistrering/integrasjonstest/BrukerRegistreringServiceIntegrationTest.kt
@@ -19,6 +19,9 @@ import no.nav.fo.veilarbregistrering.registrering.formidling.RegistreringTilstan
 import no.nav.fo.veilarbregistrering.registrering.formidling.RegistreringTilstandRepository
 import no.nav.fo.veilarbregistrering.registrering.formidling.Status
 import no.nav.fo.veilarbregistrering.registrering.manuell.ManuellRegistreringRepository
+import no.nav.fo.veilarbregistrering.registrering.ordinaer.BrukerRegistreringRepository
+import no.nav.fo.veilarbregistrering.registrering.ordinaer.BrukerRegistreringService
+import no.nav.fo.veilarbregistrering.registrering.ordinaer.OrdinaerBrukerRegistreringTestdataBuilder
 import no.nav.veilarbregistrering.integrasjonstest.BrukerRegistreringServiceIntegrationTest.BrukerregistreringConfigTest
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.*


### PR DESCRIPTION
Ønsker å tydeliggjøre `ordinaer` registrering fra sykmeldt registering. Det er et eget subdomene/use-case.