### PR TITLE
Flytter ut `reaktivering`-endepunkt til egen Resource

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -90,7 +90,7 @@ jobs:
       env:
         APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
         CLUSTER: prod-fss
-        DRY_RUN: false
+        DRY_RUN: true
         RESOURCE: nais/nais-prod-fss.yaml
 
   release:

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/config/ServiceBeansConfig.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/config/ServiceBeansConfig.kt
@@ -50,6 +50,7 @@ import no.nav.fo.veilarbregistrering.registrering.publisering.ArbeidssokerRegist
 import no.nav.fo.veilarbregistrering.registrering.publisering.PubliseringAvEventsService
 import no.nav.fo.veilarbregistrering.registrering.reaktivering.ReaktiveringBrukerService
 import no.nav.fo.veilarbregistrering.registrering.reaktivering.ReaktiveringRepository
+import no.nav.fo.veilarbregistrering.registrering.reaktivering.resources.ReaktiveringResource
 import no.nav.fo.veilarbregistrering.registrering.sykmeldt.SykmeldtRegistreringRepository
 import no.nav.fo.veilarbregistrering.registrering.sykmeldt.SykmeldtRegistreringService
 import no.nav.fo.veilarbregistrering.tidslinje.TidslinjeAggregator
@@ -163,6 +164,21 @@ class ServiceBeansConfig {
     }
 
     @Bean
