### PR TITLE
Rename Arbeidssokerperiode til Formidlingsgruppeperiode

### DIFF
--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/arbeidssoker/ArbeidssokerperiodeAvsluttetProducer.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/arbeidssoker/ArbeidssokerperiodeAvsluttetProducer.kt
@@ -4,9 +4,9 @@ import no.nav.fo.veilarbregistrering.log.logger
 
 class ArbeidssokerperiodeAvsluttetProducer {
 
-    fun publiserArbeidssokerperiodeAvsluttet(endretFormidlingsgruppeCommand: EndretFormidlingsgruppeCommand, sisteArbeidssokerperiode: Arbeidssokerperiode) {
+    fun publiserArbeidssokerperiodeAvsluttet(endretFormidlingsgruppeCommand: EndretFormidlingsgruppeCommand, sisteFormidlingsgruppeperiode: Formidlingsgruppeperiode) {
 
         logger.info("Ny formidlingsgruppe for person: ${endretFormidlingsgruppeCommand.formidlingsgruppe} - arbeidssøkerperiode avsluttet ${endretFormidlingsgruppeCommand.formidlingsgruppeEndret}. " +
-                "Nyeste arbeidssøkerperiode før denne endringen er: $sisteArbeidssokerperiode.")
+                "Nyeste arbeidssøkerperiode før denne endringen er: $sisteFormidlingsgruppeperiode.")
     }
 }

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/arbeidssoker/ArbeidssokerperiodeAvsluttetService.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/arbeidssoker/ArbeidssokerperiodeAvsluttetService.kt
@@ -6,21 +6,21 @@ class ArbeidssokerperiodeAvsluttetService(
 
     fun behandleAvslutningAvArbeidssokerperiode(
         endretFormidlingsgruppeCommand: EndretFormidlingsgruppeCommand,
-        arbeidssokerperioder: Arbeidssokerperioder
+        formidlingsgruppeperioder: Arbeidssokerperioder
     ) {
-        if (erAvslutningAvArbeidssokerperiode(endretFormidlingsgruppeCommand, arbeidssokerperioder)) {
-            val sistePeriode = arbeidssokerperioder.eldsteFoerst().last()
+        if (erAvslutningAvArbeidssokerperiode(endretFormidlingsgruppeCommand, formidlingsgruppeperioder)) {
+            val sistePeriode = formidlingsgruppeperioder.eldsteFoerst().last()
             arbeidssokerperiodeAvsluttetProducer.publiserArbeidssokerperiodeAvsluttet(endretFormidlingsgruppeCommand, sistePeriode)
         }
     }
 
     private fun erAvslutningAvArbeidssokerperiode(
         endretFormidlingsgruppeCommand: EndretFormidlingsgruppeCommand,
-        arbeidssokerperioder: Arbeidssokerperioder
+        formidlingsgruppeperioder: Arbeidssokerperioder
     ): Boolean {
-        if (arbeidssokerperioder.asList().isEmpty()) return false
+        if (formidlingsgruppeperioder.asList().isEmpty()) return false
         endretFormidlingsgruppeCommand.foedselsnummer?.let {
-            val sistePeriode = arbeidssokerperioder.eldsteFoerst().last()
+            val sistePeriode = formidlingsgruppeperioder.eldsteFoerst().last()
             if (harNaavaerendePeriodeMedARBS(sistePeriode) && endretFormidlingsgruppeCommand.formidlingsgruppe.kode != "ARBS") {
                 return true
             }
@@ -29,6 +29,6 @@ class ArbeidssokerperiodeAvsluttetService(
         return false
     }
 
-    private fun harNaavaerendePeriodeMedARBS(sistePeriode: Arbeidssokerperiode): Boolean =
+    private fun harNaavaerendePeriodeMedARBS(sistePeriode: Formidlingsgruppeperiode): Boolean =
         sistePeriode.formidlingsgruppe.kode == "ARBS" && sistePeriode.periode.til == null
 }

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/arbeidssoker/Arbeidssokerperioder.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/arbeidssoker/Arbeidssokerperioder.kt
@@ -3,9 +3,9 @@ package no.nav.fo.veilarbregistrering.arbeidssoker
 import no.nav.fo.veilarbregistrering.bruker.Periode
 import java.util.Objects
 
-class Arbeidssokerperioder(arbeidssokerperioder: List<Arbeidssokerperiode>?) {
+class Arbeidssokerperioder(arbeidssokerperioder: List<Formidlingsgruppeperiode>?) {
 
-    private val arbeidssokerperioder: List<Arbeidssokerperiode> = arbeidssokerperioder ?: emptyList()
+    private val arbeidssokerperioder: List<Formidlingsgruppeperiode> = arbeidssokerperioder ?: emptyList()
 
     fun overlapperMed(forespurtPeriode: Periode): Arbeidssokerperioder {
         return Arbeidssokerperioder(arbeidssokerperioder
@@ -14,16 +14,16 @@ class Arbeidssokerperioder(arbeidssokerperioder: List<Arbeidssokerperiode>?) {
     }
 
     fun dekkerHele(forespurtPeriode: Periode): Boolean {
-        val eldsteArbeidssokerperiode: Arbeidssokerperiode? = arbeidssokerperioder.minByOrNull { it.periode.fra }
+        val eldsteFormidlingsgruppeperiode: Formidlingsgruppeperiode? = arbeidssokerperioder.minByOrNull { it.periode.fra }
 
-        return eldsteArbeidssokerperiode?.let { forespurtPeriode.fraOgMed(it.periode) } ?: false
+        return eldsteFormidlingsgruppeperiode?.let { forespurtPeriode.fraOgMed(it.periode) } ?: false
     }
 
-    fun asList(): List<Arbeidssokerperiode> {
+    fun asList(): List<Formidlingsgruppeperiode> {
         return arbeidssokerperioder
     }
 
-    fun eldsteFoerst(): List<Arbeidssokerperiode> {
+    fun eldsteFoerst(): List<Formidlingsgruppeperiode> {
         return arbeidssokerperioder.sortedBy{ it.periode.fra }
     }
 
@@ -43,7 +43,7 @@ class Arbeidssokerperioder(arbeidssokerperioder: List<Arbeidssokerperiode>?) {
     }
 
     companion object {
-        fun of(arbeidssokerperioder: List<Arbeidssokerperiode>?): Arbeidssokerperioder {
+        fun of(arbeidssokerperioder: List<Formidlingsgruppeperiode>?): Arbeidssokerperioder {
             return Arbeidssokerperioder(arbeidssokerperioder)
         }
     }

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/arbeidssoker/EldsteFoerst.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/arbeidssoker/EldsteFoerst.kt
@@ -2,8 +2,8 @@ package no.nav.fo.veilarbregistrering.arbeidssoker
 
 import java.util.Comparator
 
-class EldsteFoerst : Comparator<Arbeidssokerperiode> {
-    override fun compare(t0: Arbeidssokerperiode, t1: Arbeidssokerperiode): Int {
+class EldsteFoerst : Comparator<Formidlingsgruppeperiode> {
+    override fun compare(t0: Formidlingsgruppeperiode, t1: Formidlingsgruppeperiode): Int {
         return t0.periode.compareTo(t1.periode)
     }
 }

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/arbeidssoker/Formidlingsgruppeperiode.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/arbeidssoker/Formidlingsgruppeperiode.kt
@@ -3,8 +3,8 @@ package no.nav.fo.veilarbregistrering.arbeidssoker
 import no.nav.fo.veilarbregistrering.bruker.Periode
 import java.time.LocalDate
 
-data class Arbeidssokerperiode(val formidlingsgruppe: Formidlingsgruppe, val periode: Periode) {
-    fun tilOgMed(tilDato: LocalDate?): Arbeidssokerperiode {
+data class Formidlingsgruppeperiode(val formidlingsgruppe: Formidlingsgruppe, val periode: Periode) {
+    fun tilOgMed(tilDato: LocalDate?): Formidlingsgruppeperiode {
         return of(
             formidlingsgruppe,
             periode.tilOgMed(tilDato)
@@ -14,8 +14,8 @@ data class Arbeidssokerperiode(val formidlingsgruppe: Formidlingsgruppe, val per
     override fun toString() = "{formidlingsgruppe=$formidlingsgruppe, fraOgMed=${periode.fra}, tilOgMed=${periode.til}}"
 
     companion object {
-        fun of(formidlingsgruppe: Formidlingsgruppe, periode: Periode): Arbeidssokerperiode {
-            return Arbeidssokerperiode(formidlingsgruppe, periode)
+        fun of(formidlingsgruppe: Formidlingsgruppe, periode: Periode): Formidlingsgruppeperiode {
+            return Formidlingsgruppeperiode(formidlingsgruppe, periode)
         }
     }
 }

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/arbeidssoker/adapter/FormidlingsgruppeGatewayImpl.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/arbeidssoker/adapter/FormidlingsgruppeGatewayImpl.kt
@@ -1,6 +1,6 @@
 package no.nav.fo.veilarbregistrering.arbeidssoker.adapter
 
-import no.nav.fo.veilarbregistrering.arbeidssoker.Arbeidssokerperiode
+import no.nav.fo.veilarbregistrering.arbeidssoker.Formidlingsgruppeperiode
 import no.nav.fo.veilarbregistrering.arbeidssoker.Arbeidssokerperioder
 import no.nav.fo.veilarbregistrering.arbeidssoker.FormidlingsgruppeGateway
 import no.nav.fo.veilarbregistrering.bruker.Foedselsnummer
@@ -9,7 +9,7 @@ import no.nav.fo.veilarbregistrering.bruker.Periode
 class FormidlingsgruppeGatewayImpl(private val formidlingsgruppeRestClient: FormidlingsgruppeRestClient) :
     FormidlingsgruppeGateway {
     override fun finnArbeissokerperioder(foedselsnummer: Foedselsnummer, periode: Periode): Arbeidssokerperioder {
-        val arbeidssokerperioder: List<Arbeidssokerperiode> =
+        val arbeidssokerperioder: List<Formidlingsgruppeperiode> =
             formidlingsgruppeRestClient.hentFormidlingshistorikk(foedselsnummer, periode)
                 ?.let(FormidlingshistorikkMapper::map) ?: emptyList()
         return Arbeidssokerperioder(arbeidssokerperioder)

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/arbeidssoker/adapter/FormidlingshistorikkMapper.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/arbeidssoker/adapter/FormidlingshistorikkMapper.kt
@@ -1,15 +1,15 @@
 package no.nav.fo.veilarbregistrering.arbeidssoker.adapter
 
-import no.nav.fo.veilarbregistrering.arbeidssoker.Arbeidssokerperiode
+import no.nav.fo.veilarbregistrering.arbeidssoker.Formidlingsgruppeperiode
 import no.nav.fo.veilarbregistrering.arbeidssoker.Formidlingsgruppe
 import no.nav.fo.veilarbregistrering.bruker.Periode
 
 internal object FormidlingshistorikkMapper {
-    fun map(response: FormidlingsgruppeResponseDto): List<Arbeidssokerperiode> =
+    fun map(response: FormidlingsgruppeResponseDto): List<Formidlingsgruppeperiode> =
         response.formidlingshistorikk?.map(::map) ?: emptyList()
 
-    private fun map(formidlingshistorikkDto: FormidlingshistorikkDto): Arbeidssokerperiode {
-        return Arbeidssokerperiode(
+    private fun map(formidlingshistorikkDto: FormidlingshistorikkDto): Formidlingsgruppeperiode {
+        return Formidlingsgruppeperiode(
             Formidlingsgruppe(formidlingshistorikkDto.formidlingsgruppeKode),
             Periode(
                 formidlingshistorikkDto.fraDato,

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/arbeidssoker/resources/ArbeidssokerResource.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/arbeidssoker/resources/ArbeidssokerResource.kt
@@ -1,7 +1,7 @@
 package no.nav.fo.veilarbregistrering.arbeidssoker.resources
 
 import no.nav.fo.veilarbregistrering.arbeidssoker.ArbeidssokerService
-import no.nav.fo.veilarbregistrering.arbeidssoker.Arbeidssokerperiode
+import no.nav.fo.veilarbregistrering.arbeidssoker.Formidlingsgruppeperiode
 import no.nav.fo.veilarbregistrering.autorisasjon.AutorisasjonService
 import no.nav.fo.veilarbregistrering.bruker.Bruker
 import no.nav.fo.veilarbregistrering.bruker.Foedselsnummer
@@ -56,9 +56,9 @@ class ArbeidssokerResource(
         return map(arbeidssokerperiodes.eldsteFoerst())
     }
 
-    private fun map(arbeidssokerperioder: List<Arbeidssokerperiode>): ArbeidssokerperioderDto {
+    private fun map(arbeidssokerperioder: List<Formidlingsgruppeperiode>): ArbeidssokerperioderDto {
         val arbeidssokerperiodeDtoer = arbeidssokerperioder
-            .map { periode: Arbeidssokerperiode ->
+            .map { periode: Formidlingsgruppeperiode ->
                 ArbeidssokerperiodeDto(
                     periode.periode.fra.toString(),
                     periode.periode.til?.toString(),

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/db/arbeidssoker/ArbeidssokerperioderMapper.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/db/arbeidssoker/ArbeidssokerperioderMapper.kt
@@ -1,6 +1,6 @@
 package no.nav.fo.veilarbregistrering.db.arbeidssoker
 
-import no.nav.fo.veilarbregistrering.arbeidssoker.Arbeidssokerperiode
+import no.nav.fo.veilarbregistrering.arbeidssoker.Formidlingsgruppeperiode
 import no.nav.fo.veilarbregistrering.arbeidssoker.Arbeidssokerperioder
 import no.nav.fo.veilarbregistrering.arbeidssoker.EldsteFoerst
 import no.nav.fo.veilarbregistrering.arbeidssoker.Formidlingsgruppe
@@ -26,8 +26,8 @@ internal object ArbeidssokerperioderMapper {
             .values.flatMap { samtidigeEndringer -> if (samtidigeEndringer.size > 1) samtidigeEndringer.filter { !it.erISERV() } else samtidigeEndringer }
             .sortedWith(NyesteFoerst.nyesteFoerst())
 
-    private fun beholdKunSisteEndringPerDagIListen(formidlingsgruppeendringer: List<Formidlingsgruppeendring>): List<Arbeidssokerperiode> {
-        val arbeidssokerperioder: MutableList<Arbeidssokerperiode> = mutableListOf()
+    private fun beholdKunSisteEndringPerDagIListen(formidlingsgruppeendringer: List<Formidlingsgruppeendring>): List<Formidlingsgruppeperiode> {
+        val arbeidssokerperioder: MutableList<Formidlingsgruppeperiode> = mutableListOf()
 
         var forrigeEndretDato = LocalDate.MAX
         for (formidlingsgruppeendring in formidlingsgruppeendringer) {
@@ -36,7 +36,7 @@ internal object ArbeidssokerperioderMapper {
                 continue
             }
             arbeidssokerperioder.add(
-                Arbeidssokerperiode(
+                Formidlingsgruppeperiode(
                     Formidlingsgruppe(formidlingsgruppeendring.formidlingsgruppe),
                     Periode(
                         endretDato,
@@ -50,7 +50,7 @@ internal object ArbeidssokerperioderMapper {
         return arbeidssokerperioder
     }
 
-    private fun populerTilDatoMedNestePeriodesFraDatoMinusEn(arbeidssokerperioder: List<Arbeidssokerperiode>): List<Arbeidssokerperiode> =
+    private fun populerTilDatoMedNestePeriodesFraDatoMinusEn(arbeidssokerperioder: List<Formidlingsgruppeperiode>): List<Formidlingsgruppeperiode> =
         arbeidssokerperioder.mapIndexed { index, arbeidssokerperiode ->
             val forrigePeriodesFraDato = if (index > 0) arbeidssokerperioder[index - 1].periode.fra else null
             arbeidssokerperiode.tilOgMed(forrigePeriodesFraDato?.minusDays(1))

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/tidslinje/ArbeidssokerperiodeTidslinje.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/tidslinje/ArbeidssokerperiodeTidslinje.kt
@@ -1,16 +1,16 @@
 package no.nav.fo.veilarbregistrering.tidslinje
 
-import no.nav.fo.veilarbregistrering.arbeidssoker.Arbeidssokerperiode
+import no.nav.fo.veilarbregistrering.arbeidssoker.Formidlingsgruppeperiode
 import no.nav.fo.veilarbregistrering.bruker.Periode
 
-class ArbeidssokerperiodeTidslinje(private val arbeidssokerperioder: List<Arbeidssokerperiode>) : Tidslinje {
+class ArbeidssokerperiodeTidslinje(private val arbeidssokerperioder: List<Formidlingsgruppeperiode>) : Tidslinje {
 
     override fun tidslinje(): List<TidslinjeElement> =
         arbeidssokerperioder.map(::ArbeidssokerperiodeTidslinjeElement)
 
-    private class ArbeidssokerperiodeTidslinjeElement(private var arbeidssokerperiode: Arbeidssokerperiode) : TidslinjeElement {
+    private class ArbeidssokerperiodeTidslinjeElement(private var formidlingsgruppeperiode: Formidlingsgruppeperiode) : TidslinjeElement {
         override fun periode(): Periode {
-            return arbeidssokerperiode.periode
+            return formidlingsgruppeperiode.periode
         }
 
         override fun type(): Type {

--- a/src/test/kotlin/no/nav/fo/veilarbregistrering/arbeidssoker/ArbeidssokerServiceHentArbeidssokerperioderTest.kt
+++ b/src/test/kotlin/no/nav/fo/veilarbregistrering/arbeidssoker/ArbeidssokerServiceHentArbeidssokerperioderTest.kt
@@ -39,10 +39,10 @@ class ArbeidssokerServiceHentArbeidssokerperioderTest {
         )
         val arbeidssokerperiodes = arbeidssokerService.hentArbeidssokerperioder(BRUKER_3, forespurtPeriode)
         assertThat(arbeidssokerperiodes.eldsteFoerst()).containsExactly(
-            StubArbeidssokerRepository.ARBEIDSSOKERPERIODE_1,
-            StubArbeidssokerRepository.ARBEIDSSOKERPERIODE_2,
-            StubArbeidssokerRepository.ARBEIDSSOKERPERIODE_3,
-            StubArbeidssokerRepository.ARBEIDSSOKERPERIODE_4
+            StubArbeidssokerRepository.FORMIDLINGSGRUPPEPERIODE_1,
+            StubArbeidssokerRepository.FORMIDLINGSGRUPPEPERIODE_2,
+            StubArbeidssokerRepository.FORMIDLINGSGRUPPEPERIODE_3,
+            StubArbeidssokerRepository.FORMIDLINGSGRUPPEPERIODE_4
         )
     }
 
@@ -54,11 +54,11 @@ class ArbeidssokerServiceHentArbeidssokerperioderTest {
         )
         val arbeidssokerperiodes = arbeidssokerService.hentArbeidssokerperioder(BRUKER_3, forespurtPeriode)
         assertThat(arbeidssokerperiodes.eldsteFoerst()).containsExactly(
-            StubFormidlingsgruppeGateway.ARBEIDSSOKERPERIODE_0,
-            StubFormidlingsgruppeGateway.ARBEIDSSOKERPERIODE_1,
-            StubFormidlingsgruppeGateway.ARBEIDSSOKERPERIODE_2,
-            StubFormidlingsgruppeGateway.ARBEIDSSOKERPERIODE_3,
-            StubFormidlingsgruppeGateway.ARBEIDSSOKERPERIODE_4
+            StubFormidlingsgruppeGateway.FORMIDLINGSGRUPPEPERIODE_0,
+            StubFormidlingsgruppeGateway.FORMIDLINGSGRUPPEPERIODE_1,
+            StubFormidlingsgruppeGateway.FORMIDLINGSGRUPPEPERIODE_2,
+            StubFormidlingsgruppeGateway.FORMIDLINGSGRUPPEPERIODE_3,
+            StubFormidlingsgruppeGateway.FORMIDLINGSGRUPPEPERIODE_4
         )
     }
 
@@ -99,11 +99,11 @@ class ArbeidssokerServiceHentArbeidssokerperioderTest {
         )
         val arbeidssokerperioder = arbeidssokerService.hentArbeidssokerperioder(bruker, forespurtPeriode)
         assertThat(arbeidssokerperioder.eldsteFoerst()).containsExactly(
-            StubArbeidssokerRepository.ARBEIDSSOKERPERIODE_3,
-            StubArbeidssokerRepository.ARBEIDSSOKERPERIODE_4,
-            StubArbeidssokerRepository.ARBEIDSSOKERPERIODE_5,
-            StubArbeidssokerRepository.ARBEIDSSOKERPERIODE_6,
-            StubArbeidssokerRepository.ARBEIDSSOKERPERIODE_7
+            StubArbeidssokerRepository.FORMIDLINGSGRUPPEPERIODE_3,
+            StubArbeidssokerRepository.FORMIDLINGSGRUPPEPERIODE_4,
+            StubArbeidssokerRepository.FORMIDLINGSGRUPPEPERIODE_5,
+            StubArbeidssokerRepository.FORMIDLINGSGRUPPEPERIODE_6,
+            StubArbeidssokerRepository.FORMIDLINGSGRUPPEPERIODE_7
         )
     }
 
@@ -119,11 +119,11 @@ class ArbeidssokerServiceHentArbeidssokerperioderTest {
         )
         val arbeidssokerperioder = arbeidssokerService.hentArbeidssokerperioder(BRUKER_1, forespurtPeriode)
         assertThat(arbeidssokerperioder.eldsteFoerst()).containsExactly(
-            StubFormidlingsgruppeGateway.ARBEIDSSOKERPERIODE_1,
-            StubFormidlingsgruppeGateway.ARBEIDSSOKERPERIODE_2,
-            StubFormidlingsgruppeGateway.ARBEIDSSOKERPERIODE_3,
-            StubFormidlingsgruppeGateway.ARBEIDSSOKERPERIODE_4,
-            StubFormidlingsgruppeGateway.ARBEIDSSOKERPERIODE_5
+            StubFormidlingsgruppeGateway.FORMIDLINGSGRUPPEPERIODE_1,
+            StubFormidlingsgruppeGateway.FORMIDLINGSGRUPPEPERIODE_2,
+            StubFormidlingsgruppeGateway.FORMIDLINGSGRUPPEPERIODE_3,
+            StubFormidlingsgruppeGateway.FORMIDLINGSGRUPPEPERIODE_4,
+            StubFormidlingsgruppeGateway.FORMIDLINGSGRUPPEPERIODE_5
         )
     }
 
@@ -139,8 +139,8 @@ class ArbeidssokerServiceHentArbeidssokerperioderTest {
         )
         val arbeidssokerperioder = arbeidssokerService.hentArbeidssokerperioder(BRUKER_2, forespurtPeriode)
         assertThat(arbeidssokerperioder.eldsteFoerst()).containsExactly(
-            StubArbeidssokerRepository.ARBEIDSSOKERPERIODE_9,
-            StubArbeidssokerRepository.ARBEIDSSOKERPERIODE_10,
+            StubArbeidssokerRepository.FORMIDLINGSGRUPPEPERIODE_9,
+            StubArbeidssokerRepository.FORMIDLINGSGRUPPEPERIODE_10,
         )
     }
 
@@ -153,63 +153,63 @@ class ArbeidssokerServiceHentArbeidssokerperioderTest {
             return mapOf(
                 FOEDSELSNUMMER_3 to Arbeidssokerperioder(
                     listOf(
-                        ARBEIDSSOKERPERIODE_3,
-                        ARBEIDSSOKERPERIODE_1,
-                        ARBEIDSSOKERPERIODE_4,
-                        ARBEIDSSOKERPERIODE_2,
-                        ARBEIDSSOKERPERIODE_6,
-                        ARBEIDSSOKERPERIODE_5,
-                        ARBEIDSSOKERPERIODE_7,
-                        ARBEIDSSOKERPERIODE_8,
+                        FORMIDLINGSGRUPPEPERIODE_3,
+                        FORMIDLINGSGRUPPEPERIODE_1,
+                        FORMIDLINGSGRUPPEPERIODE_4,
+                        FORMIDLINGSGRUPPEPERIODE_2,
+                        FORMIDLINGSGRUPPEPERIODE_6,
+                        FORMIDLINGSGRUPPEPERIODE_5,
+                        FORMIDLINGSGRUPPEPERIODE_7,
+                        FORMIDLINGSGRUPPEPERIODE_8,
                     )
                 ),
                 FOEDSELSNUMMER_4 to Arbeidssokerperioder(
                     listOf(
-                        ARBEIDSSOKERPERIODE_9,
-                        ARBEIDSSOKERPERIODE_10,
+                        FORMIDLINGSGRUPPEPERIODE_9,
+                        FORMIDLINGSGRUPPEPERIODE_10,
                     ),
                 )
             ).entries.first { (fnr, _) -> fnr in foedselsnummerList }.value
         }
 
         companion object {
-            val ARBEIDSSOKERPERIODE_1 = Arbeidssokerperiode(
+            val FORMIDLINGSGRUPPEPERIODE_1 = Formidlingsgruppeperiode(
                 Formidlingsgruppe("ARBS"),
                 Periode(LocalDate.of(2020, 1, 1), LocalDate.of(2020, 1, 31))
             )
-            val ARBEIDSSOKERPERIODE_2 = Arbeidssokerperiode(
+            val FORMIDLINGSGRUPPEPERIODE_2 = Formidlingsgruppeperiode(
                 Formidlingsgruppe("ARBS"),
                 Periode(LocalDate.of(2020, 2, 1), LocalDate.of(2020, 2, 29))
             )
-            val ARBEIDSSOKERPERIODE_3 = Arbeidssokerperiode(
+            val FORMIDLINGSGRUPPEPERIODE_3 = Formidlingsgruppeperiode(
                 Formidlingsgruppe("ARBS"),
                 Periode(LocalDate.of(2020, 3, 1), LocalDate.of(2020, 3, 31))
             )
-            val ARBEIDSSOKERPERIODE_4 = Arbeidssokerperiode(
+            val FORMIDLINGSGRUPPEPERIODE_4 = Formidlingsgruppeperiode(
                 Formidlingsgruppe("ARBS"),
                 Periode(LocalDate.of(2020, 4, 1), LocalDate.of(2020, 5, 2))
             )
-            val ARBEIDSSOKERPERIODE_5 = Arbeidssokerperiode(
+            val FORMIDLINGSGRUPPEPERIODE_5 = Formidlingsgruppeperiode(
                 Formidlingsgruppe("ARBS"),
                 Periode(LocalDate.of(2020, 5, 3), LocalDate.of(2020, 5, 9))
             )
-            val ARBEIDSSOKERPERIODE_6 = Arbeidssokerperiode(
+            val FORMIDLINGSGRUPPEPERIODE_6 = Formidlingsgruppeperiode(
                 Formidlingsgruppe("ARBS"),
                 Periode(LocalDate.of(2020, 5, 10), LocalDate.of(2020, 5, 29))
             )
-            val ARBEIDSSOKERPERIODE_7 = Arbeidssokerperiode(
+            val FORMIDLINGSGRUPPEPERIODE_7 = Formidlingsgruppeperiode(
                 Formidlingsgruppe("ARBS"),
                 Periode(LocalDate.of(2020, 5, 30), LocalDate.of(2020, 6, 30))
             )
-            val ARBEIDSSOKERPERIODE_8 = Arbeidssokerperiode(
+            val FORMIDLINGSGRUPPEPERIODE_8 = Formidlingsgruppeperiode(
                 Formidlingsgruppe("ARBS"),
                 Periode(LocalDate.of(2020, 7, 1), null)
             )
-            val ARBEIDSSOKERPERIODE_9 = Arbeidssokerperiode(
+            val FORMIDLINGSGRUPPEPERIODE_9 = Formidlingsgruppeperiode(
                 Formidlingsgruppe("ARBS"),
                 Periode(LocalDate.of(2021, 1, 15), LocalDate.of(2021, 10, 5))
             )
-            val ARBEIDSSOKERPERIODE_10 = Arbeidssokerperiode(
+            val FORMIDLINGSGRUPPEPERIODE_10 = Formidlingsgruppeperiode(
                 Formidlingsgruppe("ARBS"),
                 Periode(LocalDate.of(2021, 10, 17), null)
             )
@@ -221,13 +221,13 @@ class ArbeidssokerServiceHentArbeidssokerperioderTest {
             val map: Map<Foedselsnummer, Arbeidssokerperioder> = mapOf(
                 FOEDSELSNUMMER_3 to Arbeidssokerperioder(
                     listOf(
-                        ARBEIDSSOKERPERIODE_2,
-                        ARBEIDSSOKERPERIODE_4,
-                        ARBEIDSSOKERPERIODE_3,
-                        ARBEIDSSOKERPERIODE_0,
-                        ARBEIDSSOKERPERIODE_1,
-                        ARBEIDSSOKERPERIODE_5,
-                        ARBEIDSSOKERPERIODE_6
+                        FORMIDLINGSGRUPPEPERIODE_2,
+                        FORMIDLINGSGRUPPEPERIODE_4,
+                        FORMIDLINGSGRUPPEPERIODE_3,
+                        FORMIDLINGSGRUPPEPERIODE_0,
+                        FORMIDLINGSGRUPPEPERIODE_1,
+                        FORMIDLINGSGRUPPEPERIODE_5,
+                        FORMIDLINGSGRUPPEPERIODE_6
                     )
                 ),
                 FOEDSELSNUMMER_4 to Arbeidssokerperioder(emptyList())
@@ -236,31 +236,31 @@ class ArbeidssokerServiceHentArbeidssokerperioderTest {
         }
 
         companion object {
-            val ARBEIDSSOKERPERIODE_0 = Arbeidssokerperiode(
+            val FORMIDLINGSGRUPPEPERIODE_0 = Formidlingsgruppeperiode(
                 Formidlingsgruppe("ARBS"),
                 Periode(LocalDate.of(2019, 12, 1), LocalDate.of(2019, 12, 31))
             )
-            val ARBEIDSSOKERPERIODE_1 = Arbeidssokerperiode(
+            val FORMIDLINGSGRUPPEPERIODE_1 = Formidlingsgruppeperiode(
                 Formidlingsgruppe("ARBS"),
                 Periode(LocalDate.of(2020, 1, 1), LocalDate.of(2020, 1, 31))
             )
-            val ARBEIDSSOKERPERIODE_2 = Arbeidssokerperiode(
+            val FORMIDLINGSGRUPPEPERIODE_2 = Formidlingsgruppeperiode(
                 Formidlingsgruppe("ARBS"),
                 Periode(LocalDate.of(2020, 2, 1), LocalDate.of(2020, 2, 29))
             )
-            val ARBEIDSSOKERPERIODE_3 = Arbeidssokerperiode(
+            val FORMIDLINGSGRUPPEPERIODE_3 = Formidlingsgruppeperiode(
                 Formidlingsgruppe("ARBS"),
                 Periode(LocalDate.of(2020, 3, 1), LocalDate.of(2020, 3, 31))
             )
-            val ARBEIDSSOKERPERIODE_4 = Arbeidssokerperiode(
+            val FORMIDLINGSGRUPPEPERIODE_4 = Formidlingsgruppeperiode(
                 Formidlingsgruppe("ARBS"),
                 Periode(LocalDate.of(2020, 4, 1), LocalDate.of(2020, 5, 2))
             )
-            val ARBEIDSSOKERPERIODE_5 = Arbeidssokerperiode(
+            val FORMIDLINGSGRUPPEPERIODE_5 = Formidlingsgruppeperiode(
                 Formidlingsgruppe("ARBS"),
                 Periode(LocalDate.of(2020, 5, 3), LocalDate.of(2020, 5, 9))
             )
-            val ARBEIDSSOKERPERIODE_6 = Arbeidssokerperiode(
+            val FORMIDLINGSGRUPPEPERIODE_6 = Formidlingsgruppeperiode(
                 Formidlingsgruppe("ARBS"),
                 Periode(LocalDate.of(2020, 5, 10), null)
             )

--- a/src/test/kotlin/no/nav/fo/veilarbregistrering/arbeidssoker/ArbeidssokerperiodeAvsluttetServiceTest.kt
+++ b/src/test/kotlin/no/nav/fo/veilarbregistrering/arbeidssoker/ArbeidssokerperiodeAvsluttetServiceTest.kt
@@ -92,19 +92,19 @@ internal class ArbeidssokerperiodeAvsluttetServiceTest {
     }
 
     companion object {
-        val AVSLUTTET_ARBS = Arbeidssokerperiode(
+        val AVSLUTTET_ARBS = Formidlingsgruppeperiode(
             Formidlingsgruppe("ARBS"),
             Periode(LocalDate.of(2020, 1, 1), LocalDate.of(2020, 1, 31))
         )
-        val AVSLUTTET_IARBS = Arbeidssokerperiode(
+        val AVSLUTTET_IARBS = Formidlingsgruppeperiode(
             Formidlingsgruppe("IARBS"),
             Periode(LocalDate.of(2020, 1, 1), LocalDate.of(2020, 1, 31))
         )
-        val NÅVÆRENDE_ARBS = Arbeidssokerperiode(
+        val NÅVÆRENDE_ARBS = Formidlingsgruppeperiode(
             Formidlingsgruppe("ARBS"),
             Periode(LocalDate.of(2020, 2, 1), null)
         )
-        val NÅVÆRENDE_IARBS = Arbeidssokerperiode(
+        val NÅVÆRENDE_IARBS = Formidlingsgruppeperiode(
             Formidlingsgruppe("IARBS"),
             Periode(LocalDate.of(2020, 3, 1), null)
         )

--- a/src/test/kotlin/no/nav/fo/veilarbregistrering/arbeidssoker/ArbeidssokerperiodeTestdataBuilder.kt
+++ b/src/test/kotlin/no/nav/fo/veilarbregistrering/arbeidssoker/ArbeidssokerperiodeTestdataBuilder.kt
@@ -4,11 +4,11 @@ import no.nav.fo.veilarbregistrering.bruker.Periode
 import java.time.LocalDate
 
 class ArbeidssokerperiodeTestdataBuilder private constructor(private val formidlingsgruppe: Formidlingsgruppe) :
-    Builder<Arbeidssokerperiode> {
+    Builder<Formidlingsgruppeperiode> {
     private var fra: LocalDate? = null
     private var til: LocalDate? = null
-    override fun build(): Arbeidssokerperiode {
-        return Arbeidssokerperiode(formidlingsgruppe, Periode.gyldigPeriode(fra, til))
+    override fun build(): Formidlingsgruppeperiode {
+        return Formidlingsgruppeperiode(formidlingsgruppe, Periode.gyldigPeriode(fra, til))
     }
 
     fun fra(fra: LocalDate?): ArbeidssokerperiodeTestdataBuilder {

--- a/src/test/kotlin/no/nav/fo/veilarbregistrering/arbeidssoker/ArbeidssokerperioderTest.kt
+++ b/src/test/kotlin/no/nav/fo/veilarbregistrering/arbeidssoker/ArbeidssokerperioderTest.kt
@@ -13,7 +13,7 @@ class ArbeidssokerperioderTest {
     fun `gitt at forespurt periode starter etter eldste periode dekkes hele`() {
         val arbeidssokerperioder = Arbeidssokerperioder(
             listOf(
-                ARBEIDSSOKERPERIODE_2
+                Formidlingsgruppeperiode_2
             )
         )
         val forespurtPeriode = Periode(
@@ -27,7 +27,7 @@ class ArbeidssokerperioderTest {
     fun `gitt at forespurt periode starter før eldste periode dekkes ikke hele`() {
         val arbeidssokerperioder = Arbeidssokerperioder(
             listOf(
-                ARBEIDSSOKERPERIODE_2
+                Formidlingsgruppeperiode_2
             )
         )
         val forespurtPeriode = Periode(
@@ -41,7 +41,7 @@ class ArbeidssokerperioderTest {
     fun `gitt at forespurt periode starter samme dag som eldste periode dekkes hele perioden`() {
         val arbeidssokerperioder = Arbeidssokerperioder(
             listOf(
-                ARBEIDSSOKERPERIODE_2
+                Formidlingsgruppeperiode_2
             )
         )
         val forespurtPeriode = Periode(
@@ -55,7 +55,7 @@ class ArbeidssokerperioderTest {
     fun `gitt at forespurt periode slutter dagen etter siste periode`() {
         val arbeidssokerperioder = Arbeidssokerperioder(
             listOf(
-                ARBEIDSSOKERPERIODE_1
+                Formidlingsgruppeperiode_1
             )
         )
         val forespurtPeriode = Periode(
@@ -93,11 +93,11 @@ class ArbeidssokerperioderTest {
     }
 
     companion object {
-        private val ARBEIDSSOKERPERIODE_1 = Arbeidssokerperiode(
+        private val Formidlingsgruppeperiode_1 = Formidlingsgruppeperiode(
             Formidlingsgruppe("ISERV"),
             Periode(LocalDate.of(2016, 9, 24), null)
         )
-        private val ARBEIDSSOKERPERIODE_2 = Arbeidssokerperiode(
+        private val Formidlingsgruppeperiode_2 = Formidlingsgruppeperiode(
             Formidlingsgruppe("ARBS"),
             Periode(LocalDate.of(2020, 1, 1), null)
         )

--- a/src/test/kotlin/no/nav/fo/veilarbregistrering/arbeidssoker/ArbeidssokerperioderTestdataBuilder.kt
+++ b/src/test/kotlin/no/nav/fo/veilarbregistrering/arbeidssoker/ArbeidssokerperioderTestdataBuilder.kt
@@ -1,7 +1,7 @@
 package no.nav.fo.veilarbregistrering.arbeidssoker
 
 class ArbeidssokerperioderTestdataBuilder private constructor() {
-    private val arbeidssokerperioder: MutableList<Arbeidssokerperiode>
+    private val arbeidssokerperioder: MutableList<Formidlingsgruppeperiode>
     fun periode(arbeidssokerperiode: ArbeidssokerperiodeTestdataBuilder): ArbeidssokerperioderTestdataBuilder {
         arbeidssokerperioder.add(arbeidssokerperiode.build())
         return this
@@ -11,8 +11,8 @@ class ArbeidssokerperioderTestdataBuilder private constructor() {
         return Arbeidssokerperioder(arbeidssokerperioder)
     }
 
-    fun arbeidssokerperiode(arbeidssokerperiode: Builder<Arbeidssokerperiode>): ArbeidssokerperioderTestdataBuilder {
-        arbeidssokerperioder.add(arbeidssokerperiode.build())
+    fun arbeidssokerperiode(formidlingsgruppeperiode: Builder<Formidlingsgruppeperiode>): ArbeidssokerperioderTestdataBuilder {
+        arbeidssokerperioder.add(formidlingsgruppeperiode.build())
         return this
     }
 

--- a/src/test/kotlin/no/nav/fo/veilarbregistrering/arbeidssoker/adapter/FormidlingshistorikkMapperTest.kt
+++ b/src/test/kotlin/no/nav/fo/veilarbregistrering/arbeidssoker/adapter/FormidlingshistorikkMapperTest.kt
@@ -1,6 +1,6 @@
 package no.nav.fo.veilarbregistrering.arbeidssoker.adapter
 
-import no.nav.fo.veilarbregistrering.arbeidssoker.Arbeidssokerperiode
+import no.nav.fo.veilarbregistrering.arbeidssoker.Formidlingsgruppeperiode
 import no.nav.fo.veilarbregistrering.arbeidssoker.Formidlingsgruppe
 import no.nav.fo.veilarbregistrering.bruker.Periode
 import org.assertj.core.api.Assertions.assertThat
@@ -46,14 +46,14 @@ class FormidlingshistorikkMapperTest {
         val liste = FormidlingshistorikkMapper.map(response)
         assertThat(liste).hasSize(4)
         assertThat(liste).contains(
-            Arbeidssokerperiode(
+            Formidlingsgruppeperiode(
                 Formidlingsgruppe("ISERV"),
                 Periode(
                     LocalDate.of(2020, 2, 21),
                     LocalDate.of(2020, 3, 11)
                 )
             ),
-            Arbeidssokerperiode(
+            Formidlingsgruppeperiode(
                 Formidlingsgruppe("ARBS"),
                 Periode(
                     LocalDate.of(2020, 3, 12),

--- a/src/test/kotlin/no/nav/fo/veilarbregistrering/db/arbeidssoker/ArbeidssokerRepositoryDbIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/fo/veilarbregistrering/db/arbeidssoker/ArbeidssokerRepositoryDbIntegrationTest.kt
@@ -39,8 +39,8 @@ class ArbeidssokerRepositoryDbIntegrationTest(
         val id = arbeidssokerRepository.lagre(command)
         Assertions.assertThat(id).isNotNull
         val arbeidssokerperiodes = arbeidssokerRepository.finnFormidlingsgrupper(listOf(FOEDSELSNUMMER))
-        val arbeidssokerperiode = Arbeidssokerperiode.of(Formidlingsgruppe("ARBS"), Periode(LocalDate.now(), null))
-        Assertions.assertThat(arbeidssokerperiodes.asList()).containsOnly(arbeidssokerperiode)
+        val formidlingsgruppeperiode = Formidlingsgruppeperiode.of(Formidlingsgruppe("ARBS"), Periode(LocalDate.now(), null))
+        Assertions.assertThat(arbeidssokerperiodes.asList()).containsOnly(formidlingsgruppeperiode)
     }
 
     @Test

--- a/src/test/kotlin/no/nav/fo/veilarbregistrering/db/arbeidssoker/ArbeidssokerperioderMapperTest.kt
+++ b/src/test/kotlin/no/nav/fo/veilarbregistrering/db/arbeidssoker/ArbeidssokerperioderMapperTest.kt
@@ -1,6 +1,6 @@
 package no.nav.fo.veilarbregistrering.db.arbeidssoker
 
-import no.nav.fo.veilarbregistrering.arbeidssoker.Arbeidssokerperiode
+import no.nav.fo.veilarbregistrering.arbeidssoker.Formidlingsgruppeperiode
 import no.nav.fo.veilarbregistrering.arbeidssoker.Arbeidssokerperioder
 import no.nav.fo.veilarbregistrering.arbeidssoker.Formidlingsgruppe
 import no.nav.fo.veilarbregistrering.bruker.Periode
@@ -228,12 +228,12 @@ class ArbeidssokerperioderMapperTest {
             )
         )
 
-        val iservAktiv = Arbeidssokerperiode.of(
+        val iservAktiv = Formidlingsgruppeperiode.of(
             Formidlingsgruppe("ISERV"),
             Periode(LocalDate.of(2019, 3, 6), LocalDate.of(2019, 12, 8))
         )
         val arbsAktiv =
-            Arbeidssokerperiode.of(Formidlingsgruppe("ARBS"), Periode(LocalDate.of(2019, 12, 9), null))
+            Formidlingsgruppeperiode.of(Formidlingsgruppe("ARBS"), Periode(LocalDate.of(2019, 12, 9), null))
         Assertions.assertThat(arbeidssokerperioder.asList()).containsExactly(
             iservAktiv,
             arbsAktiv
@@ -268,11 +268,11 @@ class ArbeidssokerperioderMapperTest {
             )
         )
 
-        var arbs1 = Arbeidssokerperiode.of(
+        var arbs1 = Formidlingsgruppeperiode.of(
             Formidlingsgruppe("ARBS"),
             Periode(LocalDate.of(2020, 8, 14), LocalDate.of(2020, 9, 8))
         )
-        val arbs2 = Arbeidssokerperiode.of(Formidlingsgruppe("ARBS"), Periode(LocalDate.of(2020, 9, 9), null))
+        val arbs2 = Formidlingsgruppeperiode.of(Formidlingsgruppe("ARBS"), Periode(LocalDate.of(2020, 9, 9), null))
         Assertions.assertThat(arbeidssokerperioder.asList()).containsExactly(
             arbs1,
             arbs2
@@ -293,7 +293,7 @@ class ArbeidssokerperioderMapperTest {
             )
         )
 
-        arbs1 = Arbeidssokerperiode.of(Formidlingsgruppe("ARBS"), Periode(LocalDate.of(2020, 8, 14), null))
+        arbs1 = Formidlingsgruppeperiode.of(Formidlingsgruppe("ARBS"), Periode(LocalDate.of(2020, 8, 14), null))
         Assertions.assertThat(arbeidssokerperioder.asList()).containsExactly(
             arbs1
         )
@@ -308,7 +308,7 @@ class ArbeidssokerperioderMapperTest {
             )
         )
 
-        arbs1 = Arbeidssokerperiode.of(Formidlingsgruppe("ARBS"), Periode(LocalDate.of(2020, 8, 14), null))
+        arbs1 = Formidlingsgruppeperiode.of(Formidlingsgruppe("ARBS"), Periode(LocalDate.of(2020, 8, 14), null))
         Assertions.assertThat(arbeidssokerperioder.asList()).containsExactly(
             arbs1
         )
@@ -341,11 +341,11 @@ class ArbeidssokerperioderMapperTest {
             )
         )
 
-        val arbs1 = Arbeidssokerperiode.of(
+        val arbs1 = Formidlingsgruppeperiode.of(
             Formidlingsgruppe("IARBS"),
             Periode(LocalDate.of(2020, 8, 14), LocalDate.of(2020, 9, 8))
         )
-        val arbs2 = Arbeidssokerperiode.of(Formidlingsgruppe("IARBS"), Periode(LocalDate.of(2020, 9, 9), null))
+        val arbs2 = Formidlingsgruppeperiode.of(Formidlingsgruppe("IARBS"), Periode(LocalDate.of(2020, 9, 9), null))
         Assertions.assertThat(arbeidssokerperioder.asList()).containsExactly(
             arbs1,
             arbs2


### PR DESCRIPTION
Arbeidssokerperiode inneholder info om formidlingsgruppe og når denne ble startet og avsluttet.
Formidlingsgruppa kan være ARBS (dvs. arbeidssøker), men den kan også være IARBS eller ISERV,
så navnet Arbeidssøkerperiode er litt misvisende, siden det også kan være snakk om en periode hvor
brukeren ikke er arbeidssøker.

Det fins fortsatt andre klasser som bruker Arbeidssokerperiode-begrepet,
men tar dette som en første del så det ikke blir altfor mye endringer på en gang.