### PR TITLE
Returnerer 204 no content hvis bruker ikke finnes i arena

### DIFF
--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/arbeidssoker/formidlingsgruppe/adapter/FormidlingsgruppeNoContentException.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/arbeidssoker/formidlingsgruppe/adapter/FormidlingsgruppeNoContentException.kt
@@ -1,0 +1,3 @@
+package no.nav.fo.veilarbregistrering.arbeidssoker.formidlingsgruppe.adapter
+
+class FormidlingsgruppeNoContentException(message: String) : RuntimeException(message)

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/arbeidssoker/formidlingsgruppe/adapter/FormidlingsgruppeRestClient.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/arbeidssoker/formidlingsgruppe/adapter/FormidlingsgruppeRestClient.kt
@@ -57,12 +57,14 @@ class FormidlingsgruppeRestClient internal constructor(
         }
         return doTimedCall {
             httpClient.newCall(request).execute().use {
+                val status = HttpStatus.valueOf(it.code())
                 if (it.isSuccessful) {
+                    if (status == HttpStatus.NO_CONTENT) throw FormidlingsgruppeNoContentException("Tomt svar fra Arena. Bruker finnes ikke i Arena.")
                     it.body()?.string()?.let { objectMapper.readValue(it, FormidlingsgruppeResponseDto::class.java)
                     } ?: throw RuntimeException("Unexpected empty body")
 
                 } else {
-                    when (val status = HttpStatus.valueOf(it.code())) {
+                    when (status) {
                         HttpStatus.NOT_FOUND -> null
                         HttpStatus.UNAUTHORIZED -> throw UnauthorizedException("Hent formidlingshistorikk fra Arena feilet med 401 - UNAUTHORIZED")
                         else -> throw RuntimeException("Hent formidlingshistorikk fra Arena feilet med statuskode: $status")

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/feil/FeilHandtering.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/feil/FeilHandtering.kt
@@ -2,6 +2,7 @@ package no.nav.fo.veilarbregistrering.feil
 
 import no.nav.fo.veilarbregistrering.arbeidsforhold.ForbiddenException
 import no.nav.fo.veilarbregistrering.arbeidsforhold.HentArbeidsforholdException
+import no.nav.fo.veilarbregistrering.arbeidssoker.formidlingsgruppe.adapter.FormidlingsgruppeNoContentException
 import no.nav.fo.veilarbregistrering.arbeidssoker.perioder.UnauthorizedException
 import no.nav.fo.veilarbregistrering.autorisasjon.AutorisasjonException
 import no.nav.fo.veilarbregistrering.autorisasjon.AutorisasjonLevel3Exception
@@ -122,5 +123,11 @@ class FeilHandtering : ResponseEntityExceptionHandler() {
     fun handleUnsupportedMediaTypeStatusException(e: UnsupportedMediaTypeStatusException):ResponseEntity<Any> {
         logger.warn("Feil media-type i request: ${e.message}", e)
         return ResponseEntity.status(UNSUPPORTED_MEDIA_TYPE).build()
+    }
+
+    @ExceptionHandler(FormidlingsgruppeNoContentException::class)
+    fun handleFormidlingsgruppeNoContentException(feil: FormidlingsgruppeNoContentException): ResponseEntity<Any> {
+        logger.warn(feil.message)
+        return ResponseEntity.status(NO_CONTENT).build()
     }
 }

--- a/src/test/kotlin/no/nav/fo/veilarbregistrering/arbeidssoker/formidlingsgruppe/adapter/FormidlingsgruppeGatewayTest.kt
+++ b/src/test/kotlin/no/nav/fo/veilarbregistrering/arbeidssoker/formidlingsgruppe/adapter/FormidlingsgruppeGatewayTest.kt
@@ -11,6 +11,7 @@ import no.nav.fo.veilarbregistrering.log.CallId.leggTilCallId
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockserver.integration.ClientAndServer
 import org.mockserver.junit.jupiter.MockServerExtension
@@ -138,5 +139,25 @@ class FormidlingsgruppeGatewayTest(private val mockServer: ClientAndServer) {
                 LocalDate.of(2020, 1, 11)))
 
         assertThat(arbeidssokerperioder.asList()).isEmpty()
+    }
+
+    @Test
+    fun `skal kaste exception ved 204 fra arena`() {
+        mockServer.`when`(
+            HttpRequest
+                .request()
+                .withMethod("GET")
+                .withPath("/arena/api/v1/person/arbeidssoeker/formidlingshistorikk")
+                .withQueryStringParameter("fnr", "11118035157"))
+            .respond(response()
+                .withStatusCode(204))
+
+        assertThrows<FormidlingsgruppeNoContentException> {
+            formidlingsgruppeGateway.finnArbeissokerperioder(
+                Foedselsnummer("11118035157"),
+                Periode(
+                    LocalDate.of(2020, 1, 10),
+                    LocalDate.of(2020, 1, 11)))
+        }
     }
 }


### PR DESCRIPTION
Ved en 204 repons fra Arena ble det kastet feil `No content to map due to end-of-input at [Source: (String)""; line: 1, column: 0]`, da vi forsøkte å serialisere en tom respons til
`FormidlingsgruppeResponseDto`.

Nå returnerer vi heller 204, og logger en warning med "Tomt svar fra Arena. Bruker finnes ikke i Arena."