### PR TITLE
Legger aktørId'er som ikke finnes i PDL til i denylist

### DIFF
--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/bruker/pdl/PdlOppslagClient.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/bruker/pdl/PdlOppslagClient.kt
@@ -51,7 +51,7 @@ open class PdlOppslagClient(
         val json = hentFraPdl(request)
         val response = mapAndValidateResponse<PdlHentIdenterBolkResponse>(json)
         if (isDevelopment()) {
-            logger.info("Fikk følgende respons fra hentIdenterBolk: ${response}")
+            logger.info("Fikk følgende respons fra hentIdenterBolk: ${response.data.hentIdenterBolk}")
         }
         return response.data.hentIdenterBolk
     }

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/db/registrering/SykmeldtRegistreringRepositoryImpl.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/db/registrering/SykmeldtRegistreringRepositoryImpl.kt
@@ -68,10 +68,15 @@ class SykmeldtRegistreringRepositoryImpl(private val db: NamedParameterJdbcTempl
         return db.queryForObject(sql, noParams, Long::class.java)!!
     }
 
-    override fun finnAktorIdTilSykmeldtRegistreringUtenFoedselsnummer(maksAntall: Int): List<AktorId> {
-        val sql = "SELECT DISTINCT $AKTOR_ID FROM $SYKMELDT_REGISTRERING " +
-                "WHERE $FOEDSELSNUMMER IS NULL LIMIT $maksAntall"
-        return db.query(sql) { rs, _ -> AktorId(rs.getString("$AKTOR_ID")) }
+    override fun finnAktorIdTilSykmeldtRegistreringUtenFoedselsnummer(maksAntall: Int, aktorIdDenyList: List<AktorId>): List<AktorId> {
+        val sql = if (aktorIdDenyList.isEmpty()) {
+            "SELECT DISTINCT $AKTOR_ID FROM $SYKMELDT_REGISTRERING " +
+                    "WHERE $FOEDSELSNUMMER IS NULL LIMIT $maksAntall"
+        } else {
+            "SELECT DISTINCT $AKTOR_ID FROM $SYKMELDT_REGISTRERING " +
+                    "WHERE $FOEDSELSNUMMER IS NULL AND $AKTOR_ID NOT IN (${aktorIdDenyList.joinToString(",")} LIMIT $maksAntall"
+        }
+        return db.query(sql) { rs, _ -> AktorId(rs.getString(AKTOR_ID)) }
     }
 
     override fun oppdaterSykmeldtRegistreringerMedManglendeFoedselsnummer(aktorIdFoedselsnummerMap: Map<AktorId, Foedselsnummer>): IntArray {

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/db/registrering/SykmeldtRegistreringRepositoryImpl.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/db/registrering/SykmeldtRegistreringRepositoryImpl.kt
@@ -74,7 +74,7 @@ class SykmeldtRegistreringRepositoryImpl(private val db: NamedParameterJdbcTempl
                     "WHERE $FOEDSELSNUMMER IS NULL LIMIT $maksAntall"
         } else {
             "SELECT DISTINCT $AKTOR_ID FROM $SYKMELDT_REGISTRERING " +
-                    "WHERE $FOEDSELSNUMMER IS NULL AND $AKTOR_ID NOT IN (${aktorIdDenyList.joinToString(",")} LIMIT $maksAntall"
+                    "WHERE $FOEDSELSNUMMER IS NULL AND $AKTOR_ID NOT IN (${aktorIdDenyList.joinToString(",") { t -> "'" + t.aktorId + "'" }}) LIMIT $maksAntall"
         }
         return db.query(sql) { rs, _ -> AktorId(rs.getString(AKTOR_ID)) }
     }

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/registrering/bruker/PopulerFoedselsnummerScheduler.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/registrering/bruker/PopulerFoedselsnummerScheduler.kt
@@ -56,5 +56,8 @@ class PopulerFoedselsnummerScheduler(
             totalRowsUpdated = oppdaterteSykmeldtRegistreringer.toList().sum()
             logger.info("Oppdaterte totalt ${totalRowsUpdated} SykmeldtRegistrering")
         }
+
+        logger.info("Avslutter populering av Foedselsnummer da det ikke var flere kjente aktørIder. " +
+                "Fant totalt ${denyList.size} aktorIder som ikke gav treff i PDL")
     }
 }

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/registrering/sykmeldt/SykmeldtRegistreringRepository.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/registrering/sykmeldt/SykmeldtRegistreringRepository.kt
@@ -9,6 +9,6 @@ interface SykmeldtRegistreringRepository {
     fun hentSykmeldtregistreringForAktorId(aktorId: AktorId): SykmeldtRegistrering?
     fun finnSykmeldtRegistreringerFor(aktorId: AktorId): List<SykmeldtRegistrering>
 
-    fun finnAktorIdTilSykmeldtRegistreringUtenFoedselsnummer(maksAntall: Int): List<AktorId>
+    fun finnAktorIdTilSykmeldtRegistreringUtenFoedselsnummer(maksAntall: Int, aktorIdDenyList: List<AktorId> = emptyList()): List<AktorId>
     fun oppdaterSykmeldtRegistreringerMedManglendeFoedselsnummer(aktorIdFoedselsnummerMap: Map<AktorId, Foedselsnummer>): IntArray
 }

