### PR TITLE
Flytter SykmeldtRegistrering-endepunktet til egen Resource

### DIFF
--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/config/ServiceBeansConfig.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/config/ServiceBeansConfig.kt
@@ -53,6 +53,7 @@ import no.nav.fo.veilarbregistrering.registrering.reaktivering.ReaktiveringRepos
 import no.nav.fo.veilarbregistrering.registrering.reaktivering.resources.ReaktiveringResource
 import no.nav.fo.veilarbregistrering.registrering.sykmeldt.SykmeldtRegistreringRepository
 import no.nav.fo.veilarbregistrering.registrering.sykmeldt.SykmeldtRegistreringService
+import no.nav.fo.veilarbregistrering.registrering.sykmeldt.resources.SykmeldtResource
 import no.nav.fo.veilarbregistrering.tidslinje.TidslinjeAggregator
 import no.nav.fo.veilarbregistrering.tidslinje.resources.TidslinjeResource
 import org.springframework.context.annotation.Bean
@@ -164,6 +165,20 @@ class ServiceBeansConfig {
     }
 
     @Bean
+    fun sykmeldtResource(
+        autorisasjonService: AutorisasjonService,
+        userService: UserService,
+        unleashClient: UnleashClient,
+        sykmeldtRegistreringService: SykmeldtRegistreringService
+    ) : SykmeldtResource {
+        return SykmeldtResource(
+            autorisasjonService,
+            userService,
+            unleashClient,
+            sykmeldtRegistreringService)
+    }
+
+    @Bean
     fun reaktiveringResource(
         autorisasjonService: AutorisasjonService,
         userService: UserService,
@@ -185,8 +200,7 @@ class ServiceBeansConfig {
         brukerRegistreringService: BrukerRegistreringService,
         hentRegistreringService: HentRegistreringService,
         unleashClient: UnleashClient,
-        startRegistreringStatusService: StartRegistreringStatusService,
-        sykmeldtRegistreringService: SykmeldtRegistreringService
+        startRegistreringStatusService: StartRegistreringStatusService
     ): RegistreringResource {
         return RegistreringResource(
             autorisasjonService,
@@ -194,7 +208,6 @@ class ServiceBeansConfig {
             brukerRegistreringService,
             hentRegistreringService,
             unleashClient,
-            sykmeldtRegistreringService,
             startRegistreringStatusService
         )
     }

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/registrering/bruker/resources/RegistreringApi.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/registrering/bruker/resources/RegistreringApi.kt
@@ -39,6 +39,4 @@ interface RegistreringApi {
     @Operation(summary = "Henter siste påbegynte registrering")
     fun hentPaabegyntRegistrering(): ResponseEntity<BrukerRegistreringWrapper>
 
-    @Operation(summary = "Registrerer bruker som `sykmeldt registrert`.")
-    fun registrerSykmeldt(sykmeldtRegistrering: SykmeldtRegistrering)
 }

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/registrering/bruker/resources/RegistreringResource.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/registrering/bruker/resources/RegistreringResource.kt
@@ -10,9 +10,6 @@ import no.nav.fo.veilarbregistrering.registrering.bruker.StartRegistreringStatus
 import no.nav.fo.veilarbregistrering.registrering.bruker.resources.BrukerRegistreringWrapperFactory.create
 import no.nav.fo.veilarbregistrering.registrering.ordinaer.BrukerRegistreringService
 import no.nav.fo.veilarbregistrering.registrering.ordinaer.OrdinaerBrukerRegistrering
-import no.nav.fo.veilarbregistrering.registrering.sykmeldt.SykmeldtRegistrering
-import no.nav.fo.veilarbregistrering.registrering.sykmeldt.SykmeldtRegistreringService
-import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 
@@ -24,7 +21,6 @@ class RegistreringResource(
     private val brukerRegistreringService: BrukerRegistreringService,
     private val hentRegistreringService: HentRegistreringService,
     private val unleashClient: UnleashClient,
-    private val sykmeldtRegistreringService: SykmeldtRegistreringService,
     private val startRegistreringStatusService: StartRegistreringStatusService
 ) : RegistreringApi {
 
@@ -73,18 +69,6 @@ class RegistreringResource(
             return ResponseEntity.noContent().build()
         }
         return ResponseEntity.ok(brukerRegistreringWrapper)
-    }
-
-    @PostMapping("/startregistrersykmeldt")
-    @ResponseStatus(HttpStatus.NO_CONTENT)
-    override fun registrerSykmeldt(@RequestBody sykmeldtRegistrering: SykmeldtRegistrering) {
-        if (tjenesteErNede()) {
-            throw RuntimeException("Tjenesten er nede for øyeblikket. Prøv igjen senere.")
-        }
-        val bruker = userService.finnBrukerGjennomPdl()
-        autorisasjonsService.sjekkSkrivetilgangTilBruker(bruker.aktorId)
-        val veileder = navVeileder()
-        sykmeldtRegistreringService.registrerSykmeldt(sykmeldtRegistrering, bruker, veileder)
     }
 
     private fun navVeileder(): NavVeileder? {

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/registrering/sykmeldt/resources/SykmeldtApi.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/registrering/sykmeldt/resources/SykmeldtApi.kt
@@ -1,0 +1,12 @@
+package no.nav.fo.veilarbregistrering.registrering.sykmeldt.resources
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import no.nav.fo.veilarbregistrering.registrering.sykmeldt.SykmeldtRegistrering
+
+@Tag(name = "SykmeldtResource")
+interface SykmeldtApi {
+
+    @Operation(summary = "Registrerer bruker som `sykmeldt registrert`.")
+    fun registrerSykmeldt(sykmeldtRegistrering: SykmeldtRegistrering)
+}

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/registrering/sykmeldt/resources/SykmeldtResource.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/registrering/sykmeldt/resources/SykmeldtResource.kt
@@ -1,0 +1,43 @@
+package no.nav.fo.veilarbregistrering.registrering.sykmeldt.resources
+
+import no.nav.common.featuretoggle.UnleashClient
+import no.nav.fo.veilarbregistrering.autorisasjon.AutorisasjonService
+import no.nav.fo.veilarbregistrering.bruker.UserService
+import no.nav.fo.veilarbregistrering.registrering.bruker.NavVeileder
+import no.nav.fo.veilarbregistrering.registrering.sykmeldt.SykmeldtRegistrering
+import no.nav.fo.veilarbregistrering.registrering.sykmeldt.SykmeldtRegistreringService
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/api")
+class SykmeldtResource(
+    private val autorisasjonsService: AutorisasjonService,
+    private val userService: UserService,
+    private val unleashClient: UnleashClient,
+    private val sykmeldtRegistreringService: SykmeldtRegistreringService
+) : SykmeldtApi {
+
+    @PostMapping("/startregistrersykmeldt")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    override fun registrerSykmeldt(@RequestBody sykmeldtRegistrering: SykmeldtRegistrering) {
+        if (tjenesteErNede()) {
+            throw RuntimeException("Tjenesten er nede for øyeblikket. Prøv igjen senere.")
+        }
+        val bruker = userService.finnBrukerGjennomPdl()
+        autorisasjonsService.sjekkSkrivetilgangTilBruker(bruker.aktorId)
+        val veileder = navVeileder()
+        sykmeldtRegistreringService.registrerSykmeldt(sykmeldtRegistrering, bruker, veileder)
+    }
+
+    private fun navVeileder(): NavVeileder? {
+        return if (!autorisasjonsService.erVeileder()) {
+            null
+        } else NavVeileder(
+            autorisasjonsService.innloggetVeilederIdent,
+            userService.getEnhetIdFromUrlOrThrow()
+        )
+    }
+
+    private fun tjenesteErNede(): Boolean = unleashClient.isEnabled("arbeidssokerregistrering.nedetid")
+}

--- a/src/test/kotlin/no/nav/fo/veilarbregistrering/registrering/sykmeldt/resources/SykmeldtResourceTest.kt
+++ b/src/test/kotlin/no/nav/fo/veilarbregistrering/registrering/sykmeldt/resources/SykmeldtResourceTest.kt
@@ -1,0 +1,126 @@
+package no.nav.fo.veilarbregistrering.registrering.sykmeldt.resources
+
+import io.mockk.*
+import no.nav.common.auth.context.AuthContextHolder
+import no.nav.common.featuretoggle.UnleashClient
+import no.nav.fo.veilarbregistrering.FileToJson
+import no.nav.fo.veilarbregistrering.autorisasjon.AutorisasjonService
+import no.nav.fo.veilarbregistrering.besvarelse.Besvarelse
+import no.nav.fo.veilarbregistrering.besvarelse.FremtidigSituasjonSvar
+import no.nav.fo.veilarbregistrering.besvarelse.TilbakeIArbeidSvar
+import no.nav.fo.veilarbregistrering.bruker.*
+import no.nav.fo.veilarbregistrering.config.RequestContext
+import no.nav.fo.veilarbregistrering.registrering.sykmeldt.SykmeldtRegistreringService
+import no.nav.fo.veilarbregistrering.registrering.sykmeldt.SykmeldtRegistreringTestdataBuilder
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.http.MediaType
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.post
+import java.util.*
+import javax.servlet.http.HttpServletRequest
+
+@AutoConfigureMockMvc
+@WebMvcTest
+@ContextConfiguration(classes = [SykmeldtResourceConfig::class])
+class SykmeldtResourceTest(
+    @Autowired private val mvc: MockMvc,
+    @Autowired private val autorisasjonService: AutorisasjonService,
+    @Autowired private val authContextHolder: AuthContextHolder,
+    @Autowired private val pdlOppslagGateway: PdlOppslagGateway,
+    @Autowired private val sykmeldtResource: SykmeldtResource
+) {
+    private lateinit var request: HttpServletRequest
+
+    @BeforeEach
+    fun setup() {
+        clearAllMocks()
+        mockkStatic(RequestContext::class)
+        request = mockk(relaxed = true)
+        every { RequestContext.servletRequest() } returns request
+        every { autorisasjonService.erVeileder() } returns true
+        every { authContextHolder.subject} returns Optional.of("sub")
+        every { authContextHolder.idTokenClaims } returns Optional.empty()
+    }
+
+    @Test
+    fun skalSjekkeTilgangTilBrukerVedRegistreringSykmeldt() {
+        val sykmeldtRegistrering = SykmeldtRegistreringTestdataBuilder.gyldigSykmeldtRegistrering(
+            besvarelse = Besvarelse(
+                fremtidigSituasjon = FremtidigSituasjonSvar.SAMME_ARBEIDSGIVER,
+                tilbakeIArbeid = TilbakeIArbeidSvar.JA_FULL_STILLING,
+            )
+        )
+        every { request.getParameter("fnr") } returns IDENT.stringValue()
+        every { pdlOppslagGateway.hentIdenter(any<Foedselsnummer>()) } returns IDENTER
+        sykmeldtResource.registrerSykmeldt(sykmeldtRegistrering)
+        verify(exactly = 1) { autorisasjonService.sjekkSkrivetilgangTilBruker(any<AktorId>()) }
+    }
+
+
+    @Test
+    fun `startregistrersykmeldt har riktig status og responsbody`() {
+        every { request.getParameter("fnr") } returns IDENT.stringValue()
+        every { pdlOppslagGateway.hentIdenter(any<Foedselsnummer>()) } returns IDENTER
+        val responseString = mvc.post("/api/startregistrersykmeldt") {
+            contentType = MediaType.APPLICATION_JSON
+            content = FileToJson.toJson("/registrering/startregistrersykmeldt.json")
+        }.andExpect {
+            status { isNoContent() }
+        }.andReturn().response.contentAsString
+
+        Assertions.assertThat(responseString).isNullOrEmpty()
+    }
+
+    companion object {
+        private val IDENT = Foedselsnummer("10108000398") //Aremark fiktivt fnr.";
+        private val IDENTER = Identer(
+            mutableListOf(
+                Ident(IDENT.stringValue(), false, Gruppe.FOLKEREGISTERIDENT),
+                Ident("22222222222", false, Gruppe.AKTORID)
+            )
+        )
+    }
+}
+
+@Configuration
+private class SykmeldtResourceConfig {
+    @Bean
+    fun sykmeldtResource(
+        autorisasjonService: AutorisasjonService,
+        userService: UserService,
+        unleashClient: UnleashClient,
+        sykmeldtRegistreringService: SykmeldtRegistreringService
+    ) = SykmeldtResource(
+        autorisasjonService,
+        userService,
+        unleashClient,
+        sykmeldtRegistreringService
+    )
+
+    @Bean
+    fun autorisasjonService(): AutorisasjonService = mockk(relaxed = true)
+
+    @Bean
+    fun unleashClient(): UnleashClient = mockk(relaxed = true)
+
+    @Bean
+    fun pdlOppslagGateway(): PdlOppslagGateway = mockk()
+
+    @Bean
+    fun authContextHolder(): AuthContextHolder = mockk()
+
+    @Bean
+    fun userService(pdlOppslagGateway: PdlOppslagGateway, authContextHolder: AuthContextHolder): UserService =
+        UserService(pdlOppslagGateway, authContextHolder)
+
+    @Bean
+    fun sykmeldtRegistreringService(): SykmeldtRegistreringService = mockk(relaxed = true)
+}


### PR DESCRIPTION
På lik linje med Reaktivering, lager vi egen Resource for endepunktet til SykmeldtRegistrering. Det gjør at SykmeldtRegistrering kan holdes innenfor en pakke i større grad.