### PR TITLE
Refaktorering + fjerner unødvendig sjekk av formidlingsgruppe

### DIFF
--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/arbeidssoker/ArbeidssokerperiodeAvsluttetService.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/arbeidssoker/ArbeidssokerperiodeAvsluttetService.kt
@@ -8,27 +8,15 @@ class ArbeidssokerperiodeAvsluttetService(
         endretFormidlingsgruppeCommand: EndretFormidlingsgruppeCommand,
         arbeidssokerperioder: Arbeidssokerperioder
     ) {
-        if (erAvslutningAvArbeidssokerperiode(endretFormidlingsgruppeCommand, arbeidssokerperioder)) {
-            val sistePeriode = arbeidssokerperioder.eldsteFoerst().last()
-            arbeidssokerperiodeAvsluttetProducer.publiserArbeidssokerperiodeAvsluttet(endretFormidlingsgruppeCommand, sistePeriode)
-        }
-    }
-
-    private fun erAvslutningAvArbeidssokerperiode(
-        endretFormidlingsgruppeCommand: EndretFormidlingsgruppeCommand,
-        arbeidssokerperioder: Arbeidssokerperioder
-    ): Boolean {
-        if (arbeidssokerperioder.asList().isEmpty()) return false
         endretFormidlingsgruppeCommand.foedselsnummer?.let {
-            val sistePeriode = arbeidssokerperioder.eldsteFoerst().last()
-            if (harNaavaerendePeriodeMedARBS(sistePeriode) && endretFormidlingsgruppeCommand.formidlingsgruppe.kode != "ARBS") {
-                return true
+            arbeidssokerperioder.nyestePeriode()?.let {
+                if (it.erGjeldende() && endretFormidlingsgruppeCommand.formidlingsgruppe.kode != "ARBS") {
+                    arbeidssokerperiodeAvsluttetProducer.publiserArbeidssokerperiodeAvsluttet(
+                        endretFormidlingsgruppeCommand,
+                        it
+                    )
+                }
             }
-            return false
         }
-        return false
     }
-
-    private fun harNaavaerendePeriodeMedARBS(sistePeriode: Arbeidssokerperiode): Boolean =
-        sistePeriode.formidlingsgruppe.kode == "ARBS" && sistePeriode.erGjeldende()
 }

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/arbeidssoker/Arbeidssokerperioder.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/arbeidssoker/Arbeidssokerperioder.kt
@@ -23,6 +23,10 @@ class Arbeidssokerperioder(arbeidssokerperioder: List<Arbeidssokerperiode>?) {
         return arbeidssokerperioder
     }
 
+    fun nyestePeriode(): Arbeidssokerperiode? {
+        return this.eldsteFoerst().lastOrNull()
+    }
+
     fun eldsteFoerst(): List<Arbeidssokerperiode> {
         return arbeidssokerperioder.sortedBy{ it.periode.fra }
     }


### PR DESCRIPTION
Arbeidssokerperioder er kun perioder med formidlingsgruppe ARBS. 
Andre grupper filtreres bort med en gang vi henter og mapper om periodene fra databasen.
Fjerner derfor sjekken for om nåværende periode er ARBS.