### PR TITLE
Hent arbeidssøkerperioder med nivå3-innlogging

### DIFF
--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/arbeidssoker/resources/ArbeidssokerApi.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/arbeidssoker/resources/ArbeidssokerApi.kt
@@ -6,9 +6,6 @@ import io.swagger.v3.oas.annotations.parameters.RequestBody
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
-import org.springframework.format.annotation.DateTimeFormat
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.RequestParam
 import java.time.LocalDate
 
 @Tag(name = "ArbeidssokerResource")
@@ -43,8 +40,16 @@ interface ArbeidssokerApi {
             @Parameter(description = "Til og med dato") tilOgMed: LocalDate?
     ): ArbeidssokerperioderDto
 
+    @Operation(summary = "Henter alle perioder hvor bruker er registrert som arbeidssøker. Denne skal kun brukes av personbrukere og støtter innlogging med nivå 3.")
+    @ApiResponses(
+        ApiResponse(responseCode = "200", description = "Ok"),
+        ApiResponse(responseCode = "400", description = "Ugyldig periode - fra og med dato må være før til dato"),
+        ApiResponse(responseCode = "401", description = "Unauthorized - bruker er ikke autorisert"),
+        ApiResponse(responseCode = "403", description = "Forbidden - ingen tilgang"),
+        ApiResponse(responseCode = "500", description = "Ukjent feil")
+    )
     fun hentArbeidssokerperioderMedNivå3(
-        @RequestParam(value = "fraOgMed") @DateTimeFormat(pattern = "yyyy-MM-dd") fraOgMed: LocalDate,
-        @RequestParam(required = false, value = "tilOgMed") @DateTimeFormat(pattern = "yyyy-MM-dd") tilOgMed: LocalDate?
+        @Parameter(required = true, description = "Fra og med dato") fraOgMed: LocalDate,
+        @Parameter(description = "Til og med dato") tilOgMed: LocalDate?
     ): ArbeidssokerperioderDto
 }

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/arbeidssoker/resources/ArbeidssokerApi.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/arbeidssoker/resources/ArbeidssokerApi.kt
@@ -6,6 +6,9 @@ import io.swagger.v3.oas.annotations.parameters.RequestBody
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.format.annotation.DateTimeFormat
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestParam
 import java.time.LocalDate
 
 @Tag(name = "ArbeidssokerResource")
