### PR TITLE
Logger hvis selvbetjenings cookie er satt

### DIFF
--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/autentisering/tokenveksling/TokenResolver.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/autentisering/tokenveksling/TokenResolver.kt
@@ -31,6 +31,6 @@ class TokenResolver(private val authContextHolder: AuthContextHolder) {
 
 fun AuthContextHolder.erAADToken(): Boolean = hentIssuer().contains("login.microsoftonline.com")
 private fun AuthContextHolder.erSystemTilSystemToken(): Boolean = this.subject == this.getStringClaim(this.idTokenClaims.get(), "oid")
-private fun AuthContextHolder.erTokenXToken(): Boolean = listOf("tokendings", "tokenx").any { hentIssuer().contains(it) }
+private fun AuthContextHolder.erTokenXToken(): Boolean = hentIssuer().contains("tokenx")
 private fun AuthContextHolder.erIdPortenToken(): Boolean = hentIssuer().contains("difi.no")
 private fun AuthContextHolder.hentIssuer(): String = this.requireIdTokenClaims().issuer

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/config/filters/AuthStatsFilter.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/config/filters/AuthStatsFilter.kt
@@ -34,6 +34,9 @@ class AuthStatsFilter(private val metricsService: MetricsService) : Filter {
         val selvbetjeningToken =
             request.cookies?.filter { it.name == Constants.AZURE_AD_B2C_ID_TOKEN_COOKIE_NAME }?.map { it.value }
                 ?.firstOrNull()
+        selvbetjeningToken?.let {
+            log.warn("$consumerId sender med cookie ${Constants.AZURE_AD_B2C_ID_TOKEN_COOKIE_NAME}")
+        }
         val type = when {
             Constants.AZURE_AD_B2C_ID_TOKEN_COOKIE_NAME in cookieNames -> selvbetjeningToken?.let { checkTokenForType(it) }
                 ?: ID_PORTEN
@@ -87,4 +90,4 @@ class AuthStatsFilter(private val metricsService: MetricsService) : Filter {
 
 fun JWT.erAzureAdToken(): Boolean = this.jwtClaimsSet.issuer.contains("microsoftonline.com")
 fun JWT.erIdPortenToken(): Boolean = this.jwtClaimsSet.issuer.contains("difi.no")
-fun JWT.erTokenXToken(): Boolean = listOf("tokendings", "tokenx").any { this.jwtClaimsSet.issuer.contains(it) }
+fun JWT.erTokenXToken(): Boolean = this.jwtClaimsSet.issuer.contains("tokenx")

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/config/filters/FilterConfig.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/config/filters/FilterConfig.kt
@@ -90,6 +90,7 @@ class FilterConfig {
         return OidcAuthenticatorConfig()
             .withDiscoveryUrl(discoveryUrl)
             .withClientId(allowedAudience)
+            .withIdTokenCookieName(Constants.AZURE_AD_B2C_ID_TOKEN_COOKIE_NAME)
             .withUserRoleResolver(AzureAdUserRoleResolver())
     }
 

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/config/filters/FilterConfig.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/config/filters/FilterConfig.kt
@@ -77,7 +77,6 @@ class FilterConfig {
         return OidcAuthenticatorConfig()
             .withDiscoveryUrl(discoveryUrl)
             .withClientId(clientId)
-            .withIdTokenCookieName(Constants.AZURE_AD_B2C_ID_TOKEN_COOKIE_NAME)
             .withUserRole(UserRole.EKSTERN)
     }
 

--- a/src/test/kotlin/no/nav/fo/veilarbregistrering/oppfolging/adapter/OppfolgingClientTest.kt
+++ b/src/test/kotlin/no/nav/fo/veilarbregistrering/oppfolging/adapter/OppfolgingClientTest.kt
@@ -44,6 +44,7 @@ internal class OppfolgingClientTest(private val mockServer: ClientAndServer) {
         mockkStatic(RequestContext::class)
         every { RequestContext.servletRequest() } returns httpServletRequest
         every { httpServletRequest.getHeader(HttpHeaders.COOKIE) } returns "czas Å\u009Brodkowoeuropejski standardowy"
+        every { httpServletRequest.cookies } returns emptyArray()
         val baseUrl = "http://" + mockServer.remoteAddress().address.hostName + ":" + mockServer.remoteAddress().port
         return OppfolgingClient(objectMapper, mockk(relaxed = true), baseUrl, mockk(relaxed = true)) { "TOKEN" }.also { oppfolgingClient = it }
     }


### PR DESCRIPTION
selvbetjenings cookie skal ikke lenger bli satt.
Skrur i første omgang på logging om token er med eller ikke, før jeg fjerner cookie.

Logglinjer å se etter:

- `$consumerId sender med cookie selvbetjening-idtoken`

- `Sender med cookie(s): ${cookie.map { it.name }} til oppfolging`