--- a/src/test/kotlin/no/nav/fo/veilarbregistrering/db/registrering/GcpSykmeldtRegistreringRepositoryDbIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/fo/veilarbregistrering/db/registrering/GcpSykmeldtRegistreringRepositoryDbIntegrationTest.kt
@@ -5,6 +5,8 @@ import no.nav.fo.veilarbregistrering.besvarelse.TilbakeIArbeidSvar
 import no.nav.fo.veilarbregistrering.bruker.AktorId
 import no.nav.fo.veilarbregistrering.bruker.Bruker
 import no.nav.fo.veilarbregistrering.bruker.Foedselsnummer
+import no.nav.fo.veilarbregistrering.bruker.FoedselsnummerTestdataBuilder
+import no.nav.fo.veilarbregistrering.bruker.FoedselsnummerTestdataBuilder.aremark
 import no.nav.fo.veilarbregistrering.db.DatabaseConfig
 import no.nav.fo.veilarbregistrering.db.RepositoryConfig
 import no.nav.fo.veilarbregistrering.registrering.sykmeldt.SykmeldtRegistrering
@@ -16,6 +18,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
 import org.springframework.boot.test.autoconfigure.jdbc.JdbcTest
+import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.ContextConfiguration
 
@@ -24,6 +27,9 @@ import org.springframework.test.context.ContextConfiguration
 @ContextConfiguration(initializers = [DbContainerInitializer::class], classes = [ RepositoryConfig::class, DatabaseConfig::class ])
 @ActiveProfiles("gcp")
 class GcpSykmeldtRegistreringRepositoryDbIntegrationTest(
+
+    @Autowired
+    private val jdbcTemplate: JdbcTemplate,
 
     @Autowired
     private val sykmeldtRegistreringRepository: SykmeldtRegistreringRepository
@@ -68,13 +74,34 @@ class GcpSykmeldtRegistreringRepositoryDbIntegrationTest(
             tilbakeIArbeid = TilbakeIArbeidSvar.JA_FULL_STILLING))
         val bruker2 = SykmeldtRegistreringTestdataBuilder.gyldigSykmeldtRegistrering(besvarelse = BesvarelseTestdataBuilder.gyldigSykmeldtSkalTilbakeSammeJobbBesvarelse(
             tilbakeIArbeid = TilbakeIArbeidSvar.JA_REDUSERT_STILLING))
-        sykmeldtRegistreringRepository.lagreSykmeldtBruker(bruker1, BRUKER)
-        sykmeldtRegistreringRepository.lagreSykmeldtBruker(bruker2, BRUKER)
+        val sykmeldtId1 = sykmeldtRegistreringRepository.lagreSykmeldtBruker(bruker1, BRUKER)
+        val sykmeldtId2 = sykmeldtRegistreringRepository.lagreSykmeldtBruker(bruker2, BRUKER2)
+
+        jdbcTemplate.update("UPDATE SYKMELDT_REGISTRERING SET FOEDSELSNUMMER = NULL WHERE SYKMELDT_REGISTRERING_ID = ?", sykmeldtId1)
+        jdbcTemplate.update("UPDATE SYKMELDT_REGISTRERING SET FOEDSELSNUMMER = NULL WHERE SYKMELDT_REGISTRERING_ID = ?", sykmeldtId2)
 
         val aktorIdList =
             sykmeldtRegistreringRepository.finnAktorIdTilSykmeldtRegistreringUtenFoedselsnummer(50)
 