+    fun reaktiveringResource(
+        autorisasjonService: AutorisasjonService,
+        userService: UserService,
+        unleashClient: UnleashClient,
+        reaktiveringBrukerService: ReaktiveringBrukerService
+    ) : ReaktiveringResource {
+        return ReaktiveringResource(
+            autorisasjonService,
+            userService,
+            unleashClient,
+            reaktiveringBrukerService
+        )
+    }
+
+    @Bean
     fun registreringResource(
         autorisasjonService: AutorisasjonService,
         userService: UserService,
@@ -170,8 +186,7 @@ class ServiceBeansConfig {
         hentRegistreringService: HentRegistreringService,
         unleashClient: UnleashClient,
         startRegistreringStatusService: StartRegistreringStatusService,
-        sykmeldtRegistreringService: SykmeldtRegistreringService,
-        reaktiveringBrukerService: ReaktiveringBrukerService
+        sykmeldtRegistreringService: SykmeldtRegistreringService
     ): RegistreringResource {
         return RegistreringResource(
             autorisasjonService,
@@ -180,8 +195,7 @@ class ServiceBeansConfig {
             hentRegistreringService,
             unleashClient,
             sykmeldtRegistreringService,
-            startRegistreringStatusService,
-            reaktiveringBrukerService
+            startRegistreringStatusService
         )
     }
 

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/registrering/bruker/resources/RegistreringApi.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/registrering/bruker/resources/RegistreringApi.kt
@@ -39,14 +39,6 @@ interface RegistreringApi {
     @Operation(summary = "Henter siste påbegynte registrering")
     fun hentPaabegyntRegistrering(): ResponseEntity<BrukerRegistreringWrapper>
 
-    @Operation(
-        summary = "Reaktiverer bruker som arbeidssøker.",
-        description = "Tjenesten gjør en reaktivering av brukere som har blitt inaktivert i løpet av de siste 28 " +
-                "dagene. Enkel reaktivering vil si at bruker settes til arbeidssøker (formidlingsgruppe=ARBS) i Arena " +
-                "uten at saksbehandler manuelt vurderer reaktiveringen via en arbeidsprosess."
-    )
-    fun reaktivering()
-
     @Operation(summary = "Registrerer bruker som `sykmeldt registrert`.")
     fun registrerSykmeldt(sykmeldtRegistrering: SykmeldtRegistrering)
 }

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/registrering/bruker/resources/RegistreringResource.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/registrering/bruker/resources/RegistreringResource.kt
@@ -4,11 +4,12 @@ import no.nav.common.featuretoggle.UnleashClient
 import no.nav.fo.veilarbregistrering.autorisasjon.AutorisasjonService
 import no.nav.fo.veilarbregistrering.bruker.UserService
 import no.nav.fo.veilarbregistrering.log.logger
-import no.nav.fo.veilarbregistrering.registrering.bruker.*
+import no.nav.fo.veilarbregistrering.registrering.bruker.HentRegistreringService
+import no.nav.fo.veilarbregistrering.registrering.bruker.NavVeileder
+import no.nav.fo.veilarbregistrering.registrering.bruker.StartRegistreringStatusService
 import no.nav.fo.veilarbregistrering.registrering.bruker.resources.BrukerRegistreringWrapperFactory.create
 import no.nav.fo.veilarbregistrering.registrering.ordinaer.BrukerRegistreringService
 import no.nav.fo.veilarbregistrering.registrering.ordinaer.OrdinaerBrukerRegistrering
-import no.nav.fo.veilarbregistrering.registrering.reaktivering.ReaktiveringBrukerService
 import no.nav.fo.veilarbregistrering.registrering.sykmeldt.SykmeldtRegistrering
 import no.nav.fo.veilarbregistrering.registrering.sykmeldt.SykmeldtRegistreringService
 import org.springframework.http.HttpStatus
@@ -24,9 +25,9 @@ class RegistreringResource(
     private val hentRegistreringService: HentRegistreringService,
     private val unleashClient: UnleashClient,
     private val sykmeldtRegistreringService: SykmeldtRegistreringService,
-    private val startRegistreringStatusService: StartRegistreringStatusService,
-    private val reaktiveringBrukerService: ReaktiveringBrukerService
+    private val startRegistreringStatusService: StartRegistreringStatusService
 ) : RegistreringApi {
+
     @GetMapping("/startregistrering")
     override fun hentStartRegistreringStatus(): StartRegistreringStatusDto {
         val bruker = userService.finnBrukerGjennomPdl()
@@ -72,17 +73,6 @@ class RegistreringResource(
             return ResponseEntity.noContent().build()
         }
         return ResponseEntity.ok(brukerRegistreringWrapper)
-    }
-
-    @PostMapping("/startreaktivering")
-    @ResponseStatus(HttpStatus.NO_CONTENT)
-    override fun reaktivering() {
-        if (tjenesteErNede()) {
-            throw RuntimeException("Tjenesten er nede for øyeblikket. Prøv igjen senere.")
-        }
-        val bruker = userService.finnBrukerGjennomPdl()
-        autorisasjonsService.sjekkSkrivetilgangTilBruker(bruker.gjeldendeFoedselsnummer)
-        reaktiveringBrukerService.reaktiverBruker(bruker, autorisasjonsService.erVeileder())
     }
 
     @PostMapping("/startregistrersykmeldt")

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/registrering/reaktivering/resources/ReaktiveringApi.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/registrering/reaktivering/resources/ReaktiveringApi.kt
@@ -1,0 +1,16 @@
+package no.nav.fo.veilarbregistrering.registrering.reaktivering.resources
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+
+@Tag(name = "ReaktiveringResource")
+interface ReaktiveringApi {
+
+    @Operation(
+        summary = "Reaktiverer bruker som arbeidssøker.",
+        description = "Tjenesten gjør en reaktivering av brukere som har blitt inaktivert i løpet av de siste 28 " +
+                "dagene. Enkel reaktivering vil si at bruker settes til arbeidssøker (formidlingsgruppe=ARBS) i Arena " +
+                "uten at saksbehandler manuelt vurderer reaktiveringen via en arbeidsprosess."
+    )
+    fun reaktivering()
+}

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/registrering/reaktivering/resources/ReaktiveringResource.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/registrering/reaktivering/resources/ReaktiveringResource.kt
@@ -1,0 +1,34 @@
+package no.nav.fo.veilarbregistrering.registrering.reaktivering.resources
+
+import no.nav.common.featuretoggle.UnleashClient
+import no.nav.fo.veilarbregistrering.autorisasjon.AutorisasjonService
+import no.nav.fo.veilarbregistrering.bruker.UserService
+import no.nav.fo.veilarbregistrering.registrering.reaktivering.ReaktiveringBrukerService
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api")
+class ReaktiveringResource(
+    private val autorisasjonsService: AutorisasjonService,
+    private val userService: UserService,
+    private val unleashClient: UnleashClient,
+    private val reaktiveringBrukerService: ReaktiveringBrukerService
+) : ReaktiveringApi {
+
+    @PostMapping("/startreaktivering")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    override fun reaktivering() {
+        if (tjenesteErNede()) {
+            throw RuntimeException("Tjenesten er nede for øyeblikket. Prøv igjen senere.")
+        }
+        val bruker = userService.finnBrukerGjennomPdl()
+        autorisasjonsService.sjekkSkrivetilgangTilBruker(bruker.gjeldendeFoedselsnummer)
+        reaktiveringBrukerService.reaktiverBruker(bruker, autorisasjonsService.erVeileder())
+    }
+
+    private fun tjenesteErNede(): Boolean = unleashClient.isEnabled("arbeidssokerregistrering.nedetid")
+}

--- a/src/test/kotlin/no/nav/fo/veilarbregistrering/registrering/bruker/resources/RegistreringResourceTest.kt
+++ b/src/test/kotlin/no/nav/fo/veilarbregistrering/registrering/bruker/resources/RegistreringResourceTest.kt
@@ -12,12 +12,12 @@ import no.nav.fo.veilarbregistrering.besvarelse.TilbakeIArbeidSvar
 import no.nav.fo.veilarbregistrering.bruker.*
 import no.nav.fo.veilarbregistrering.config.RequestContext
 import no.nav.fo.veilarbregistrering.profilering.ProfileringTestdataBuilder.lagProfilering
-import no.nav.fo.veilarbregistrering.registrering.bruker.*
-import no.nav.fo.veilarbregistrering.registrering.ordinaer.OrdinaerBrukerRegistreringTestdataBuilder.gyldigBrukerRegistrering
+import no.nav.fo.veilarbregistrering.registrering.bruker.HentRegistreringService
+import no.nav.fo.veilarbregistrering.registrering.bruker.StartRegistreringStatusService
 import no.nav.fo.veilarbregistrering.registrering.ordinaer.BrukerRegistreringService
-import no.nav.fo.veilarbregistrering.registrering.sykmeldt.SykmeldtRegistreringTestdataBuilder.gyldigSykmeldtRegistrering
-import no.nav.fo.veilarbregistrering.registrering.reaktivering.ReaktiveringBrukerService
+import no.nav.fo.veilarbregistrering.registrering.ordinaer.OrdinaerBrukerRegistreringTestdataBuilder.gyldigBrukerRegistrering
 import no.nav.fo.veilarbregistrering.registrering.sykmeldt.SykmeldtRegistreringService
+import no.nav.fo.veilarbregistrering.registrering.sykmeldt.SykmeldtRegistreringTestdataBuilder.gyldigSykmeldtRegistrering
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -71,17 +71,6 @@ class RegistreringResourceTest(
             contentType = MediaType.APPLICATION_JSON
             content = FileToJson.toJson("/registrering/startregistrersykmeldt.json")
         }.andExpect {
-            status { isNoContent() }
-        }.andReturn().response.contentAsString
-
-        assertThat(responseString).isNullOrEmpty()
-    }
-
-    @Test
-    fun `startreaktivering returnerer riktig status og responsbody`() {
-        every { request.getParameter("fnr") } returns IDENT.stringValue()
-        every { pdlOppslagGateway.hentIdenter(any<Foedselsnummer>()) } returns IDENTER
-        val responseString = mvc.post("/api/startreaktivering").andExpect {
             status { isNoContent() }
         }.andReturn().response.contentAsString
 
@@ -299,8 +288,7 @@ private class RegistreringResourceConfig {
         hentRegistreringService: HentRegistreringService,
         unleashClient: UnleashClient,
         sykmeldtRegistreringService: SykmeldtRegistreringService,
-        startRegistreringStatusService: StartRegistreringStatusService,
-        reaktiveringBrukerService: ReaktiveringBrukerService
+        startRegistreringStatusService: StartRegistreringStatusService
     ) = RegistreringResource(
         autorisasjonService,
         userService,
@@ -308,8 +296,7 @@ private class RegistreringResourceConfig {
         hentRegistreringService,
         unleashClient,
         sykmeldtRegistreringService,
-        startRegistreringStatusService,
-        reaktiveringBrukerService,
+        startRegistreringStatusService
     )
 
     @Bean
@@ -339,7 +326,4 @@ private class RegistreringResourceConfig {
 
     @Bean
     fun sykmeldtRegistreringService(): SykmeldtRegistreringService = mockk(relaxed = true)
-
-    @Bean
-    fun inaktivBrukerService(): ReaktiveringBrukerService = mockk(relaxed = true)
 }

--- a/src/test/kotlin/no/nav/fo/veilarbregistrering/registrering/reaktivering/resources/ReaktiveringResourceTest.kt
+++ b/src/test/kotlin/no/nav/fo/veilarbregistrering/registrering/reaktivering/resources/ReaktiveringResourceTest.kt
@@ -1,0 +1,104 @@
+package no.nav.fo.veilarbregistrering.registrering.reaktivering.resources
+
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import no.nav.common.auth.context.AuthContextHolder
+import no.nav.common.featuretoggle.UnleashClient
+import no.nav.fo.veilarbregistrering.autorisasjon.AutorisasjonService
+import no.nav.fo.veilarbregistrering.bruker.*
+import no.nav.fo.veilarbregistrering.config.RequestContext
+import no.nav.fo.veilarbregistrering.registrering.reaktivering.ReaktiveringBrukerService
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.post
+import java.util.*
+import javax.servlet.http.HttpServletRequest
+
+@AutoConfigureMockMvc
+@WebMvcTest
+@ContextConfiguration(classes = [ReaktiveringResourceConfig::class])
+class ReaktiveringResourceTest(
+    @Autowired private val mvc: MockMvc,
+    @Autowired private val autorisasjonService: AutorisasjonService,
+    @Autowired private val authContextHolder: AuthContextHolder,
+    @Autowired private val pdlOppslagGateway: PdlOppslagGateway,
+) {
+    private lateinit var request: HttpServletRequest
+
+    @BeforeEach
+    fun setup() {
+        clearAllMocks()
+        mockkStatic(RequestContext::class)
+        request = mockk(relaxed = true)
+        every { RequestContext.servletRequest() } returns request
+        every { autorisasjonService.erVeileder() } returns true
+        every { authContextHolder.subject} returns Optional.of("sub")
+        every { authContextHolder.idTokenClaims } returns Optional.empty()
+    }
+
+    @Test
+    fun `startreaktivering returnerer riktig status og responsbody`() {
+        every { request.getParameter("fnr") } returns IDENT.stringValue()
+        every { pdlOppslagGateway.hentIdenter(any<Foedselsnummer>()) } returns IDENTER
+        val responseString = mvc.post("/api/startreaktivering").andExpect {
+            status { isNoContent() }
+        }.andReturn().response.contentAsString
+
+        Assertions.assertThat(responseString).isNullOrEmpty()
+    }
+
+    companion object {
+        private val IDENT = Foedselsnummer("10108000398") //Aremark fiktivt fnr.";
+        private val IDENTER = Identer(
+            mutableListOf(
+                Ident(IDENT.stringValue(), false, Gruppe.FOLKEREGISTERIDENT),
+                Ident("22222222222", false, Gruppe.AKTORID)
+            )
+        )
+    }
+}
+
+@Configuration
+private class ReaktiveringResourceConfig {
+    @Bean
+    fun reaktiveringResource(
+        autorisasjonService: AutorisasjonService,
+        userService: UserService,
+        unleashClient: UnleashClient,
+        reaktiveringBrukerService: ReaktiveringBrukerService
+    ) = ReaktiveringResource(
+        autorisasjonService,
+        userService,
+        unleashClient,
+        reaktiveringBrukerService,
+    )
+
+    @Bean
+    fun autorisasjonService(): AutorisasjonService = mockk(relaxed = true)
+
+    @Bean
+    fun unleashClient(): UnleashClient = mockk(relaxed = true)
+
+    @Bean
+    fun pdlOppslagGateway(): PdlOppslagGateway = mockk()
+
+    @Bean
+    fun authContextHolder(): AuthContextHolder = mockk()
+
+    @Bean
+    fun userService(pdlOppslagGateway: PdlOppslagGateway, authContextHolder: AuthContextHolder): UserService =
+        UserService(pdlOppslagGateway, authContextHolder)
+
+    @Bean
+    fun reaktiveringBrukerService(): ReaktiveringBrukerService = mockk(relaxed = true)
+}


### PR DESCRIPTION
Ønsker å trimme ned RegistreringResource til å være mer fokusert, fremfor å være inngangen for alt.
Samler da `reaktivering` i samme pakke.