### PR TITLE
Oppgrader til java 17

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,10 +27,10 @@ jobs:
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
         restore-keys: ${{ runner.os }}-maven-
 
-    - name: Set up JDK 11
+    - name: Set up JDK 17
       uses: actions/setup-java@v2
       with:
-        java-version: 11
+        java-version: 17
         distribution: 'adopt'
 
     - name: Build with Maven

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,7 +53,7 @@ jobs:
     name: Deploy to dev FSS
     needs: test-build-and-push
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/oppgradering'
+    if: github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v1
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,7 +53,7 @@ jobs:
     name: Deploy to dev FSS
     needs: test-build-and-push
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/oppgradering'
     steps:
       - uses: actions/checkout@v1
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,2 @@
-FROM ghcr.io/navikt/pus-nais-java-app/pus-nais-java-app:java11
+FROM ghcr.io/navikt/pus-nais-java-app/pus-nais-java-app:java17
 COPY /target/veilarbregistrering.jar app.jar

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     </repositories>
 
     <properties>
-        <java.version>11</java.version>
+        <java.version>17</java.version>
         <kotlin.version>1.7.10</kotlin.version>
         <kotlin.compiler.incremental>true</kotlin.compiler.incremental>
         <common.version>2.2022.07.01_07.12-6a0864fa6938</common.version>
@@ -150,7 +150,7 @@
         <dependency>
             <groupId>com.zaxxer</groupId>
             <artifactId>HikariCP</artifactId>
-            <version>2.7.9</version>
+            <version>5.0.1</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@
         <dependency>
             <groupId>com.zaxxer</groupId>
             <artifactId>HikariCP</artifactId>
-            <version>5.0.1</version>
+            <version>2.7.9</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Java-versjoner > 14 på linux-systemer har nanosekund-presisjon på timestamps. Dette skaper trøbbel når vi sammenligner timestamps opprettet i koden med timestamps fra databasen, fordi databasen har presisjon opp til mikrosekunder. Derfor lagrer vi timestamp for `FORMIDLINGSGRUPPE_ENDRET` i databasen med mikrosekundpresisjon, slik at dette ikke blir et problem. Har gått gjennom alle tabellene som har timestamp-kolonner og sjekket at det ikke gjøres sammenligninger med timestamps i de tilsvarende repository-klassene. 