-        assertThat(aktorIdList).isEmpty()
+        assertThat(aktorIdList).hasSize(2)
+    }
+
+    @Test
+    fun `finnAktorIdTilSykmeldtRegistreringUtenFoedselsnummer skal ikke returnere AktorId som er svartelistet`() {
+        val bruker1 = SykmeldtRegistreringTestdataBuilder.gyldigSykmeldtRegistrering(besvarelse = BesvarelseTestdataBuilder.gyldigSykmeldtSkalTilbakeSammeJobbBesvarelse(
+            tilbakeIArbeid = TilbakeIArbeidSvar.JA_FULL_STILLING))
+        val bruker2 = SykmeldtRegistreringTestdataBuilder.gyldigSykmeldtRegistrering(besvarelse = BesvarelseTestdataBuilder.gyldigSykmeldtSkalTilbakeSammeJobbBesvarelse(
+            tilbakeIArbeid = TilbakeIArbeidSvar.JA_REDUSERT_STILLING))
+        val sykmeldtId1 = sykmeldtRegistreringRepository.lagreSykmeldtBruker(bruker1, BRUKER)
+        val sykmeldtId2 = sykmeldtRegistreringRepository.lagreSykmeldtBruker(bruker2, BRUKER2)
+
+        jdbcTemplate.update("UPDATE SYKMELDT_REGISTRERING SET FOEDSELSNUMMER = NULL WHERE SYKMELDT_REGISTRERING_ID = ?", sykmeldtId1)
+        jdbcTemplate.update("UPDATE SYKMELDT_REGISTRERING SET FOEDSELSNUMMER = NULL WHERE SYKMELDT_REGISTRERING_ID = ?", sykmeldtId2)
+
+        val aktorIdList =
+            sykmeldtRegistreringRepository.finnAktorIdTilSykmeldtRegistreringUtenFoedselsnummer(50, listOf(BRUKER2.aktorId))
+
+        assertThat(aktorIdList).hasSize(1)
     }
 
     @Test
@@ -83,18 +110,22 @@ class GcpSykmeldtRegistreringRepositoryDbIntegrationTest(
             tilbakeIArbeid = TilbakeIArbeidSvar.JA_FULL_STILLING))
         val bruker2 = SykmeldtRegistreringTestdataBuilder.gyldigSykmeldtRegistrering(besvarelse = BesvarelseTestdataBuilder.gyldigSykmeldtSkalTilbakeSammeJobbBesvarelse(
             tilbakeIArbeid = TilbakeIArbeidSvar.JA_REDUSERT_STILLING))
-        sykmeldtRegistreringRepository.lagreSykmeldtBruker(bruker1, BRUKER)
-        sykmeldtRegistreringRepository.lagreSykmeldtBruker(bruker2, BRUKER)
+        val sykmeldtId1 = sykmeldtRegistreringRepository.lagreSykmeldtBruker(bruker1, BRUKER)
+        val sykmeldtId2 = sykmeldtRegistreringRepository.lagreSykmeldtBruker(bruker2, BRUKER2)
+
+        jdbcTemplate.update("UPDATE SYKMELDT_REGISTRERING SET FOEDSELSNUMMER = NULL WHERE SYKMELDT_REGISTRERING_ID = ?", sykmeldtId1)
+        jdbcTemplate.update("UPDATE SYKMELDT_REGISTRERING SET FOEDSELSNUMMER = NULL WHERE SYKMELDT_REGISTRERING_ID = ?", sykmeldtId2)
 
         val antallOppdaterteRader =
-            sykmeldtRegistreringRepository.oppdaterSykmeldtRegistreringerMedManglendeFoedselsnummer(mapOf(BRUKER.aktorId to BRUKER.gjeldendeFoedselsnummer))
+            sykmeldtRegistreringRepository.oppdaterSykmeldtRegistreringerMedManglendeFoedselsnummer(
+                mapOf(BRUKER.aktorId to BRUKER.gjeldendeFoedselsnummer))
 
-        assertThat(antallOppdaterteRader[0]).isEqualTo(0)
+        assertThat(antallOppdaterteRader[0]).isEqualTo(1)
     }
 
     companion object {
-        private val ident = Foedselsnummer("10108000398") //Aremark fiktivt fnr.";
-        private val BRUKER = Bruker(ident, AktorId("11111"))
+        private val BRUKER = Bruker(aremark(), AktorId("11111"))
+        private val BRUKER2 = Bruker(aremark(), AktorId("22222"))
     }
 
 }


### PR DESCRIPTION
Legger aktørId'er som ikke finnes i PDL til en egen denylist, som gjør at de ikke blir plukket opp av SQL-uthentingen ved neste runde.