### PR TITLE
Fjerner muligheter for idporten autentisering. TokenX skal benyttes i

### DIFF
--- a/nais/nais-dev-gcp.yaml
+++ b/nais/nais-dev-gcp.yaml
@@ -15,8 +15,6 @@ spec:
           - "NAVident"
   tokenx:
     enabled: true
-  idporten:
-    enabled: true
   envFrom:
     - secret: veilarbregistrering
   image: {{image}}

--- a/nais/nais-prod-gcp.yaml
+++ b/nais/nais-prod-gcp.yaml
@@ -15,8 +15,6 @@ spec:
           - "NAVident"
   tokenx:
     enabled: true
-  idporten:
-    enabled: true
   envFrom:
     - secret: veilarbregistrering
   image: {{image}}

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/autentisering/tokenveksling/TokenExchangeService.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/autentisering/tokenveksling/TokenExchangeService.kt
@@ -13,7 +13,6 @@ class TokenExchangeService(private val tokenResolver: TokenResolver) {
     fun exchangeToken(api: DownstreamApi): String {
         val opprinneligToken = tokenResolver.token()
         return when {
-            tokenResolver.erIdPortenToken() -> exchangeTokenXToken(api, opprinneligToken)
             tokenResolver.erTokenXToken() -> exchangeTokenXToken(api, opprinneligToken)
             tokenResolver.erAzureAdOboToken() -> exchangeAadOboToken(api, opprinneligToken)
             tokenResolver.erAzureAdSystemTilSystemToken() -> createAadMachineToMachineToken(api)

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/autentisering/tokenveksling/TokenResolver.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/autentisering/tokenveksling/TokenResolver.kt
@@ -23,14 +23,9 @@ class TokenResolver(private val authContextHolder: AuthContextHolder) {
     fun erTokenXToken(): Boolean {
         return authContextHolder.erTokenXToken()
     }
-
-    fun erIdPortenToken(): Boolean {
-        return authContextHolder.erIdPortenToken()
-    }
 }
 
 fun AuthContextHolder.erAADToken(): Boolean = hentIssuer().contains("login.microsoftonline.com")
 private fun AuthContextHolder.erSystemTilSystemToken(): Boolean = this.subject == this.getStringClaim(this.idTokenClaims.get(), "oid")
 private fun AuthContextHolder.erTokenXToken(): Boolean = hentIssuer().contains("tokenx")
-private fun AuthContextHolder.erIdPortenToken(): Boolean = hentIssuer().contains("difi.no")
 private fun AuthContextHolder.hentIssuer(): String = this.requireIdTokenClaims().issuer

--- a/src/main/kotlin/no/nav/fo/veilarbregistrering/config/filters/FilterConfig.kt
+++ b/src/main/kotlin/no/nav/fo/veilarbregistrering/config/filters/FilterConfig.kt
@@ -60,7 +60,6 @@ class FilterConfig {
         val registration = FilterRegistrationBean<OidcAuthenticationFilter>()
         val authenticationFilter = OidcAuthenticationFilter(
             OidcAuthenticator.fromConfigs(
-                createAzureAdB2CConfig(),
                 createAadTokenConfig(),
                 createTokenXConfig()
             )
@@ -69,15 +68,6 @@ class FilterConfig {
         registration.order = 4
         registration.addUrlPatterns("/api/*")
         return registration
-    }
-
-    private fun createAzureAdB2CConfig(): OidcAuthenticatorConfig {
-        val discoveryUrl = requireProperty("IDPORTEN_WELL_KNOWN_URL")
-        val clientId = requireProperty("IDPORTEN_CLIENT_ID")
-        return OidcAuthenticatorConfig()
-            .withDiscoveryUrl(discoveryUrl)
-            .withClientId(clientId)
-            .withUserRole(UserRole.EKSTERN)
     }
 
     /**


### PR DESCRIPTION
Tokens fra ID-porten [bør ikke propageres videre](https://doc.nais.io/security/auth/idporten/#next-steps) - de bør byttes ut med TokenX ved kall bakover til andre tjenester.