@@ -38,5 +41,10 @@ interface ArbeidssokerApi {
             @RequestBody(description = "Fødselsnummer") fnr: Fnr?,
             @Parameter(required = true, description = "Fra og med dato") fraOgMed: LocalDate,
             @Parameter(description = "Til og med dato") tilOgMed: LocalDate?
+    ): ArbeidssokerperioderDto
+
+    fun hentArbeidssokerperioderMedNivå3(
+        @RequestParam(value = "fraOgMed") @DateTimeFormat(pattern = "yyyy-MM-dd") fraOgMed: LocalDate,
+        @RequestParam(required = false, value = "tilOgMed") @DateTimeFormat(pattern = "yyyy-MM-dd") tilOgMed: LocalDate?
     ): ArbeidssokerperioderDto
 }

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/arbeidssoker/resources/ArbeidssokerResource.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/arbeidssoker/resources/ArbeidssokerResource.kt
@@ -26,7 +26,6 @@ class ArbeidssokerResource(
         @RequestParam("fraOgMed") @DateTimeFormat(pattern = "yyyy-MM-dd") fraOgMed: LocalDate,
         @RequestParam(value = "tilOgMed", required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") tilOgMed: LocalDate?
     ): ArbeidssokerperioderDto {
-        logger.info("hentArbeidssokerperioder med fnr i request param - deprecated metode")
         val bruker = userService.finnBrukerGjennomPdl()
         tilgangskontrollService.sjekkLesetilgangTilBrukerMedNivå3(bruker.gjeldendeFoedselsnummer)
         return hentArbeidssokerperioder(bruker, fraOgMed, tilOgMed)

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/arbeidssoker/resources/ArbeidssokerResource.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/arbeidssoker/resources/ArbeidssokerResource.kt
@@ -21,6 +21,17 @@ class ArbeidssokerResource(
     private val tilgangskontrollService: TilgangskontrollService
 ) : ArbeidssokerApi {
 
+    @GetMapping("/perioder/niva3")
+    override fun hentArbeidssokerperioderMedNivå3(
+        @RequestParam("fraOgMed") @DateTimeFormat(pattern = "yyyy-MM-dd") fraOgMed: LocalDate,
+        @RequestParam(value = "tilOgMed", required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") tilOgMed: LocalDate?
+    ): ArbeidssokerperioderDto {
+        logger.info("hentArbeidssokerperioder med fnr i request param - deprecated metode")
+        val bruker = userService.finnBrukerGjennomPdl()
+        tilgangskontrollService.sjekkLesetilgangTilBrukerMedNivå3(bruker.gjeldendeFoedselsnummer)
+        return hentArbeidssokerperioder(bruker, fraOgMed, tilOgMed)
+    }
+
     @GetMapping("/perioder")
     override fun hentArbeidssokerperioder(
         @RequestParam("fnr") fnr: String,
@@ -29,6 +40,7 @@ class ArbeidssokerResource(
     ): ArbeidssokerperioderDto {
         logger.info("hentArbeidssokerperioder med fnr i request param - deprecated metode")
         val bruker = userService.finnBrukerGjennomPdl()
+        tilgangskontrollService.sjekkLesetilgangTilBruker(bruker.gjeldendeFoedselsnummer)
         return hentArbeidssokerperioder(bruker, fraOgMed, tilOgMed)
     }
 
@@ -40,13 +52,14 @@ class ArbeidssokerResource(
     ): ArbeidssokerperioderDto {
         logger.info("hentArbeidssokerperioder med fnr i body")
         val bruker = if (fnr != null) userService.finnBrukerGjennomPdl(Foedselsnummer(fnr.fnr)) else userService.finnBrukerGjennomPdl()
+        tilgangskontrollService.sjekkLesetilgangTilBruker(bruker.gjeldendeFoedselsnummer)
         return hentArbeidssokerperioder(bruker, fraOgMed, tilOgMed)
     }
 
     private fun hentArbeidssokerperioder(bruker: Bruker,
                                          fraOgMed: LocalDate,
                                          tilOgMed: LocalDate?): ArbeidssokerperioderDto {
-        tilgangskontrollService.sjekkLesetilgangTilBruker(bruker.gjeldendeFoedselsnummer)
+
         val arbeidssokerperiodes = arbeidssokerService.hentArbeidssokerperioder(
             bruker, Periode.gyldigPeriode(fraOgMed, tilOgMed)
         )

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/autorisasjon/AutorisasjonService.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/autorisasjon/AutorisasjonService.kt
@@ -3,9 +3,12 @@ package no.nav.fo.veilarbregistrering.autorisasjon
 import no.nav.fo.veilarbregistrering.bruker.Foedselsnummer
 
 interface AutorisasjonService {
-    fun sjekkLesetilgangTilBruker(bruker: Foedselsnummer)
-    fun sjekkSkrivetilgangTilBruker(bruker: Foedselsnummer)
+
+    fun sjekkLesetilgangTilBrukerMedNivå3(fnr: Foedselsnummer)
+    fun sjekkLesetilgangTilBruker(fnr: Foedselsnummer)
+    fun sjekkSkrivetilgangTilBruker(fnr: Foedselsnummer)
 
     fun erVeileder(): Boolean
+
     val innloggetVeilederIdent: String
 }

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/autorisasjon/PersonbrukerAutorisasjonService.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/autorisasjon/PersonbrukerAutorisasjonService.kt
@@ -32,7 +32,6 @@ open class PersonbrukerAutorisasjonService(
         if (listOf(INNLOGGINGSNIVÅ_3, INNLOGGINGSNIVÅ_4).contains(innloggingsnivå)) return
 
         throw AutorisasjonException("Personbruker ber om lesetilgang med for lavt innloggingsnivå. Bruker har $innloggingsnivå - vi krever $INNLOGGINGSNIVÅ_3 eller $INNLOGGINGSNIVÅ_4")
-
     }
 
     override fun sjekkLesetilgangTilBruker(fnr: Foedselsnummer) = sjekkTilgang(ActionId.READ, tilEksternId(fnr))
@@ -47,14 +46,9 @@ open class PersonbrukerAutorisasjonService(
         registrerAutorisationEvent(handling)
 
         if (!veilarbPep.harTilgangTilPerson(innloggetBrukerToken, handling, bruker)) {
-            if (innloggetMedNivå3()) throw AutorisasjonLevel3Exception("Bruker er innlogget på nivå 3. $handling-tilgang til ekstern bruker som krever nivå 4-innlogging.")
+            if (INNLOGGINGSNIVÅ_3 == authContextHolder.hentInnloggingsnivå()) throw AutorisasjonLevel3Exception("Bruker er innlogget på nivå 3. $handling-tilgang til ekstern bruker som krever nivå 4-innlogging.")
             throw AutorisasjonException("Bruker mangler $handling-tilgang til ekstern bruker")
         }
-    }
-
-    private fun innloggetMedNivå3(): Boolean {
-        LOG.info("Forsøker å hente innloggingsnivå")
-        return INNLOGGINGSNIVÅ_3 == authContextHolder.hentInnloggingsnivå()
     }
 
     private fun rolle(): UserRole = authContextHolder.role.orElseThrow { IllegalStateException("Ingen role funnet") }

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/autorisasjon/SystembrukerAutorisasjonService.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/autorisasjon/SystembrukerAutorisasjonService.kt
@@ -14,8 +14,12 @@ open class SystembrukerAutorisasjonService(
     private val authContextHolder: AuthContextHolder,
     private val metricsService: MetricsService) : AutorisasjonService {
 
-    override fun sjekkLesetilgangTilBruker(bruker: Foedselsnummer) = sjekkLesetilgangTilBruker()
-    override fun sjekkSkrivetilgangTilBruker(bruker: Foedselsnummer) = sjekkSkrivetilgangTilBruker()
+    override fun sjekkLesetilgangTilBrukerMedNivå3(fnr: Foedselsnummer) {
+        throw AutorisasjonValideringException("Kan ikke utføre tilgangskontroll på nivå 3 for systembruker")
+    }
+
+    override fun sjekkLesetilgangTilBruker(fnr: Foedselsnummer) = sjekkLesetilgangTilBruker()
+    override fun sjekkSkrivetilgangTilBruker(fnr: Foedselsnummer) = sjekkSkrivetilgangTilBruker()
 
     private fun sjekkLesetilgangTilBruker() {
         logger.info("harTilgangTilPerson utfører ${ActionId.READ} for ${UserRole.SYSTEM}-rolle")

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/autorisasjon/TilgangskontrollService.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/autorisasjon/TilgangskontrollService.kt
@@ -8,6 +8,12 @@ class TilgangskontrollService(
     private val authContextHolder: AuthContextHolder,
     private val autorisasjonServiceMap: Map<UserRole, AutorisasjonService>
 ) {
+
+    fun sjekkLesetilgangTilBrukerMedNivå3(fnr: Foedselsnummer) {
+        autorisasjonServiceMap[hentRolle()]?.sjekkLesetilgangTilBrukerMedNivå3(fnr)
+            ?: throw AutorisasjonValideringException("Fant ikke tilgangskontroll for rollen ${hentRolle()}")
+    }
+
     fun sjekkLesetilgangTilBruker(fnr: Foedselsnummer) {
         autorisasjonServiceMap[hentRolle()]?.sjekkLesetilgangTilBruker(fnr)
             ?: throw AutorisasjonValideringException("Fant ikke tilgangskontroll for rollen ${hentRolle()}")
@@ -32,4 +38,5 @@ class TilgangskontrollService(
     private fun hentRolle(): UserRole {
         return authContextHolder.role.orElseThrow { AutorisasjonValideringException("Fant ikke rolle for bruker") }
     }
+
 }

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/autorisasjon/VeilederAutorisasjonService.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/autorisasjon/VeilederAutorisasjonService.kt
@@ -22,8 +22,11 @@ open class VeilederAutorisasjonService(
     private val metricsService: MetricsService
 ) : AutorisasjonService {
 
-    override fun sjekkLesetilgangTilBruker(bruker: Foedselsnummer) = sjekkTilgang(ActionId.READ, tilEksternId(bruker))
-    override fun sjekkSkrivetilgangTilBruker(bruker: Foedselsnummer) = sjekkTilgang(ActionId.WRITE, tilEksternId(bruker))
+    override fun sjekkLesetilgangTilBrukerMedNivå3(fnr: Foedselsnummer) {
+        throw AutorisasjonValideringException("Kan ikke utføre tilgangskontroll på nivå 3 for veileder")
+    }
+    override fun sjekkLesetilgangTilBruker(fnr: Foedselsnummer) = sjekkTilgang(ActionId.READ, tilEksternId(fnr))
+    override fun sjekkSkrivetilgangTilBruker(fnr: Foedselsnummer) = sjekkTilgang(ActionId.WRITE, tilEksternId(fnr))
 
     private fun tilEksternId(bruker: Foedselsnummer) = Fnr(bruker.stringValue())
 

--- a/src/test/kotlin/no/nav/fo/veilarbregistrering/autorisasjon/PersonbrukerAutorisasjonServiceTest.kt
+++ b/src/test/kotlin/no/nav/fo/veilarbregistrering/autorisasjon/PersonbrukerAutorisasjonServiceTest.kt
@@ -11,6 +11,7 @@ import no.nav.common.abac.domain.request.ActionId
 import no.nav.common.auth.context.AuthContextHolder
 import no.nav.common.auth.context.UserRole
 import no.nav.common.types.identer.Fnr
+import no.nav.fo.veilarbregistrering.bruker.Foedselsnummer
 import no.nav.fo.veilarbregistrering.bruker.FoedselsnummerTestdataBuilder.aremark
 import no.nav.fo.veilarbregistrering.metrics.MetricsService
 import org.junit.jupiter.api.Assertions.assertDoesNotThrow
@@ -27,9 +28,49 @@ class PersonbrukerAutorisasjonServiceTest {
     private val autorisasjonService = PersonbrukerAutorisasjonService(pep, authContextHolder, metricsService)
 
     @Test
+    fun `gitt at personbruker er logget inn på nivå 3 og har lesetilgang til seg selv med nivå3 skal ingen exception kastes`() {
+        every { authContextHolder.role } returns Optional.of(UserRole.EKSTERN)
+        every { authContextHolder.idTokenString } returns Optional.of("innloggetBrukerIdToken")
+        every { authContextHolder.idTokenClaims } returns Optional.of(JWTClaimsSet.Builder().build())
+        every { authContextHolder.getStringClaim(any(), "acr") } returns Optional.of("Level3")
+        every { authContextHolder.getStringClaim(any(), "pid") } returns Optional.of(aremark().stringValue())
+
+        assertDoesNotThrow { autorisasjonService.sjekkLesetilgangTilBrukerMedNivå3(aremark()) }
+    }
+
+    @Test
+    fun `gitt at personbruker er logget inn med et annet innloggingsnivå enn Level3 og Level 4 skal exception kastes i tilgangskontroll for nivå 3`() {
+        every { authContextHolder.role } returns Optional.of(UserRole.EKSTERN)
+        every { authContextHolder.idTokenString } returns Optional.of("innloggetBrukerIdToken")
+        every { authContextHolder.idTokenClaims } returns Optional.of(JWTClaimsSet.Builder().build())
+        every { authContextHolder.getStringClaim(any(), "acr") } returns Optional.of("TEST")
+        every { authContextHolder.getStringClaim(any(), "pid") } returns Optional.of(aremark().stringValue())
+
+        val exception = assertThrows(AutorisasjonException::class.java) {
+            autorisasjonService.sjekkLesetilgangTilBrukerMedNivå3(aremark())
+        }
+
+        assertEquals("Personbruker ber om lesetilgang med for lavt innloggingsnivå. Bruker har TEST - vi krever Level3 eller Level4", exception.message)
+    }
+
+    @Test
+    fun `gitt at personbruker ber om tilgang til noen andre enn seg selv i tilgangskontroll for nivå 3 skal exception kastes`() {
+        every { authContextHolder.role } returns Optional.of(UserRole.EKSTERN)
+        every { authContextHolder.idTokenString } returns Optional.of("innloggetBrukerIdToken")
+        every { authContextHolder.idTokenClaims } returns Optional.of(JWTClaimsSet.Builder().build())
+        every { authContextHolder.getStringClaim(any(), "acr") } returns Optional.of("TEST")
+        every { authContextHolder.getStringClaim(any(), "pid") } returns Optional.of(aremark().stringValue())
+
+        val exception = assertThrows(AutorisasjonException::class.java) {
+            autorisasjonService.sjekkLesetilgangTilBrukerMedNivå3(Foedselsnummer("12345678911"))
+        }
+
+        assertEquals("Personbruker ber om lesetilgang til noen andre enn seg selv.", exception.message)
+    }
+
+    @Test
     fun `gitt at personbruker har lesetilgang til seg selv skal ingen exception kastes`() {
         every { authContextHolder.role} returns Optional.of(UserRole.EKSTERN)
-        every { authContextHolder.requireIdTokenClaims() } returns JWTClaimsSet.Builder().build()
         every { authContextHolder.idTokenString } returns Optional.of("innloggetBrukerIdToken")
         every { metricsService.registrer(any(), *anyVararg<Tag>()) } just Runs
         every { pep.harTilgangTilPerson("innloggetBrukerIdToken", ActionId.READ, PERSON_AREMARK) } returns true
@@ -40,8 +81,9 @@ class PersonbrukerAutorisasjonServiceTest {
     @Test
     fun `gitt at personbruker IKKE har lesetilgang til seg selv (?) skal exception kastes`() {
         every { authContextHolder.role} returns Optional.of(UserRole.EKSTERN)
-        every { authContextHolder.requireIdTokenClaims() } returns JWTClaimsSet.Builder().build()
         every { authContextHolder.idTokenString } returns Optional.of("innloggetBrukerIdToken")
+        every { authContextHolder.idTokenClaims } returns Optional.of(JWTClaimsSet.Builder().build())
+        every { authContextHolder.getStringClaim(any(), any()) } returns Optional.of("Level4")
         every { metricsService.registrer(any(), *anyVararg<Tag>()) } just Runs
         every { pep.harTilgangTilPerson("innloggetBrukerIdToken", ActionId.READ, PERSON_AREMARK) } returns false
 
@@ -55,7 +97,6 @@ class PersonbrukerAutorisasjonServiceTest {
     @Test
     fun `gitt at personbruker har skrivetilgang til seg selv skal ingen exception kastes`() {
         every { authContextHolder.role} returns Optional.of(UserRole.EKSTERN)
-        every { authContextHolder.requireIdTokenClaims() } returns JWTClaimsSet.Builder().build()
         every { authContextHolder.idTokenString } returns Optional.of("innloggetBrukerIdToken")
         every { metricsService.registrer(any(), *anyVararg<Tag>()) } just Runs
         every { pep.harTilgangTilPerson("innloggetBrukerIdToken", ActionId.WRITE, PERSON_AREMARK) } returns true
@@ -66,8 +107,9 @@ class PersonbrukerAutorisasjonServiceTest {
     @Test
     fun `gitt at personbruker IKKE har skrivetilgang til seg selv (?) skal exception kastes`() {
         every { authContextHolder.role} returns Optional.of(UserRole.EKSTERN)
-        every { authContextHolder.requireIdTokenClaims() } returns JWTClaimsSet.Builder().build()
         every { authContextHolder.idTokenString } returns Optional.of("innloggetBrukerIdToken")
+        every { authContextHolder.idTokenClaims } returns Optional.of(JWTClaimsSet.Builder().build())
+        every { authContextHolder.getStringClaim(any(), any()) } returns Optional.of("Level4")
         every { metricsService.registrer(any(), *anyVararg<Tag>()) } just Runs
         every { pep.harTilgangTilPerson("innloggetBrukerIdToken", ActionId.WRITE, PERSON_AREMARK) } returns false
 
@@ -81,7 +123,6 @@ class PersonbrukerAutorisasjonServiceTest {
     @Test
     fun `gitt at tilgangskontroll for personbruker brukes av veileder ved skriv skal exception kastes`() {
         every { authContextHolder.role} returns Optional.of(UserRole.INTERN)
-        every { authContextHolder.requireIdTokenClaims() } returns JWTClaimsSet.Builder().build()
         every { authContextHolder.idTokenString } returns Optional.of("innloggetBrukerIdToken")
         every { metricsService.registrer(any(), *anyVararg<Tag>()) } just Runs
         every { pep.harTilgangTilPerson("innloggetBrukerIdToken", ActionId.WRITE, PERSON_AREMARK) } returns false
@@ -96,7 +137,6 @@ class PersonbrukerAutorisasjonServiceTest {
     @Test
     fun `gitt at tilgangskontroll for personbruker brukes av veileder ved les skal exception kastes`() {
         every { authContextHolder.role} returns Optional.of(UserRole.INTERN)
-        every { authContextHolder.requireIdTokenClaims() } returns JWTClaimsSet.Builder().build()
         every { authContextHolder.idTokenString } returns Optional.of("innloggetBrukerIdToken")
         every { metricsService.registrer(any(), *anyVararg<Tag>()) } just Runs
         every { pep.harTilgangTilPerson("innloggetBrukerIdToken", ActionId.READ, PERSON_AREMARK) } returns false
@@ -106,6 +146,19 @@ class PersonbrukerAutorisasjonServiceTest {
         }
 
         assertEquals("Kan ikke utføre tilgangskontroll for personbruker med rolle INTERN", exception.message)
+    }
+
+    @Test
+    fun `gitt at tilgangskontroll for personbruker med nivå3 brukes av veileder skal exception kastes`() {
+        every { authContextHolder.role} returns Optional.of(UserRole.INTERN)
+        every { authContextHolder.idTokenString } returns Optional.of("innloggetBrukerIdToken")
+        every { metricsService.registrer(any(), *anyVararg<Tag>()) } just Runs
+
+        val exception = assertThrows(AutorisasjonValideringException::class.java) {
+            autorisasjonService.sjekkLesetilgangTilBrukerMedNivå3(aremark())
+        }
+
+        assertEquals("Kan ikke utføre tilgangskontroll på nivå3 for personbruker med rolle INTERN", exception.message)
     }
 
     companion object {


### PR DESCRIPTION
AiA har behov for å hente arbeidssøkerperioder for brukere som er logget inn med nivå 3. Lager et eget endepunkt for dette med tilhørende separat tilgangskontroll. 